### PR TITLE
[FIX] Add check for repeated function parameters

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -42,6 +42,8 @@
 
 #include <unordered_set>
 
+#include "../../printer/text_printer.h"
+
 namespace tvm {
 namespace relax {
 
@@ -121,12 +123,6 @@ class WellFormedChecker : public relax::ExprVisitor {
     }
   }
 
-  String GetFuncName(Function func) {
-    Optional<String> gsymbol = func->GetAttr<String>(tvm::attr::kGlobalSymbol);
-    ICHECK(gsymbol.defined());
-    return gsymbol.value();
-  }
-
   void VisitExpr_(const FunctionNode* op) {
     // save the var_set_ for local function
     std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> previous_var_set_ = var_set_;
@@ -152,9 +148,10 @@ class WellFormedChecker : public relax::ExprVisitor {
 
       if (param_var_func_map_.count(param) == 1) {
         Malformed(Diagnostic::Error(param->span)
-                  << "Parameter variable " << param->name_hint()
-                  << " is repeatedly defined in function " << GetFuncName(param_var_func_map_[param])
-                  << " and function " << GetFuncName(func));
+                  << "Relax variable " << param->name_hint()
+                  << " is repeatedly used as parameters in function:\n"
+                  << AsRelaxScript(param_var_func_map_[param], false)
+                  << "\nand function:\n" << AsRelaxScript(func, false));
       }
       param_var_func_map_.insert({param, func});
     }

--- a/src/relax/backend/vm/codegen_vm.cc
+++ b/src/relax/backend/vm/codegen_vm.cc
@@ -72,6 +72,9 @@ class CodeGenVM : public ExprFunctor<Instruction::Arg(const Expr&)> {
     ICHECK(gsymbol.defined()) << "there should be no local functions in Relax VM codegen phase. "
                                  "Did you forget to apply LambdaLift pass?";
 
+    // var_register_map_ is local in function scope
+    var_register_map_.clear();
+
     Array<String> param_names;
     for (Var param : func_node->params) {
       param_names.push_back(param->name_hint());

--- a/tests/python/relax/test_transform_well_formed.py
+++ b/tests/python/relax/test_transform_well_formed.py
@@ -100,6 +100,29 @@ def test_dataflow_var():
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
     assert not rx.analysis.well_formed(mod)
 
+def test_param_var():
+    v0 = rx.Var("v0", [m, n], type_anno)
+    v1 = rx.Var("v1", [m, n], type_anno)
+    v2 = rx.Var("v2", [m, n], type_anno)
+    v3 = rx.Var("v3", [m, n], type_anno)
+    bb = rx.BlockBuilder()
+    with bb.function("func1", [v0, v1]):
+        with bb.dataflow():
+            lv0 = bb.emit(rx.op.add(v0, v1))
+            gv0 = bb.emit_output(lv0)
+        bb.emit_func_output(gv0)
+    with bb.function("func2", [v0, v2]):
+        with bb.dataflow():
+            lv0 = bb.emit(rx.op.add(v0, v2))
+            gv0 = bb.emit_output(lv0)
+        bb.emit_func_output(gv0)
+    with bb.function("func3", [v2, v3]):
+        with bb.dataflow():
+            lv0 = bb.emit(rx.op.add(v2, v3))
+            gv0 = bb.emit_output(lv0)
+        bb.emit_func_output(gv0)
+    mod = bb.get()
+    assert not rx.analysis.well_formed(mod)
 
 def test_global_var():
     # Error: GlobalVar GlobalVar0 is not defined

--- a/tests/python/relax/test_transform_well_formed.py
+++ b/tests/python/relax/test_transform_well_formed.py
@@ -100,29 +100,21 @@ def test_dataflow_var():
     mod = tvm.IRModule({rx.GlobalVar("foo"): func})
     assert not rx.analysis.well_formed(mod)
 
+
 def test_param_var():
     v0 = rx.Var("v0", [m, n], type_anno)
     v1 = rx.Var("v1", [m, n], type_anno)
     v2 = rx.Var("v2", [m, n], type_anno)
-    v3 = rx.Var("v3", [m, n], type_anno)
     bb = rx.BlockBuilder()
     with bb.function("func1", [v0, v1]):
-        with bb.dataflow():
-            lv0 = bb.emit(rx.op.add(v0, v1))
-            gv0 = bb.emit_output(lv0)
+        gv0 = bb.emit(rx.op.add(v0, v1))
         bb.emit_func_output(gv0)
     with bb.function("func2", [v0, v2]):
-        with bb.dataflow():
-            lv0 = bb.emit(rx.op.add(v0, v2))
-            gv0 = bb.emit_output(lv0)
-        bb.emit_func_output(gv0)
-    with bb.function("func3", [v2, v3]):
-        with bb.dataflow():
-            lv0 = bb.emit(rx.op.add(v2, v3))
-            gv0 = bb.emit_output(lv0)
+        gv0 = bb.emit(rx.op.add(v0, v2))
         bb.emit_func_output(gv0)
     mod = bb.get()
     assert not rx.analysis.well_formed(mod)
+
 
 def test_global_var():
     # Error: GlobalVar GlobalVar0 is not defined


### PR DESCRIPTION
This PR adds check for repeated function parameters in `WellFormedChecker`. In other words, one relax variable cannot be used more than once as a function parameter. 

Besides, previously in `CodeGenVM` variables defined in different functions will be stored together in `var_register_map_`, which is redundant. This PR changes the behaviour so that the map is cleared for every function passed.