### PR TITLE
[Relax][Op] `out_dtype` for Conv2D and Matmul

### DIFF
--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -568,6 +568,15 @@ struct AdaptivePool2DAttrs : public tvm::AttrsNode<AdaptivePool2DAttrs> {
   }
 };  // struct AdaptivePool2DAttrs
 
+/*! \brief Attributes for matmul operator */
+struct MatmulAttrs : public tvm::AttrsNode<MatmulAttrs> {
+  DataType out_dtype;
+
+  TVM_DECLARE_ATTRS(MatmulAttrs, "relax.attrs.MatmulAttrs") {
+    TVM_ATTR_FIELD(out_dtype).describe("The data type of the output tensor");
+  }
+};  // struct MatmulAttrs
+
 }  // namespace relax
 }  // namespace tvm
 #endif  // TVM_RELAX_OP_ATTR_TYPES_H_

--- a/python/tvm/relax/frontend/pytorch_fx.py
+++ b/python/tvm/relax/frontend/pytorch_fx.py
@@ -349,6 +349,12 @@ class TorchFXTranslator:
     def _cos(self, node: fx.node.Node) -> relax.Var:
         return self.bb.emit(relax.op.cos(self.env[node.args[0]]))
 
+    def _sqrt(self, node: fx.node.Node) -> relax.Var:
+        arg = self.env[node.args[0]]
+        if isinstance(arg, (int, float)):
+            arg = relax.const(arg, "float32")
+        return self.bb.emit(relax.op.sqrt(arg))
+
     def _cat(self, node: fx.node.Node) -> relax.Var:
         args = self.retrive_args(node)
         return self.bb.emit(relax.op.concatenate(args[0], axis=node.kwargs["dim"]))
@@ -588,6 +594,7 @@ class TorchFXTranslator:
             "mul": self._mul,
             "sin": self._sin,
             "cos": self._cos,
