### PR TITLE
[Fix] update parser and printer for relax

### DIFF
--- a/python/tvm/script/relax/parser.py
+++ b/python/tvm/script/relax/parser.py
@@ -1711,8 +1711,8 @@ def from_source(
         )
     elif inspect.isfunction(input_func):
         env: Dict[str, Any] = input_func.__globals__
-        relax_prefix = [key for key in env.keys() if env[key] == relax_namespace]
-        tir_prefix = [key for key in env.keys() if env[key] == tir_namespace]
+        relax_prefix = [key for key in env.keys() if env[key] is relax_namespace]
+        tir_prefix = [key for key in env.keys() if env[key] is tir_namespace]
         return synr.to_ast(
             input_func, RelaxDiagnosticContext(mod), RelaxTransformer(mod, relax_prefix, tir_prefix)
         )


### PR DESCRIPTION
This PR fixes two bugs:
1. use `is` instead of `==` during looking up parser packages. Otherwise, it fails to find correct packages if there are global vars.
2. Fix Primfunc name bug issue introduced by #1 

cc @tqchen 