### PR TITLE
[Cherry-pick] Introduce memory primitives (tlc-pack#255)

### DIFF
--- a/include/tvm/relax/attrs/memory.h
+++ b/include/tvm/relax/attrs/memory.h
@@ -26,8 +26,48 @@
 
 #include <tvm/ir/attrs.h>
 
+#include <string>
+
 namespace tvm {
 namespace relax {
+
+/*!
+ * \brief Attributes for allocating storage in memory planning.
+ */
+struct MemAllocStorageAttrs : public tvm::AttrsNode<MemAllocStorageAttrs> {
+  int64_t virtual_device_index;
+  std::string storage_scope;
+  DataType dtype;
+
+  TVM_DECLARE_ATTRS(MemAllocStorageAttrs, "relax.attrs.MemAllocStorageAttrs") {
+    TVM_ATTR_FIELD(virtual_device_index)
+        .describe(
+            "The virtual device index indicating on which device the storage is to be allocated,"
+            "Index -1 is reserved for the host device.")
+        .set_default(-1);
+    TVM_ATTR_FIELD(storage_scope)
+        .describe("The storage scope of the storage to allocate.")
+        .set_default("global");
+    TVM_ATTR_FIELD(dtype)
+        .describe("The dtype of the tensor to allocate.")
+        .set_default(DataType::Float(32, 1));
+  }
+};
+
+/*!
+ * \brief Attributes for allocating tensor in memory planning.
+ */
+struct MemAllocTensorAttrs : public tvm::AttrsNode<MemAllocTensorAttrs> {
+  int offset;
+  DataType dtype;
+
+  TVM_DECLARE_ATTRS(MemAllocTensorAttrs, "relax.attrs.MemAllocTensorAttrs") {
+    TVM_ATTR_FIELD(offset).describe("Storage offset to allocate the tensor.").set_default(0);
+    TVM_ATTR_FIELD(dtype)
+        .describe("The dtype of the tensor to allocate.")
+        .set_default(DataType::Float(32, 1));
+  }
+};
 
 /*!
  * \brief Attributes for allocating tensor.

--- a/python/tvm/relax/op/builtin/builtin.py
+++ b/python/tvm/relax/op/builtin/builtin.py
@@ -21,10 +21,28 @@ from . import _ffi_api
 from ...expr import ShapeExpr, Call
 
 
-# TODO(relax-team): add documents
 def alloc_tensor(
     shape: Union[ShapeExpr, PrimExpr, List[PrimExpr]], dtype: str, runtime_device_index: int
 ) -> Call:
+    """Construct a Call to allocate a tensor with specific shape, dtype, runtime_device_index.
+
+    Parameters
+    ----------
+    shape : Union[ShapeExpr, PrimExpr, List[PrimExpr]]
+        The shape of the tensor to be allocated.
+
+    dtype : str
+        The datatype of the tensor to be allocated.
+
+    runtime_device_index : int
+        The device index indicating on which device the tensor is to be allocated at runtime.
+        Index -1 is reserved for the host device.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which gets the allocated tensor.
+    """
     if not isinstance(shape, ShapeExpr):
         if not isinstance(shape, (tuple, list)):
             shape = (shape,)

--- a/python/tvm/relax/op/memory/__init__.py
+++ b/python/tvm/relax/op/memory/__init__.py
@@ -15,15 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""Relax memory primitives."""
 
-# Operators
-from .base import *
-from .image import *
-from .tensor import *
-from .op_attrs import *
-from .reduce import *
-from .transform import *
-from .nn import *
-from . import builtin
-from . import memory
+from .memory import *

--- a/python/tvm/relax/op/memory/_ffi_api.py
+++ b/python/tvm/relax/op/memory/_ffi_api.py
@@ -13,17 +13,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
-# under the License.
-# pylint: disable=wildcard-import, redefined-builtin
-"""Relax core operators."""
+"""FFI APIs for tvm.relax.op.memory"""
+import tvm._ffi
 
-# Operators
-from .base import *
-from .image import *
-from .tensor import *
-from .op_attrs import *
-from .reduce import *
-from .transform import *
-from .nn import *
-from . import builtin
-from . import memory
+tvm._ffi._init_api("relax.op.memory", __name__)

--- a/python/tvm/relax/op/memory/memory.py
+++ b/python/tvm/relax/op/memory/memory.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+"""Relax memory primitives."""
+
+from . import _ffi_api
+from ...expr import Expr, Call
+
+
+def alloc_storage(size: Expr, virtual_device_index: int, storage_scope: str, dtype: str) -> Call:
+    """Construct a Call to allocate a storage with specific size, virtual_device_index,
+    storage_scope and dtype.
+
+    Parameters
+    ----------
+    size : Expr
+        The size of the storage to be allocated.
+
+    virtual_device_index : int
+        The virtual device index indicating on which device the storage is to be allocated.
+        Index -1 is reserved for the host device.
+
+    storage_scope : str
+        The storage scope to allocate the storage to.
+
+    dtype : str
+        The datatype of the storage to be allocated.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which gets the allocated storage.
+    """
+    return _ffi_api.alloc_storage(size, virtual_device_index, storage_scope, dtype)
+
+
+def alloc_tensor(storage: Expr, shape: Expr, offset: int, dtype: str) -> Call:
+    """Construct a Call to allocate a tensor on a certain storage starting from the given offset.
+
+    Parameters
+    ----------
+    storage : Expr
+        The storage to allocate the tensor to.
+
+    shape : Expr
+        The shape of the tensor to be allocated.
+
+    offset : int
+        The storage offset to allocate the tensor.
+
+    dtype : str
+        The datatype of the tensor to be allocated.
+
+    Returns
+    -------
+    result : Call
+        A relax Call, which gets the allocated tensor.
+    """
+    return _ffi_api.alloc_tensor(storage, shape, offset, dtype)
+
+
+def kill_storage(storage: Expr) -> None:
+    """Construct a Call to kill a storage.
+
+    Parameters
+    ----------
+    storage : Expr
+        The storage to be killed.
+    """
+    return _ffi_api.kill_storage(storage)
+
+
+def kill_tensor(tensor: Expr) -> None:
+    """Construct a Call to kill a tensor.
+
+    Parameters
+    ----------
+    tensor : Expr
+        The tensor to be killed.
+    """
+    return _ffi_api.kill_tensor(tensor)

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -24,6 +24,16 @@ class AllocTensorAttrs(Attrs):
     """Attributes used in alloc_tensor operators"""
 
 
+@tvm._ffi.register_object("relax.attrs.MemAllocStorageAttrs")
+class MemAllocStorageAttrs(Attrs):
+    """Attributes used in memory planning alloc_storage operators"""
+
+
+@tvm._ffi.register_object("relax.attrs.MemAllocTensorAttrs")
+class MemAllocTensorAttrs(Attrs):
+    """Attributes used in memory planning alloc_tensor operators"""
+
+
 @tvm._ffi.register_object("relax.attrs.VMAllocStorageAttrs")
 class VMAllocStorageAttrs(Attrs):
     """Attributes used in VM alloc_storage operators"""

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -28,6 +28,8 @@ namespace tvm {
 namespace relax {
 
 TVM_REGISTER_NODE_TYPE(AllocTensorAttrs);
+TVM_REGISTER_NODE_TYPE(MemAllocStorageAttrs);
+TVM_REGISTER_NODE_TYPE(MemAllocTensorAttrs);
 TVM_REGISTER_NODE_TYPE(VMAllocStorageAttrs);
 TVM_REGISTER_NODE_TYPE(VMAllocTensorAttrs);
 TVM_REGISTER_NODE_TYPE(ShapeHeapAttrs);
@@ -239,6 +241,87 @@ Expr MakeAllocTensor(Expr shape, DataType dtype, int64_t runtime_device_index) {
 
 TVM_REGISTER_GLOBAL("relax.op.builtin.alloc_tensor").set_body_typed(MakeAllocTensor);
 
+// memory planning alloc_storage
+
+RELAY_REGISTER_OP("relax.memory.alloc_storage")
+    .set_attrs_type<MemAllocStorageAttrs>()
+    .set_num_inputs(1)
+    .add_argument("total_space", "Expr", "The total space of the storage to allocate.")
+    .set_attr<FInferType>("FInferType", ReturnObjectType);
+
+Expr MakeAllocStorage(Expr size, int64_t virtual_device_index, std::string storage_scope,
+                      DataType dtype) {
+  auto attrs = make_object<MemAllocStorageAttrs>();
+  attrs->virtual_device_index = std::move(virtual_device_index);
+  attrs->storage_scope = std::move(storage_scope);
+  attrs->dtype = std::move(dtype);
+  static const Op& op = Op::Get("relax.memory.alloc_storage");
+  return Call(op, {size}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.memory.alloc_storage").set_body_typed(MakeAllocStorage);
+
+// memory planning alloc_tensor
+
+Optional<Expr> InferShapeMemAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
+  return call->args[1];
+}
+
+Type InferTypeMemAllocTensor(const Call& call, DiagnosticContext diag_ctx) {
+  auto attrs = call->attrs.as<MemAllocTensorAttrs>();
+  ICHECK(attrs != nullptr) << "must be MemAllocTensorAttrs , but got " << call->attrs->GetTypeKey();
+  if (const auto* output_shape = call->args[1].as<ShapeExprNode>()) {
+    return DynTensorType(output_shape->values.size(), attrs->dtype);
+  }
+  return DynTensorType::CreateUnknownNDim(attrs->dtype, Span());
+}
+
+RELAY_REGISTER_OP("relax.memory.alloc_tensor")
+    .set_attrs_type<MemAllocTensorAttrs>()
+    .set_num_inputs(2)
+    .add_argument("storage", "Expr", "The storage to allocate the tensor to.")
+    .add_argument("shape", "Expr", "The shape of the tensor to allocate.")
+    .set_attr<FInferShape>("FInferShape", InferShapeMemAllocTensor)
+    .set_attr<FInferType>("FInferType", InferTypeMemAllocTensor);
+
+Expr MakeMemAllocTensor(Expr storage, Expr shape, int offset, DataType dtype) {
+  auto attrs = make_object<MemAllocTensorAttrs>();
+  attrs->offset = std::move(offset);
+  attrs->dtype = std::move(dtype);
+  static const Op& op = Op::Get("relax.memory.alloc_tensor");
+  return Call(op, {storage, shape}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.memory.alloc_tensor").set_body_typed(MakeMemAllocTensor);
+
+// memory planning kill_storage
+
+RELAY_REGISTER_OP("relax.memory.kill_storage")
+    .set_num_inputs(1)
+    .add_argument("storage", "Expr", "The storage to be killed.")
+    .set_attr<FInferType>("FInferType", ReturnVoidType);
+
+Expr MakeMemKillStorage(Expr storage) {
+  static const Op& op = Op::Get("relax.memory.kill_storage");
+  return Call(op, {storage}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.memory.kill_storage").set_body_typed(MakeMemKillStorage);
+
+// memory planning kill_tensor
+
+RELAY_REGISTER_OP("relax.memory.kill_tensor")
+    .set_num_inputs(1)
+    .add_argument("tensor", "Expr", "The tensor to be killed.")
+    .set_attr<FInferType>("FInferType", ReturnVoidType);
+
+Expr MakeMemKillTensor(Expr tensor) {
+  static const Op& op = Op::Get("relax.memory.kill_tensor");
+  return Call(op, {tensor}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.memory.kill_tensor").set_body_typed(MakeMemKillTensor);
+
 // vm alloc_storage
 
 RELAX_REGISTER_OP("relax.vm.builtin.alloc_storage")
@@ -280,10 +363,10 @@ RELAX_REGISTER_OP("relax.vm.builtin.alloc_tensor")
     .set_attr<FInferShape>("FInferShape", InferShapeVMAllocTensor)
     .set_attr<FInferType>("FInferType", InferTypeVMAllocTensor);
 
-Expr MakeVMAllocTensor(Expr storage, Expr shape, DataType dtype, int64_t runtime_device_index) {
-  auto attrs = make_object<VMAllocStorageAttrs>();
+Expr MakeVMAllocTensor(Expr storage, Expr shape, int offset, DataType dtype) {
+  auto attrs = make_object<VMAllocTensorAttrs>();
+  attrs->offset = std::move(offset);
   attrs->dtype = std::move(dtype);
-  attrs->runtime_device_index = std::move(runtime_device_index);
   static const Op& op = Op::Get("relax.vm.builtin.alloc_tensor");
   return Call(op, {storage, shape}, Attrs(attrs), {});
 }


### PR DESCRIPTION
Cherry-picking https://github.com/tlc-pack/relax/pull/255 by @LeshengJin

> Introduce the memory primitives, including `relax.memory.{alloc_storage, alloc_tensor, kill_storage, kill_tensor}`.