+            "sqrt": self._sqrt,
             "cat": self._cat,
             "truediv": self._truediv,
             "floordiv": self._floordiv,

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -526,7 +526,7 @@ def layer_norm(
     return _ffi_api.layer_norm(data, gamma, beta, axis, epsilon, center, scale)
 
 
-def matmul(a: Expr, b: Expr) -> Expr:
+def matmul(a: Expr, b: Expr, out_dtype: str = "") -> Expr:
     """
     General matrix multiplication of two tensors.
 
@@ -554,13 +554,15 @@ def matmul(a: Expr, b: Expr) -> Expr:
         The left operand of the matmul.
     b : relax.Expr
         The right operand of the matmul.
+    out_dtype: str
+        The data type of the matmul result
 
     Returns
     -------
     result : relax.Expr
         The result of the matmul.
     """
-    return _ffi_api.matmul(a, b)
+    return _ffi_api.matmul(a, b, out_dtype)
 
 
 def adaptive_avg_pool2d(

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -152,3 +152,9 @@ class Resize2DAttrs(Attrs):
 @tvm._ffi.register_object("relax.attrs.AdaptivePool2DAttrs")
 class AdaptivePool2DAttrs(Attrs):
     """Attributes for 2d adaptive pool operator"""
+
+
+@tvm._ffi.register_object("relax.attrs.MatmulAttrs")
+class MatmulAttrs(Attrs):
+    """Attributes for matmul operator"""
+

--- a/python/tvm/relax/transform/op_legalizer.py
+++ b/python/tvm/relax/transform/op_legalizer.py
@@ -262,7 +262,11 @@ def _nn_matmul(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: E
                 if not b_appended:
                     b_indices.append(idx_spatial[-1])
 
-                return a(*a_indices) * b(*b_indices)
+                dtype = attrs.out_dtype
+                if dtype != "":
+                    return a(*a_indices).astype(dtype) * b(*b_indices).astype(dtype)
+                else:
+                    return a(*a_indices) * b(*b_indices)
 
             return te.sum(multiply_compute(k), axis=k)
 

--- a/python/tvm/relax/transform/op_legalizer.py
+++ b/python/tvm/relax/transform/op_legalizer.py
@@ -31,13 +31,14 @@ from ..block_builder import BlockBuilder
 def _nn_conv2d(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
     return bb.call_te(
         topi.nn.conv2d,
-        args[0],
-        args[1],
-        attrs.strides,
-        attrs.padding,
-        attrs.dilation,
-        attrs.data_layout,
-        attrs.kernel_layout,
+        input=args[0],
+        filter=args[1],
+        strides=attrs.strides,
+        padding=attrs.padding,
+        dilation=attrs.dilation,
+        data_layout=attrs.data_layout,
+        kernel_layout=attrs.kernel_layout,
+        out_dtype=attrs.out_dtype,
     )
 
 

--- a/python/tvm/relax/transform/op_legalizer.py
+++ b/python/tvm/relax/transform/op_legalizer.py
@@ -38,7 +38,7 @@ def _nn_conv2d(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: E
         dilation=attrs.dilation,
         data_layout=attrs.data_layout,
         kernel_layout=attrs.kernel_layout,
-        out_dtype=attrs.out_dtype,
+        out_dtype=attrs.out_dtype if attrs.out_dtype != "" else None,
     )
 
 

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -57,8 +57,88 @@ with the layer input to produce a tensor of outputs.
     .add_argument("data", "Tensor", "The input tensor.")
     .add_argument("weight", "Tensor", "The weight tensor.")
     .set_attrs_type<Conv2DAttrs>()
-    .set_attr<FInferShape>("FInferShape", InferShapeConv2d)
-    .set_attr<FInferType>("FInferType", InferTypeBinaryBroadcast);
+    .set_attr<FInferShape>("FInferShape", InferShapeConv2D)
+    .set_attr<FInferType>("FInferType", InferTypeConv2D);
+
+Optional<Expr> InferShapeConv2D(const Call& call, DiagnosticContext diag_ctx) {
+  if (call->args.size() != 2) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Conv2d op should have 2 arguments");
+  }
+  Expr shape0 = call->args[0]->shape();
+  Expr shape1 = call->args[1]->shape();
+  auto* s0 = shape0.as<ShapeExprNode>();
+  auto* s1 = shape1.as<ShapeExprNode>();
+  auto* attrs = call->attrs.as<Conv2DAttrs>();
+  if (s0 && s1) {
+    std::vector<PrimExpr> output_shape;
+    size_t ndim0 = s0->values.size();
+    size_t ndim1 = s1->values.size();
+    if (ndim0 != 4 || ndim1 != 4) {
+      diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                         << "The 2 arguments of Conv2d must be 4D Tensors");
+    }
+    // N
+    output_shape.push_back(s0->values[0]);
+    // C
+    output_shape.push_back(s1->values[0]);
+    // H
+    output_shape.push_back((s0->values[2] + 2 * attrs->padding[0] -
+                            attrs->dilation[0] * (attrs->kernel_size[0] - 1) - 1) /
+                               attrs->strides[0] +
+                           1);
+    // W
+    output_shape.push_back((s0->values[3] + 2 * attrs->padding[1] -
+                            attrs->dilation[1] * (attrs->kernel_size[1] - 1) - 1) /
+                               attrs->strides[1] +
+                           1);
+    return ShapeExpr(Array<PrimExpr>{output_shape.begin(), output_shape.end()});
+  } else {
+    return NullOpt;
+  }
+}
+
+Type InferTypeConv2D(const Call& call, DiagnosticContext diag_ctx) {
+  if (call->args.size() != 2) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Conv2d op should have 2 arguments");
+  }
+
+  const auto* data_type = call->args[0]->checked_type().as<DynTensorTypeNode>();
+  const auto* kernel_type = call->args[1]->checked_type().as<DynTensorTypeNode>();
+  const auto* attrs = call->attrs.as<Conv2DAttrs>();
+  if (data_type == nullptr) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "The op input data should has type DynTensorType, but actually it is "
+                       << call->args[0]->checked_type()->GetTypeKey()
+                       << ". Please make sure the input data has type DynTensorType.");
+  }
+  if (kernel_type == nullptr) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "The op input kernel should has type DynTensorType, but actually it is "
+                       << call->args[1]->checked_type()->GetTypeKey()
+                       << ". Please make sure the input data has type DynTensorType.");
+  }
+
+  if (!data_type->IsUnknownNdim() && data_type->ndim != 4) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "The operator conv2d expects the input data to be a 4-rank tensor. "
+                          "However, the given data has rank "
+                       << data_type->ndim);
+  }
+  if (!kernel_type->IsUnknownNdim() && kernel_type->ndim != 4) {
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "The operator conv2d expects the input kernel to be a 4-rank tensor. "
+                          "However, the given kernel has rank "
+                       << kernel_type->ndim);
+  }
+
+  if (data_type->dtype != kernel_type->dtype && attrs->out_dtype.is_void()) {
+    diag_ctx.EmitFatal(
+        Diagnostic::Error(call->span)
+        << "The operator conv2d expects a given output dtype when the input data and kernel have "
+           "different dtypes. However, there is not a given output dtype");
+  }
+  return DynTensorType(4, attrs->out_dtype.is_void() ? data_type->dtype : attrs->out_dtype);
+}
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/nn/convolution.h
+++ b/src/relax/op/nn/convolution.h
@@ -52,44 +52,10 @@ inline Expr MakeConv(Expr data, Expr weight, Array<PrimExpr> strides, Array<Prim
   return Call(op, {data, weight}, Attrs(attrs), {});
 }
 
