### PR TITLE
[Printer] fix relax printer prints twice

### DIFF
--- a/src/printer/tvmscript_printer.cc
+++ b/src/printer/tvmscript_printer.cc
@@ -1877,10 +1877,9 @@ Doc AsTVMScriptDoc(const ObjectRef& mod, const String& tir_prefix, bool show_met
                    const PrimFunc& func) {
   ICHECK(mod->IsInstance<PrimFuncNode>() || mod->IsInstance<IRModuleNode>());
   TVMScriptPrinter printer(tir_prefix, show_meta);
-  Doc mod_doc = printer.Print(mod);
   // TODO(altan, tqchen): change to the first argument only?
   Doc doc;
-  doc << (func.defined() ? printer.Print(func) : mod_doc) << Doc::NewLine();
+  doc << (func.defined() ? printer.Print(func) : printer.Print(mod)) << Doc::NewLine();
   return doc;
 }
 


### PR DESCRIPTION
Currently, the relax printer would print a PrimFunc twice with the same printer. That's would cause a renaming for tir func parameters. E.g the `A_1` and `B_1` in the following case:

```python
@tvm.script.ir_module
class Module:
    @tir.prim_func
    def main(A_1: tir.Buffer[8, "float32"], B_1: tir.Buffer[8, "float32"]) -> None:
        # function attr dict
        tir.func_attr({"global_symbol": "main", "tir.noalias": True})
        # body
        # with tir.block("root")
        for i in tir.serial(128):
            with tir.block("B"):
                vi = tir.axis.spatial(128, i)
                tir.reads(A_1[vi])
                tir.writes(B_1[vi])
                B_1[vi] = A_1[vi] + tir.float32(1)
```