-Optional<Expr> InferShapeConv2d(const Call& call, DiagnosticContext diag_ctx) {
-  if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Conv2d op should have 2 arguments");
-  }
-  Expr shape0 = call->args[0]->shape();
-  Expr shape1 = call->args[1]->shape();
-  auto* s0 = shape0.as<ShapeExprNode>();
-  auto* s1 = shape1.as<ShapeExprNode>();
-  auto* attrs = call->attrs.as<Conv2DAttrs>();
-  if (s0 && s1) {
-    std::vector<PrimExpr> output_shape;
-    size_t ndim0 = s0->values.size();
-    size_t ndim1 = s1->values.size();
-    if (ndim0 != 4 || ndim1 != 4) {
-      LOG(INFO) << ndim0;
-      LOG(INFO) << ndim1;
-      diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                         << "The 2 arguments of Conv2d must be 4D Tensors");
-    }
-    // N
-    output_shape.push_back(s0->values[0]);
-    // C
-    output_shape.push_back(s1->values[0]);
-    // H
-    output_shape.push_back((s0->values[2] + 2 * attrs->padding[0] -
-                            attrs->dilation[0] * (attrs->kernel_size[0] - 1) - 1) /
-                               attrs->strides[0] +
-                           1);
-    // W
-    output_shape.push_back((s0->values[3] + 2 * attrs->padding[1] -
-                            attrs->dilation[1] * (attrs->kernel_size[1] - 1) - 1) /
-                               attrs->strides[1] +
-                           1);
-    return ShapeExpr(Array<PrimExpr>{output_shape.begin(), output_shape.end()});
-  } else {
-    return NullOpt;
-  }
-}
+/* relax.nn.conv2d */
+Optional<Expr> InferShapeConv2D(const Call& call, DiagnosticContext diag_ctx);
+
+Type InferTypeConv2D(const Call& call, DiagnosticContext diag_ctx);
 
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_op_legalizer.py
+++ b/tests/python/relax/test_op_legalizer.py
@@ -75,6 +75,58 @@ def test_conv2d():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
+def test_conv2d_with_out_dtype():
+    @I.ir_module
+    class Conv2d:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float16", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float16") = R.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float16"
+            )
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float16", ndim=4):
+            gv = R.call_tir(conv2d, (x, w), (2, 4, 26, 26), dtype="float16")
+            return gv
+
+        @T.prim_func
+        def conv2d(
+            rxplaceholder: T.Buffer[(2, 3, 28, 28), "float32"],
+            rxplaceholder_1: T.Buffer[(4, 3, 3, 3), "float32"],
+            conv2d_nchw: T.Buffer[(2, 4, 26, 26), "float16"],
+        ) -> None:
+            T.func_attr({"global_symbol": "conv2d", "tir.noalias": True})
+            pad_temp = T.alloc_buffer([2, 3, 28, 28], dtype="float32")
+            for i0, i1, i2, i3 in T.grid(2, 3, 28, 28):
+                with T.block("pad_temp"):
+                    i0_1, i1_1, i2_1, i3_1 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+                    T.reads(rxplaceholder[i0_1, i1_1, i2_1, i3_1])
+                    T.writes(pad_temp[i0_1, i1_1, i2_1, i3_1])
+                    pad_temp[i0_1, i1_1, i2_1, i3_1] = rxplaceholder[i0_1, i1_1, i2_1, i3_1]
+            for i0, i1, i2, i3, i4, i5, i6 in T.grid(2, 4, 26, 26, 3, 3, 3):
+                with T.block("conv2d_nchw"):
+                    nn, ff, yy, xx, rc, ry, rx = T.axis.remap(
+                        "SSSSRRR", [i0, i1, i2, i3, i4, i5, i6]
+                    )
+                    T.reads(pad_temp[nn, rc, yy + ry, xx + rx], rxplaceholder_1[ff, rc, ry, rx])
+                    T.writes(conv2d_nchw[nn, ff, yy, xx])
+                    with T.init():
+                        conv2d_nchw[nn, ff, yy, xx] = T.float16(0)
+                    conv2d_nchw[nn, ff, yy, xx] = conv2d_nchw[nn, ff, yy, xx] + T.cast(
+                        pad_temp[nn, rc, yy + ry, xx + rx], "float16"
+                    ) * T.cast(rxplaceholder_1[ff, rc, ry, rx], "float16")
+
+    mod = OperatorLegalizer(Conv2d).transform()
+    tvm.ir.assert_structural_equal(mod, Expected)
+
+
 def test_add():
     @I.ir_module
     class Add:

--- a/tests/python/relax/test_relax_tensor_ops.py
+++ b/tests/python/relax/test_relax_tensor_ops.py
@@ -107,6 +107,27 @@ def test_conv2d():
     tvm.testing.assert_allclose(out.numpy(), expected)
 
 
+def test_conv2d_with_out_dtype():
+    @R.function
+    def expected(
+        x: R.Tensor((2, 3, 228, 228), "float32"), w: R.Tensor((16, 3, 5, 5), "float32")
+    ) -> R.Tensor(None, "float16", ndim=4):
+        gv: R.Tensor((2, 16, 224, 224), "float16") = R.conv2d(
+            x, w, kernel_size=(5, 5), out_dtype="float16"
+        )
+        return gv
+
+    x = relax.Var("x", [2, 3, 228, 228], relax.DynTensorType(ndim=4, dtype="float32"))
+    w = relax.Var("w", [16, 3, 5, 5], relax.DynTensorType(ndim=4, dtype="float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [x, w]):
+        gv = bb.emit(relax.op.conv2d(x, w, kernel_size=(5, 5), out_dtype="float16"))
+        bb.emit_func_output(gv)
+
+    expected = expected.with_attr("global_symbol", "main")
+    tvm.ir.assert_structural_equal(bb.get()["main"], expected)
+
+
 def test_dense():
     # Set up
     dtype = "float32"


### PR DESCRIPTION
This PR brings `out_dtype` support for high-level operator Conv2D and Matmul. Please check out the new unit tests :-)

cc @spectrometerHBH @jinhongyii @tqchen @junrushao 