### PR TITLE
[Relax] Static memory planning

### DIFF
--- a/python/tvm/relax/frontend/pytorch_fx.py
+++ b/python/tvm/relax/frontend/pytorch_fx.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from numpy import iterable
 import torch
 import tvm
 
@@ -293,7 +292,7 @@ class TorchFXTranslator:
 
     def _getitem(self, node: fx.node.Node) -> relax.Var:
         x = self.env[node.args[0]]
-        if iterable(x):
+        if isinstance(x, (list, tuple, relax.ShapeExpr, relax.Tuple)):
             return x[node.args[1]]
         elif isinstance(x, relax.Var):
             if isinstance(x.shape, relax.Tuple):
@@ -453,7 +452,7 @@ class TorchFXTranslator:
         args = self.retrive_args(node)
         self_var = args[0]
         size = args[1:]
-        if not iterable(size):
+        if not isinstance(size, (list, tuple)):
             size = (size,)
         return self.bb.emit(
             relax.op.full(

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -101,6 +101,10 @@ def CallTIRRewrite() -> tvm.ir.transform.Pass:
     return _ffi_api.CallTIRRewrite()  # type: ignore
 
 
+def VMGraphMemoryPlan() -> tvm.ir.transform.Pass:
+    return _ffi_api.VMGraphMemoryPlan()
+
+
 def VMMemoryLower() -> tvm.ir.transform.Pass:
     """Perform memory lowering. Lowers the relax.builtin.alloc_tensor intrinsic to VM intrinsics.
 

--- a/python/tvm/relax/vm.py
+++ b/python/tvm/relax/vm.py
@@ -501,6 +501,7 @@ def build(
 
     passes = [relax.transform.ToNonDataflow()]
     passes.append(relax.transform.CallTIRRewrite())
+    passes.append(relax.transform.VMGraphMemoryPlan())
     passes.append(relax.transform.VMMemoryLower())
     passes.append(relax.transform.VMShapeLower())
     seq = tvm.transform.Sequential(passes)

--- a/src/relax/backend/vm/vm_graph_memory_plan.cc
+++ b/src/relax/backend/vm/vm_graph_memory_plan.cc
@@ -19,6 +19,10 @@
 /*!
  * \file src/relax/backend/vm/vm_graph_memory_plan.cc
  * \brief Perform memory planning for memory reuse.
+ * \note
+ *  - Nested functions are not considered yet.
+ *  - Symbolic shape cases (ones with MatchShape) are completely not considered yet.
+ *  - RuntimeDepShape is not allowed at this moment.
  */
 #include <tvm/relax/attrs/memory.h>
 #include <tvm/relax/backend.h>
@@ -37,105 +41,262 @@
 namespace tvm {
 namespace relax {
 
+/*!
+ * \brief A representation of a block of reusable memory required at runtime.
+ * \details Only the tensors whose memory can be "possibly reused" will have their storage token. In
+ * other words, we do not have storage token for tensor
+ * - that is a function parameter,
+ * - that is a function return value,
+ * - one of whose use site is a BindingBlock different from its allocation site,
+ * - that is used as a condition or branch return of a IfNode
+ * - that is used as the body of a SeqExprNode.
+ *
+ * In practice, we do create a storage token for such tensor at first. But at any time we find a
+ * tensor satisfying any of the conditions above, we erase its storage token.
+ */
 struct StorageToken {
   /*! \brief Reference counter */
   int ref_counter{0};
-  /*! \brief number of bytes */
-  int bytes{-1};
+  /*! \brief Number of bytes, which is impossible to exceed the range of int. */
+  int64_t bytes{-1};
   /*! \brief The shape of the tensor */
   Array<PrimExpr> shape;
   /*! \brief The corresponding tensor dtype. */
   DataType dtype;
   /*! \brief The storage id */
   int storage_id{-1};
-  /*! \brief The corresponding allocated storage */
+  /*! \brief The variable corresponding to the allocated storage */
   Var storage{nullptr};
 
-  // Todo:
-  // - take care of virtual device id
-  // - think about symbolic dynamic case
-  // - handle reshape
-
   std::string ToString() const {
+    ICHECK(shape.defined());
     std::ostringstream os;
     os << "{storage_id: " << storage_id << ", bytes: " << bytes << ", shape: " << shape
-       << ", dtype: " << dtype << "}";
+       << ", dtype: " << dtype << ", ref_counter: " << ref_counter << "}";
     return os.str();
   }
 };
 
-// Todo: comments
-// - only one can be non-empty, depending on `is_tuple`
-struct TokenWrapper {
-  TokenWrapper() : is_tuple(false), field_tokens{}, token(nullptr) {}
+/*!
+ * \brief A data structure used to represent the storage tokens of Exprs.
+ * \details
+ * Specially,
+ * - the tokens of a Tuple is represented as a TokenContainer with `is_tuple` true, `token` nullptr
+ * and `filed_tokens` being the list of the TokenContainers of its fields,
+ * - the tokens of a TupleGetItem is the TokenContainer at the indicated position of the
+ * TokenContainer of its `tuple`.
+ *
+ * Since not every Expr has a storage token, consider the following case
+ *
+ *    @R.function
+ *    def func(x: R.Tensor((2, 4), "float32")):
+ *      y = R.builtin.alloc_tensor((2, 4), "float32")
+ *      exp(x, y)
+ *      t = (x, y)
+ *      return t[1]
+ *
+ * Here since `x` is a parameter, we do not create a storage token for it. So if the storage tokens
+ * of a Tuple is simply represented as a list of the field storage tokens, then the storage tokens
+ * of `t` are represented as a list which only contains the storage token of `y`. And consequently,
+ * when getting the storage token of `t[1]`, we use 1 to index the list of single element inside,
+ * which leads to error. So this is why we introduce TokenContainer as a data structure for Exprs'
+ * storage tokens.
+ *
+ * \note If an Expr has no corresponding storage token, its TokenContainer has `is_tuple` true,
+ * empty `field_containers` and null `token`, in the same form as the TokenContainer of an empty
+ * Tuple.
+ */
+struct TokenContainer {
+  TokenContainer() : is_tuple(true), field_containers{}, token(nullptr) {}
 
-  TokenWrapper(bool is_tuple, std::vector<TokenWrapper> field_tokens, StorageToken* token) {
+  TokenContainer(bool is_tuple, std::vector<TokenContainer> field_containers, StorageToken* token) {
     if (is_tuple) {
       ICHECK(token == nullptr);
     } else {
       ICHECK_NOTNULL(token);
-      ICHECK(field_tokens.empty());
+      ICHECK(field_containers.empty());
     }
-
     this->is_tuple = is_tuple;
-    this->field_tokens = std::move(field_tokens);
+    this->field_containers = std::move(field_containers);
     this->token = token;
   }
 
-  bool IsEmptyToken() const { return is_tuple == true && field_tokens.empty() && token == nullptr; }
-
-  static std::vector<StorageToken*> FlattenTokens(const TokenWrapper& wrapper) {
-    std::vector<StorageToken*> tokens;
-    std::function<void(const TokenWrapper&)> f_visit = [&](const TokenWrapper& wrapper) {
-      if (wrapper.is_tuple) {
-        for (const TokenWrapper& field_wrapper : wrapper.field_tokens) {
-          f_visit(field_wrapper);
-        }
-      } else {
-        ICHECK_NOTNULL(wrapper.token);
-        tokens.push_back(wrapper.token);
-      }
-    };
-
-    f_visit(wrapper);
-    return tokens;
+  bool IsEmptyToken() const {
+    return is_tuple == true && field_containers.empty() && token == nullptr;
   }
 
+  /*! \brief Apply the given function to each storage token in this TokenContainer */
+  void ApplyToTokens(std::function<void(StorageToken*)> f_apply) const {
+    if (is_tuple) {
+      for (const TokenContainer& field_container : field_containers) {
+        field_container.ApplyToTokens(f_apply);
+      }
+    } else {
+      ICHECK_NOTNULL(token);
+      f_apply(token);
+    }
+  }
+
+  /*! \brief Remove the specified token from this TokenContainer */
   void RemoveToken(const StorageToken* token_to_remove) {
     if (is_tuple) {
-      for (TokenWrapper& wrapper : field_tokens) {
-        wrapper.RemoveToken(token_to_remove);
+      for (TokenContainer& container : field_containers) {
+        container.RemoveToken(token_to_remove);
       }
     } else if (token == token_to_remove) {
       // Set to an empty token.
       is_tuple = true;
-      ICHECK(field_tokens.empty());
+      ICHECK(field_containers.empty());
       token = nullptr;
     }
   }
 
+  std::string ToString() const {
+    std::ostringstream os;
+    os << "[";
+    ApplyToTokens([&os](StorageToken* token) { os << token->ToString() << ", "; });
+    os << "]";
+    return os.str();
+  }
+
   bool is_tuple;
-  std::vector<TokenWrapper> field_tokens;
+  std::vector<TokenContainer> field_containers;
   StorageToken* token;
 };
 
-// - Nested functions are not considered yet.
-// - Symbolic shape cases (ones with MatchShape) are completely not considered yet.
-// - RuntimeDepShape is not allowed at this moment.
-// - Reshape is not considered yet.
-class StorageAllocatorInit : public ExprVisitor {
+/**
+ * \brief Memory manager for flattened 1d memory (buffers)
+ */
+class TokenAllocator1D {
  public:
-  // Entry function
-  std::unordered_map<const ExprNode*, TokenWrapper> Init(const Function& func) {
-    const TokenWrapper& body_tokens = GetTokens(func->body);
-    // Mark the function body tokens as external referenced.
-    ClearTokens(TokenWrapper::FlattenTokens(body_tokens));
+  /*!
+   * \brief Request a storage token from the available token pool for a given prototype.
+   * \param prototype The prototype storage token.
+   * \return The result token.
+   */
+  StorageToken* Request(StorageToken* prototype) {
+    ICHECK_EQ(prototype->storage_id, -1);
+    ICHECK_EQ(prototype->bytes, -1);
+    ICHECK_GT(prototype->ref_counter, 0);
+    ICHECK(!prototype->storage.defined());
 
-    return this->token_map_;
+    // Calculate the size in byte.
+    int64_t size = GetMemorySize(prototype);
+    // Search memory blocks in [size / match_range_, size * match_range_)
+    auto begin = available_pool_.lower_bound(size / match_range_);
+    auto mid = available_pool_.lower_bound(size);
+    auto end = available_pool_.upper_bound(size * match_range_);
+    // Search for memory block that equals or is larger than the requested size
+    for (auto it = mid; it != end; ++it) {
+      StorageToken* available_token = it->second;
+      ICHECK_EQ(available_token->ref_counter, 0);
+      ICHECK_LE(size, available_token->bytes);
+      available_token->ref_counter = prototype->ref_counter;
+      // find a exact match, erase from map and return
+      available_pool_.erase(it);
+      return available_token;
+    }
+    // Then search for memory block that is smaller than the requested size.
+    for (auto it = mid; it != begin;) {
+      --it;
+      StorageToken* available_token = it->second;
+      ICHECK_EQ(available_token->ref_counter, 0);
+      ICHECK_GE(size, available_token->bytes);
+      available_token->bytes = size;
+      available_token->ref_counter = prototype->ref_counter;
+      // erase from map and return
+      available_pool_.erase(it);
+      return available_token;
+    }
+    // Return `nullptr` indicating that no satisfiable storage token is found in the available pool.
+    return nullptr;
+  }
+
+  /*!
+   * \brief Allocate a storage token for the input prototype token
+   * \param prototype The prototype token.
+   * \param storage_id The id of this token.
+   */
+  StorageToken* Alloc(StorageToken* prototype, int storage_id) {
+    ICHECK_EQ(prototype->storage_id, -1);
+    ICHECK(!prototype->storage.defined());
+    int64_t size = GetMemorySize(prototype);
+    if (prototype->bytes != -1) {
+      ICHECK_EQ(size, prototype->bytes);
+    } else {
+      prototype->bytes = size;
+    }
+    prototype->storage_id = storage_id;
+    full_pool_.push_back(prototype);
+    return prototype;
+  }
+
+  /*!
+   * \brief Release the input token, putting it into the available pool.
+   * \param token The token to be released.
+   */
+  void Release(StorageToken* token) {
+    ICHECK_GE(token->storage_id, 0);
+    ICHECK_GE(token->bytes, 0);
+    ICHECK_EQ(token->ref_counter, 0);
+    ICHECK(!token->storage.defined());
+    available_pool_.insert({token->bytes, token});
+  }
+
+  std::string DumpMemoryAllocation() const {
+    std::ostringstream os;
+    double total_gb = 0.0;
+    os << "=========================== Dump Memory Allocation ===========================\n";
+    for (const StorageToken* token : full_pool_) {
+      double size = 1.0 * token->bytes / (1ll << 30);
+      total_gb += size;
+      os << " - Allocated " << size << " GB\n";
+    }
+    os << "Total allocated memory that are possibly used: " << total_gb << " GB";
+    return os.str();
   }
 
  private:
-  void VisitBindingBlock_(const BindingBlockNode* block) final {
+  /*!
+   * \brief Get the size of the consumed memory of a prototype token.
+   * \param prototype The prototype token.
+   * \return The required memory size.
+   */
+  int64_t GetMemorySize(StorageToken* prototype) {
+    ICHECK_EQ(prototype->storage_id, -1);
+    if (prototype->bytes != -1) {
+      return prototype->bytes;
+    }
+
+    int64_t size = 1;
+    for (const PrimExpr& dim_len : prototype->shape) {
+      const int64_t* p_dim_len = tir::as_const_int(dim_len);
+      ICHECK_NOTNULL(p_dim_len);
+      size *= *p_dim_len;
+    }
+    size *= (prototype->dtype.bits() * prototype->dtype.lanes() + 7) / 8;
+    prototype->bytes = size;
+    return size;
+  }
+
+ private:
+  // scale used for rough match
+  const int match_range_{16};
+  // free list of storage entry
+  std::multimap<int64_t, StorageToken*> available_pool_;
+  // all the storage resources available
+  std::vector<StorageToken*> full_pool_;
+  /*! \brief Number of storages */
+  int n_storage_;
+};
+
+/*! \brief The base class for the storage allocation visitor */
+class StorageAllocatorBaseVisitor : public ExprVisitor {
+ public:
+  explicit StorageAllocatorBaseVisitor(support::Arena* arena) : arena_(arena) {}
+
+ protected:
+  void VisitBindingBlock_(const BindingBlockNode* block) override {
     block_stack_.push_back(block);
     ExprVisitor::VisitBindingBlock_(block);
     ICHECK(!block_stack_.empty());
@@ -143,11 +304,76 @@ class StorageAllocatorInit : public ExprVisitor {
     block_stack_.pop_back();
   }
 
-  void VisitBinding_(const VarBindingNode* binding) final {
-    const TokenWrapper& tokens = GetTokens(binding->value);
+  void VisitBinding_(const VarBindingNode* binding) override {
+    this->VisitVarDef(binding->var);
+    const TokenContainer& tokens = GetTokens(binding->value);
     ExprUsesTokens(binding->var.get(), tokens);
   }
 
+  void VisitExpr_(const TupleNode* tuple) override {
+    std::vector<TokenContainer> tokens;
+    for (const Expr& field : tuple->fields) {
+      const TokenContainer& field_containers = GetTokens(field);
+      tokens.push_back(field_containers);
+    }
+    ExprUsesTokens(tuple, TokenContainer(/*is_tuple=*/true,                       //
+                                         /*field_containers=*/std::move(tokens),  //
+                                         /*token=*/nullptr));
+  }
+
+  void VisitExpr_(const TupleGetItemNode* tuple_item) override {
+    const TokenContainer& container = GetTokens(tuple_item->tuple);
+    ICHECK(container.is_tuple);
+    if (static_cast<int>(container.field_containers.size()) > tuple_item->index) {
+      ICHECK_GE(tuple_item->index, 0);
+      ExprUsesTokens(tuple_item, container.field_containers[tuple_item->index]);
+    } else {
+      ICHECK(container.IsEmptyToken());
+      token_map_[tuple_item] = no_tokens_;
+    }
+  }
+
+  // The function is the place where recursive visit happens.
+  const TokenContainer& GetTokens(const Expr& expr) {
+    this->VisitExpr(expr);
+    auto it = token_map_.find(expr.get());
+    if (it == token_map_.end()) {
+      token_map_[expr.get()] = no_tokens_;
+      return no_tokens_;
+    }
+    return it->second;
+  }
+
+  void ExprUsesTokens(const ExprNode* expr, const TokenContainer& container) {
+    token_map_[expr] = container;
+  }
+
+  /*! \brief The allocator */
+  support::Arena* arena_;
+  /*! \brief The mapping from each Expr to its corresponding storage tokens */
+  std::unordered_map<const ExprNode*, TokenContainer> token_map_;
+  /*! \brief The binding block stack */
+  std::vector<const BindingBlockNode*> block_stack_;
+  /*! \brief An empty token map */
+  const TokenContainer no_tokens_;
+};
+
+class StorageAllocatorInit : public StorageAllocatorBaseVisitor {
+ public:
+  explicit StorageAllocatorInit(support::Arena* arena) : StorageAllocatorBaseVisitor(arena) {}
+
+  std::unordered_map<const ExprNode*, TokenContainer> Initialize(const Function& func) {
+    for (const Var& param : func->params) {
+      token_map_[param.get()] = no_tokens_;
+      this->VisitVarDef(param);
+    }
+    const TokenContainer& body_tokens = GetTokens(func->body);
+    // Erase the tokens of the function output.
+    body_tokens.ApplyToTokens([this](StorageToken* token) { this->EraseToken(token); });
+    return this->token_map_;
+  }
+
+ private:
   void VisitExpr_(const VarNode* var) final { ICHECK(token_map_.count(var)); }
 
   void VisitExpr_(const CallNode* call) final {
@@ -157,67 +383,40 @@ class StorageAllocatorInit : public ExprVisitor {
       return;
     }
 
-    ICHECK(!block_stack_.empty());
-    const BindingBlockNode* cur_binding_block = block_stack_.back();
+    // `block_stack_` here is possibly empty (e.g., the function body is a `call_packed`).
+    const BindingBlockNode* cur_block = block_stack_.empty() ? nullptr : block_stack_.back();
     for (const Expr& arg : call->args) {
-      const TokenWrapper& wrapper = GetTokensWithAllocSiteCheck(arg, cur_binding_block);
-      IncreaseRefCounter(wrapper);
-    }
-
-    // Todo: handle reshape separately
-  }
-
-  void VisitExpr_(const TupleNode* tuple) final {
-    std::vector<TokenWrapper> tokens;
-    for (const Expr& field : tuple->fields) {
-      const TokenWrapper& field_tokens = GetTokens(field);
-      tokens.push_back(field_tokens);
-    }
-    ExprUsesTokens(tuple, TokenWrapper(/*is_tuple=*/true,                   //
-                                       /*field_tokens=*/std::move(tokens),  //
-                                       /*token=*/nullptr));
-  }
-
-  void VisitExpr_(const TupleGetItemNode* tuple_item) final {
-    ICHECK_GE(tuple_item->index, 0);
-
-    const TokenWrapper& wrapper = GetTokens(tuple_item->tuple);
-    ICHECK(wrapper.is_tuple);
-    if (static_cast<int>(wrapper.field_tokens.size()) > tuple_item->index) {
-      ExprUsesTokens(tuple_item, wrapper.field_tokens[tuple_item->index]);
-    } else {
-      ICHECK(wrapper.IsEmptyToken());
-      token_map_[tuple_item] = no_tokens_;
+      const TokenContainer& container = GetTokensWithAllocSiteCheck(arg, cur_block);
+      IncreaseRefCounter(container);
     }
   }
 
   void VisitExpr_(const IfNode* if_node) final {
-    const TokenWrapper& cond_tokens = GetTokens(if_node->cond);
-    const TokenWrapper& then_tokens = GetTokens(if_node->true_branch);
-    const TokenWrapper& else_tokens = GetTokens(if_node->false_branch);
-    ClearTokens(TokenWrapper::FlattenTokens(cond_tokens));
-    ClearTokens(TokenWrapper::FlattenTokens(then_tokens));
-    ClearTokens(TokenWrapper::FlattenTokens(else_tokens));
+    const TokenContainer& cond_tokens = GetTokens(if_node->cond);
+    const TokenContainer& then_tokens = GetTokens(if_node->true_branch);
+    const TokenContainer& else_tokens = GetTokens(if_node->false_branch);
+    cond_tokens.ApplyToTokens([this](StorageToken* token) { this->EraseToken(token); });
+    then_tokens.ApplyToTokens([this](StorageToken* token) { this->EraseToken(token); });
+    else_tokens.ApplyToTokens([this](StorageToken* token) { this->EraseToken(token); });
   }
 
   void VisitExpr_(const SeqExprNode* seq) final {
     for (const BindingBlock& binding_block : seq->blocks) {
       this->VisitBindingBlock(binding_block);
     }
-    const TokenWrapper& body_tokens = GetTokens(seq->body);
-    ClearTokens(TokenWrapper::FlattenTokens(body_tokens));
+    const TokenContainer& body_tokens = GetTokens(seq->body);
+    body_tokens.ApplyToTokens([this](StorageToken* token) { this->EraseToken(token); });
   }
 
-  TokenWrapper CreateToken(const CallNode* call) {
+  TokenContainer CreateToken(const CallNode* call) {
     ICHECK(!token_map_.count(call));
 
-    // The impl guarantees that the input can only have DynTensorType
+    // The current implementation guarantees that the input can only have DynTensorType.
     const auto* ttype = call->checked_type().as<DynTensorTypeNode>();
     const auto* shape = call->shape().as<ShapeExprNode>();
     const auto* attrs = call->attrs.as<AllocTensorAttrs>();
     ICHECK_NOTNULL(ttype);
     ICHECK_NOTNULL(attrs);
-
     ICHECK(call->shape().same_as(call->args[0]));
     ICHECK(!ttype->IsUnknownDtype());
     ICHECK(ttype->dtype == attrs->dtype);
@@ -240,222 +439,83 @@ class StorageAllocatorInit : public ExprVisitor {
     ICHECK(!block_stack_.empty());
     token2block_[token] = block_stack_.back();
 
-    TokenWrapper token_wrapper(/*is_tuple=*/false, /*field_tokens=*/{}, token);
-    ExprUsesTokens(call, token_wrapper);
-    // token_map_[call] = token_wrapper;
-    return token_wrapper;
+    TokenContainer token_container(/*is_tuple=*/false, /*field_containers=*/{}, token);
+    ExprUsesTokens(call, token_container);
+    return token_container;
   }
 
-  // The function is the place where recursive visit happens.
-  const TokenWrapper& GetTokens(const Expr& expr) {
-    this->VisitExpr(expr);
-    auto it = token_map_.find(expr.get());
-    if (it == token_map_.end()) {
-      LOG(INFO) << "Tokens not created for " << expr->GetTypeKey() << ":\n" << PrettyPrint(expr);
-      token_map_[expr.get()] = no_tokens_;
-      return no_tokens_;
-    }
-    return it->second;
+  void ExprUsesTokens(const ExprNode* expr, const TokenContainer& container) {
+    StorageAllocatorBaseVisitor::ExprUsesTokens(expr, container);
+    container.ApplyToTokens(
+        [this, expr](StorageToken* token) { this->token2exprs_[token].push_back(expr); });
   }
 
-  void ExprUsesTokens(const ExprNode* expr, const TokenWrapper& wrapper) {
-    auto it = token_map_.insert({expr, wrapper});
-    ICHECK(it.second == true);
-
-    const std::vector<StorageToken*> tokens = TokenWrapper::FlattenTokens(wrapper);
-    for (const StorageToken* token : tokens) {
-      token2exprs_[token].push_back(expr);
-    }
-  }
-
-  const TokenWrapper& GetTokensWithAllocSiteCheck(const Expr& expr,
-                                                  const BindingBlockNode* cur_block) {
-    const TokenWrapper& wrapper = GetTokens(expr);
-    const std::vector<StorageToken*> tokens = TokenWrapper::FlattenTokens(wrapper);
-    for (StorageToken* token : tokens) {
-      auto it = token2block_.find(token);
-      ICHECK(it != token2block_.end());
+  const TokenContainer& GetTokensWithAllocSiteCheck(const Expr& expr,
+                                                    const BindingBlockNode* cur_block) {
+    const TokenContainer& container = GetTokens(expr);
+    container.ApplyToTokens([this, cur_block](StorageToken* token) {
+      auto it = this->token2block_.find(token);
+      ICHECK(it != this->token2block_.end());
       if (it->second != cur_block) {
-        ClearTokens({token});
+        EraseToken(token);
       }
-    }
+    });
     return token_map_[expr.get()];
   }
 
-  void IncreaseRefCounter(const TokenWrapper& token_wrapper) {
-    const std::vector<StorageToken*>& tokens = TokenWrapper::FlattenTokens(token_wrapper);
-    for (StorageToken* token : tokens) {
-      token->ref_counter += 1;
-    }
+  void IncreaseRefCounter(const TokenContainer& token_container) {
+    token_container.ApplyToTokens([](StorageToken* token) { token->ref_counter += 1; });
   }
 
-  void ClearTokens(const std::vector<StorageToken*>& tokens) {
-    for (const StorageToken* token : tokens) {
-      const std::vector<const ExprNode*>& exprs = token2exprs_[token];
-      for (const ExprNode* expr : exprs) {
-        token_map_[expr].RemoveToken(token);
-      }
-      token2exprs_.erase(token);
-      token2block_.erase(token);
+  void EraseToken(StorageToken* token) {
+    const std::vector<const ExprNode*>& exprs = token2exprs_[token];
+    for (const ExprNode* expr : exprs) {
+      token_map_[expr].RemoveToken(token);
     }
+    token2exprs_.erase(token);
+    token2block_.erase(token);
   }
 
-  /*! \brief The allocator */
-  support::Arena* arena_;
-  /*! \brief The binding block stack */
-  std::vector<const BindingBlockNode*> block_stack_;
-  /*! \brief The mapping from each Expr to its corresponding storage tokens */
-  std::unordered_map<const ExprNode*, TokenWrapper> token_map_;
   /*! \brief The mapping from each token to the binding block where it is created */
   std::unordered_map<const StorageToken*, const BindingBlockNode*> token2block_;
   /*! \brief The mapping from each token to the Exprs that share this token */
   std::unordered_map<const StorageToken*, std::vector<const ExprNode*>> token2exprs_;
-  /*! \brief An empty token map */
-  const TokenWrapper no_tokens_;
 };
 
-/**
- * \brief Memory manager for flattened 1d memory (buffers)
- * TODO: refine
- */
-class TokenAllocator1D {
+class StorageAllocator : public StorageAllocatorBaseVisitor {
  public:
-  /*!
-   * \brief Request a storage token for a given prototype.
-   * \param prototype. The prototype storage token.
-   * \return The result token.
-   */
-  StorageToken* Request(StorageToken* prototype) {
-    ICHECK_EQ(prototype->storage_id, -1);
-
-    // calculate the size;
-    int size = GetMemorySize(prototype);
-    // search memory block in [size / match_range_, size * match_range_)
-    auto begin = available_pool_.lower_bound(size / match_range_);
-    auto mid = available_pool_.lower_bound(size);
-    auto end = available_pool_.upper_bound(size * match_range_);
-    // search for memory blocks larger than requested
-    for (auto it = mid; it != end; ++it) {
-      StorageToken* available_token = it->second;
-      ICHECK_EQ(available_token->ref_counter, 0);
-      // Use exact matching strategy
-      ICHECK_LE(size, available_token->bytes);
-      available_token->ref_counter = prototype->ref_counter;
-      // find a exact match, erase from map and return
-      available_pool_.erase(it);
-      return available_token;
-    }
-    // then search for memory blocks smaller than requested space
-    for (auto it = mid; it != begin;) {
-      --it;
-      StorageToken* available_token = it->second;
-      ICHECK_EQ(available_token->ref_counter, 0);
-      // Use exact matching strategy
-      ICHECK_GE(size, available_token->bytes);
-      available_token->bytes = size;
-      available_token->ref_counter = prototype->ref_counter;
-      // erase from map and return
-      available_pool_.erase(it);
-      return available_token;
-    }
-    return nullptr;
+  explicit StorageAllocator(std::unordered_map<const ExprNode*, TokenContainer> token_map,
+                            support::Arena* arena)
+      : StorageAllocatorBaseVisitor(arena) {
+    this->token_map_ = std::move(token_map);
   }
 
-  /*!
-   * \brief Allocate a storage token by consuming prototype
-   * \param prototype The prototype token.
-   * \param size The size of memory being requested.
-   */
-  StorageToken* Alloc(StorageToken* prototype, int storage_id) {
-    ICHECK_EQ(prototype->storage_id, -1);
-    ICHECK(!prototype->storage.defined());
-    int size = GetMemorySize(prototype);
-    prototype->bytes = size;
-    prototype->storage_id = storage_id;
-    full_pool_.push_back(prototype);
-    return prototype;
-  }
+  std::string DumpMemoryAllocation() const { return allocator_.DumpMemoryAllocation(); }
 
   /*!
-   * \brief Check if we can release token.
-   * \param token The token to be released.
+   * \brief The mapping from each memory-reusable `builtin.alloc_tensor` to its corresponding
+   * underlying storage token that it is using.
    */
-  void Release(StorageToken* token) {
-    ICHECK_GE(token->storage_id, 0);
-    ICHECK_GE(token->bytes, 0);
-    ICHECK_EQ(token->ref_counter, 0);
-    ICHECK(!token->storage.defined());
-    available_pool_.insert({token->bytes, token});
-  }
-
- private:
-  /*!
-   * \brief ceil(size/word_size) to get number of words.
-   * \param size The original size.
-   * \param word_size The element size.
-   */
-  static int DivRoundUp(int size, int word_size) { return (size + word_size - 1) / word_size; }
-
-  /*!
-   * Todo: refine
-   * \brief Get the memory requirement.
-   * \param prototype The prototype token.
-   * \return The required memory size.
-   */
-  int GetMemorySize(StorageToken* prototype) {
-    ICHECK_EQ(prototype->storage_id, -1);
-    if (prototype->bytes != -1) {
-      return prototype->bytes;
-    }
-
-    int size = 1;
-    for (const PrimExpr& dim_len : prototype->shape) {
-      const int64_t* p_dim_len = tir::as_const_int(dim_len);
-      ICHECK_NOTNULL(p_dim_len);
-      size *= *p_dim_len;
-    }
-    size *= DivRoundUp(prototype->dtype.bits() * prototype->dtype.lanes(), 8);
-    prototype->bytes = size;
-    return size;
-  }
-
- private:
-  // scale used for rough match
-  const int match_range_{16};
-  // free list of storage entry
-  std::multimap<int, StorageToken*> available_pool_;
-  // all the storage resources available
-  std::vector<StorageToken*> full_pool_;
-  /*! \brief Number of storages */
-  int n_storage_;
-};
-
-class StorageAllocator : public ExprVisitor {
- public:
-  explicit StorageAllocator(std::unordered_map<const ExprNode*, TokenWrapper> token_map)
-      : token_map_(std::move(token_map)) {}
-
   std::unordered_map<const CallNode*, StorageToken*> alloc_tensor2token;
+  /*! \brief The mapping from each Expr to the tensors that need to be killed after it. */
   std::unordered_map<const ExprNode*, std::vector<Var>> expr2killed_tensors;
-  std::unordered_map<const BindingBlockNode*, std::vector<const StorageToken*>> block2tokens;
+  /*! \brief The mapping from each binding block to the storage tokens that are create inside. */
+  std::unordered_map<const BindingBlockNode*, std::unordered_set<const StorageToken*>> block2tokens;
 
  private:
   void VisitBindingBlock_(const BindingBlockNode* block) final {
-    block_stack_.push_back(block);
-    ExprVisitor::VisitBindingBlock_(block);
-    ICHECK(!block_stack_.empty());
-    ICHECK(block_stack_.back() == block);
-    block_stack_.pop_back();
-
+    StorageAllocatorBaseVisitor::VisitBindingBlock_(block);
+    // The algorithm guarantees that each the reference counter of storage token will be decreased
+    // to 0 at the end of day. And we check the property here.
     for (const StorageToken* token : block2tokens[block]) {
       ICHECK_EQ(token->ref_counter, 0);
     }
   }
 
   void VisitBinding_(const VarBindingNode* binding) final {
-    const TokenWrapper& tokens = GetTokens(binding->value);
-    token_map_[binding->var.get()] = tokens;
-
+    StorageAllocatorBaseVisitor::VisitBinding_(binding);
+    // If the binding is a memory-reusable `builtin.alloc_tensor`, map its underlying token to this
+    // binding var, indicating that the token is currently occupied by this binding var.
     if (const CallNode* call_alloc_tensor = binding->value.as<CallNode>()) {
       auto it = alloc_tensor2token.find(call_alloc_tensor);
       if (it != alloc_tensor2token.end()) {
@@ -471,11 +531,11 @@ class StorageAllocator : public ExprVisitor {
       auto it = token_map_.find(call);
       ICHECK(it != token_map_.end());
       if (it->second.IsEmptyToken()) {
-        token_map_[call] = no_tokens_;
         return;
       }
 
       const auto* attrs = call->attrs.as<AllocTensorAttrs>();
+      ICHECK_NOTNULL(attrs);
       ICHECK(!it->second.is_tuple);
       ICHECK(it->second.token != nullptr);
       StorageToken* new_token = this->RequestOrAlloc(it->second.token, attrs->runtime_device_index);
@@ -483,51 +543,21 @@ class StorageAllocator : public ExprVisitor {
       ICHECK_GT(new_token->ref_counter, 0);
 
       alloc_tensor2token[call] = new_token;
-      token_map_[call] = TokenWrapper(/*is_tuple=*/false, /*field_tokens=*/{}, /*token=*/new_token);
+      ExprUsesTokens(
+          call, TokenContainer(/*is_tuple=*/false, /*field_containers=*/{}, /*token=*/new_token));
       ICHECK(!block_stack_.empty());
-      block2tokens[block_stack_.back()].push_back(new_token);
+      block2tokens[block_stack_.back()].insert(new_token);
       return;
     }
 
     for (const Expr& arg : call->args) {
-      const TokenWrapper& wrapper = GetTokens(arg);
-      const std::vector<StorageToken*> tokens = TokenWrapper::FlattenTokens(wrapper);
-      for (StorageToken* token : tokens) {
+      const TokenContainer& container = GetTokens(arg);
+      container.ApplyToTokens([this, call](StorageToken* token) {
         ICHECK_GT(token->ref_counter, 0);
         token->ref_counter -= 1;
         this->CheckForRelease(token, call);
-      }
+      });
     }
-  }
-
-  void VisitExpr_(const TupleNode* tuple) final {
-    std::vector<TokenWrapper> tokens;
-    for (const Expr& field : tuple->fields) {
-      const TokenWrapper& field_tokens = GetTokens(field);
-      tokens.push_back(field_tokens);
-    }
-    token_map_[tuple] = TokenWrapper(/*is_tuple=*/true,                   //
-                                     /*field_tokens=*/std::move(tokens),  //
-                                     /*token=*/nullptr);
-  }
-
-  void VisitExpr_(const TupleGetItemNode* tuple_item) final {
-    ICHECK_GE(tuple_item->index, 0);
-
-    const TokenWrapper& wrapper = GetTokens(tuple_item->tuple);
-    ICHECK(wrapper.is_tuple);
-    if (static_cast<int>(wrapper.field_tokens.size()) > tuple_item->index) {
-      token_map_[tuple_item] = wrapper.field_tokens[tuple_item->index];
-    } else {
-      ICHECK(wrapper.IsEmptyToken());
-      token_map_[tuple_item] = no_tokens_;
-    }
-  }
-
-  const TokenWrapper& GetTokens(const Expr& expr) {
-    auto it = token_map_.find(expr.get());
-    ICHECK(it != token_map_.end());
-    return it->second;
   }
 
   StorageToken* RequestOrAlloc(StorageToken* prototype, int64_t virtual_device_idx) {
@@ -554,17 +584,11 @@ class StorageAllocator : public ExprVisitor {
     }
   }
 
-  /*! \brief The binding block stack */
-  std::vector<const BindingBlockNode*> block_stack_;
-
-  std::unordered_map<const ExprNode*, TokenWrapper> token_map_;
-  /*! \brief An empty token map */
-  const TokenWrapper no_tokens_;
   /*! \brief Number of allocated storages */
   int n_storage_{0};
   /*! \brief The 1D memory allocator */
   TokenAllocator1D allocator_;
-
+  /*! \brief The mapping from each token to the tensor that is currently occupying it */
   std::unordered_map<const StorageToken*, Var> token2cur_tensor_;
 };
 
@@ -573,10 +597,13 @@ class StorageAllocationRewriter : public ExprMutator {
   explicit StorageAllocationRewriter(
       std::unordered_map<const CallNode*, StorageToken*> alloc_tensor2token,
       std::unordered_map<const ExprNode*, std::vector<Var>> expr2killed_tensors,
-      std::unordered_map<const BindingBlockNode*, std::vector<const StorageToken*>> block2tokens)
+      std::unordered_map<const BindingBlockNode*, std::unordered_set<const StorageToken*>>
+          block2tokens,
+      support::Arena* arena)
       : alloc_tensor2token_(std::move(alloc_tensor2token)),
         expr2killed_tensors_(std::move(expr2killed_tensors)),
-        block2tokens_(std::move(block2tokens)) {}
+        block2tokens_(std::move(block2tokens)),
+        arena_(arena) {}
 
  private:
   BindingBlock VisitBindingBlock_(const BindingBlockNode* block) final {
@@ -585,6 +612,7 @@ class StorageAllocationRewriter : public ExprMutator {
       this->VisitBinding(binding);
     }
 
+    // Insert `memory.kill_storage` for the storage tokens allocated inside this block.
     for (const StorageToken* token : block2tokens_[block]) {
       ICHECK(token->storage.defined());
       this->builder_->Emit(MakeMemKillStorage(token->storage));
@@ -595,26 +623,23 @@ class StorageAllocationRewriter : public ExprMutator {
   }
 
   void VisitBinding_(const VarBindingNode* binding) final {
-    Expr new_value = this->VisitExpr(binding->value);
+    Expr new_value = this->builder_->Normalize(this->VisitExpr(binding->value));
     Var new_var = this->VisitVarDef(binding->var);
     ICHECK(!this->builder_->CurrentBlockIsDataFlow());
 
-    auto it = expr2killed_tensors_.find(new_value.get());
-
-    // fast path: reemit binding if nothing changes
     if (new_var.same_as(binding->var) && new_value.same_as(binding->value)) {
-      ICHECK(it == expr2killed_tensors_.end());
       this->builder_->Emit(GetRef<VarBinding>(binding));
-      return;
+    } else {
+      Var temp = WithShapeAndType(new_var, new_value->shape_, new_value->checked_type_);
+      if (!temp.same_as(new_var)) {
+        new_var = temp;
+        this->var_remap_[binding->var->vid] = new_var;
+      }
+      this->builder_->Emit(VarBinding(new_var, new_value));
     }
 
-    Var temp = WithShapeAndType(new_var, new_value->shape_, new_value->checked_type_);
-    if (!temp.same_as(new_var)) {
-      new_var = temp;
-      this->var_remap_[binding->var->vid] = new_var;
-    }
-    this->builder_->Emit(VarBinding(new_var, new_value));
-
+    // Insert `memory.kill_tensor` for the tensors that need to be killed after this binding.
+    auto it = expr2killed_tensors_.find(binding->value.get());
     if (it != expr2killed_tensors_.end()) {
       for (const Var& var : it->second) {
         Var new_var = Downcast<Var>(this->VisitExpr(var));
@@ -628,11 +653,15 @@ class StorageAllocationRewriter : public ExprMutator {
     if (it != alloc_tensor2token_.end()) {
       StorageToken* token = it->second;
       const auto* attrs = call->attrs.as<AllocTensorAttrs>();
+      ICHECK_NOTNULL(attrs);
+      // - If the token is visited for the first time, create a storage variable using
+      // `memory.alloc_storage` for it.
+      // - And always create a `memory.alloc_tensor` for the old `builtin.alloc_tensor`.
       if (!token->storage.defined()) {
-        Constant size = relay::MakeConstantScalar(token->dtype, token->bytes);
+        ShapeExpr size({tir::make_const(DataType::Int(64), token->bytes)});
         Call alloc_storage = Downcast<Call>(
             MakeAllocStorage(std::move(size), attrs->runtime_device_index, "global", token->dtype));
-        token->storage = builder_->Emit(alloc_storage);
+        token->storage = builder_->Emit(alloc_storage, "storage");
       }
       return MakeMemAllocTensor(token->storage, call->args[0], /*offset=*/0, attrs->dtype);
     }
@@ -640,21 +669,33 @@ class StorageAllocationRewriter : public ExprMutator {
     return ExprMutator::VisitExpr_(call);
   }
 
+  /*!
+   * \brief The mapping from each memory-reusable `builtin.alloc_tensor` to its corresponding
+   * underlying storage token that it is using.
+   */
   std::unordered_map<const CallNode*, StorageToken*> alloc_tensor2token_;
+  /*! \brief The mapping from each Expr to the tensors that need to be killed after it. */
   std::unordered_map<const ExprNode*, std::vector<Var>> expr2killed_tensors_;
-  std::unordered_map<const BindingBlockNode*, std::vector<const StorageToken*>> block2tokens_;
+  /*! \brief The mapping from each binding block to the storage tokens that are create inside. */
+  std::unordered_map<const BindingBlockNode*, std::unordered_set<const StorageToken*>>
+      block2tokens_;
+  /*! \brief The allocator */
+  support::Arena* arena_;
 };
 
 Expr VMGraphMemoryPlan(Function func) {
-  // First scan;
-  std::unordered_map<const ExprNode*, TokenWrapper> token_map = StorageAllocatorInit().Init(func);
-  // Second scan;
-  StorageAllocator allocator(std::move(token_map));
+  support::Arena arena;
+  // Step 1. Initialize.
+  std::unordered_map<const ExprNode*, TokenContainer> token_map =
+      StorageAllocatorInit(&arena).Initialize(func);
+  // Step 2. Collect the memory allocation info.
+  StorageAllocator allocator(std::move(token_map), &arena);
   allocator(func);
-  // Rewrite
+  // Dump the memory allocation information by using `allocator.DumpMemoryAllocation()`.
+  // Step 3. Rewrite the function.
   StorageAllocationRewriter rewriter(std::move(allocator.alloc_tensor2token),
                                      std::move(allocator.expr2killed_tensors),
-                                     std::move(allocator.block2tokens));
+                                     std::move(allocator.block2tokens), &arena);
   func = Downcast<Function>(rewriter(func));
   return func;
 }

--- a/src/relax/backend/vm/vm_graph_memory_plan.cc
+++ b/src/relax/backend/vm/vm_graph_memory_plan.cc
@@ -1,0 +1,676 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file src/relax/backend/vm/vm_graph_memory_plan.cc
+ * \brief Perform memory planning for memory reuse.
+ */
+#include <tvm/relax/attrs/memory.h>
+#include <tvm/relax/backend.h>
+#include <tvm/relax/expr_functor.h>
+#include <tvm/relax/type.h>
+#include <tvm/tir/op.h>
+
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include "../../../relay/transforms/pattern_utils.h"
+#include "../../../support/arena.h"
+#include "../../op/make_op.h"
+
+namespace tvm {
+namespace relax {
+
+struct StorageToken {
+  /*! \brief Reference counter */
+  int ref_counter{0};
+  /*! \brief number of bytes */
+  int bytes{-1};
+  /*! \brief The shape of the tensor */
+  Array<PrimExpr> shape;
+  /*! \brief The corresponding tensor dtype. */
+  DataType dtype;
+  /*! \brief The storage id */
+  int storage_id{-1};
+  /*! \brief The corresponding allocated storage */
+  Var storage{nullptr};
+
+  // Todo:
+  // - take care of virtual device id
+  // - think about symbolic dynamic case
+  // - handle reshape
+
+  std::string ToString() const {
+    std::ostringstream os;
+    os << "{storage_id: " << storage_id << ", bytes: " << bytes << ", shape: " << shape
+       << ", dtype: " << dtype << "}";
+    return os.str();
+  }
+};
+
+// Todo: comments
+// - only one can be non-empty, depending on `is_tuple`
+struct TokenWrapper {
+  TokenWrapper() : is_tuple(false), field_tokens{}, token(nullptr) {}
+
+  TokenWrapper(bool is_tuple, std::vector<TokenWrapper> field_tokens, StorageToken* token) {
+    if (is_tuple) {
+      ICHECK(token == nullptr);
+    } else {
+      ICHECK_NOTNULL(token);
+      ICHECK(field_tokens.empty());
+    }
+
+    this->is_tuple = is_tuple;
+    this->field_tokens = std::move(field_tokens);
+    this->token = token;
+  }
+
+  bool IsEmptyToken() const { return is_tuple == true && field_tokens.empty() && token == nullptr; }
+
+  static std::vector<StorageToken*> FlattenTokens(const TokenWrapper& wrapper) {
+    std::vector<StorageToken*> tokens;
+    std::function<void(const TokenWrapper&)> f_visit = [&](const TokenWrapper& wrapper) {
+      if (wrapper.is_tuple) {
+        for (const TokenWrapper& field_wrapper : wrapper.field_tokens) {
+          f_visit(field_wrapper);
+        }
+      } else {
+        ICHECK_NOTNULL(wrapper.token);
+        tokens.push_back(wrapper.token);
+      }
+    };
+
+    f_visit(wrapper);
+    return tokens;
+  }
+
+  void RemoveToken(const StorageToken* token_to_remove) {
+    if (is_tuple) {
+      for (TokenWrapper& wrapper : field_tokens) {
+        wrapper.RemoveToken(token_to_remove);
+      }
+    } else if (token == token_to_remove) {
+      // Set to an empty token.
+      is_tuple = true;
+      ICHECK(field_tokens.empty());
+      token = nullptr;
+    }
+  }
+
+  bool is_tuple;
+  std::vector<TokenWrapper> field_tokens;
+  StorageToken* token;
+};
+
+// - Nested functions are not considered yet.
+// - Symbolic shape cases (ones with MatchShape) are completely not considered yet.
+// - RuntimeDepShape is not allowed at this moment.
+// - Reshape is not considered yet.
+class StorageAllocatorInit : public ExprVisitor {
+ public:
+  // Entry function
+  std::unordered_map<const ExprNode*, TokenWrapper> Init(const Function& func) {
+    const TokenWrapper& body_tokens = GetTokens(func->body);
+    // Mark the function body tokens as external referenced.
+    ClearTokens(TokenWrapper::FlattenTokens(body_tokens));
+
+    return this->token_map_;
+  }
+
+ private:
+  void VisitBindingBlock_(const BindingBlockNode* block) final {
+    block_stack_.push_back(block);
+    ExprVisitor::VisitBindingBlock_(block);
+    ICHECK(!block_stack_.empty());
+    ICHECK(block_stack_.back() == block);
+    block_stack_.pop_back();
+  }
+
+  void VisitBinding_(const VarBindingNode* binding) final {
+    const TokenWrapper& tokens = GetTokens(binding->value);
+    ExprUsesTokens(binding->var.get(), tokens);
+  }
+
+  void VisitExpr_(const VarNode* var) final { ICHECK(token_map_.count(var)); }
+
+  void VisitExpr_(const CallNode* call) final {
+    static const Op& alloc_tensor_op = Op::Get("relax.builtin.alloc_tensor");
+    if (call->op == alloc_tensor_op) {
+      this->CreateToken(call);
+      return;
+    }
+
+    ICHECK(!block_stack_.empty());
+    const BindingBlockNode* cur_binding_block = block_stack_.back();
+    for (const Expr& arg : call->args) {
+      const TokenWrapper& wrapper = GetTokensWithAllocSiteCheck(arg, cur_binding_block);
+      IncreaseRefCounter(wrapper);
+    }
+
+    // Todo: handle reshape separately
+  }
+
+  void VisitExpr_(const TupleNode* tuple) final {
+    std::vector<TokenWrapper> tokens;
+    for (const Expr& field : tuple->fields) {
+      const TokenWrapper& field_tokens = GetTokens(field);
+      tokens.push_back(field_tokens);
+    }
+    ExprUsesTokens(tuple, TokenWrapper(/*is_tuple=*/true,                   //
+                                       /*field_tokens=*/std::move(tokens),  //
+                                       /*token=*/nullptr));
+  }
+
+  void VisitExpr_(const TupleGetItemNode* tuple_item) final {
+    ICHECK_GE(tuple_item->index, 0);
+
+    const TokenWrapper& wrapper = GetTokens(tuple_item->tuple);
+    ICHECK(wrapper.is_tuple);
+    if (static_cast<int>(wrapper.field_tokens.size()) > tuple_item->index) {
+      ExprUsesTokens(tuple_item, wrapper.field_tokens[tuple_item->index]);
+    } else {
+      ICHECK(wrapper.IsEmptyToken());
+      token_map_[tuple_item] = no_tokens_;
+    }
+  }
+
+  void VisitExpr_(const IfNode* if_node) final {
+    const TokenWrapper& cond_tokens = GetTokens(if_node->cond);
+    const TokenWrapper& then_tokens = GetTokens(if_node->true_branch);
+    const TokenWrapper& else_tokens = GetTokens(if_node->false_branch);
+    ClearTokens(TokenWrapper::FlattenTokens(cond_tokens));
+    ClearTokens(TokenWrapper::FlattenTokens(then_tokens));
+    ClearTokens(TokenWrapper::FlattenTokens(else_tokens));
+  }
+
+  void VisitExpr_(const SeqExprNode* seq) final {
+    for (const BindingBlock& binding_block : seq->blocks) {
+      this->VisitBindingBlock(binding_block);
+    }
+    const TokenWrapper& body_tokens = GetTokens(seq->body);
+    ClearTokens(TokenWrapper::FlattenTokens(body_tokens));
+  }
+
+  TokenWrapper CreateToken(const CallNode* call) {
+    ICHECK(!token_map_.count(call));
+
+    // The impl guarantees that the input can only have DynTensorType
+    const auto* ttype = call->checked_type().as<DynTensorTypeNode>();
+    const auto* shape = call->shape().as<ShapeExprNode>();
+    const auto* attrs = call->attrs.as<AllocTensorAttrs>();
+    ICHECK_NOTNULL(ttype);
+    ICHECK_NOTNULL(attrs);
+
+    ICHECK(call->shape().same_as(call->args[0]));
+    ICHECK(!ttype->IsUnknownDtype());
+    ICHECK(ttype->dtype == attrs->dtype);
+
+    if (ttype->IsUnknownNdim() || shape == nullptr) {
+      token_map_[call] = no_tokens_;
+      return no_tokens_;
+    }
+    // Does not support planning for symbolic shape at this moment.
+    for (const PrimExpr& dim_len : shape->values) {
+      if (!tir::is_const_int(dim_len)) {
+        token_map_[call] = no_tokens_;
+        return no_tokens_;
+      }
+    }
+
+    auto* token = arena_->make<StorageToken>();
+    token->dtype = ttype->dtype;
+    token->shape = shape->values;
+    ICHECK(!block_stack_.empty());
+    token2block_[token] = block_stack_.back();
+
+    TokenWrapper token_wrapper(/*is_tuple=*/false, /*field_tokens=*/{}, token);
+    ExprUsesTokens(call, token_wrapper);
+    // token_map_[call] = token_wrapper;
+    return token_wrapper;
+  }
+
+  // The function is the place where recursive visit happens.
+  const TokenWrapper& GetTokens(const Expr& expr) {
+    this->VisitExpr(expr);
+    auto it = token_map_.find(expr.get());
+    if (it == token_map_.end()) {
+      LOG(INFO) << "Tokens not created for " << expr->GetTypeKey() << ":\n" << PrettyPrint(expr);
+      token_map_[expr.get()] = no_tokens_;
+      return no_tokens_;
+    }
+    return it->second;
+  }
+
+  void ExprUsesTokens(const ExprNode* expr, const TokenWrapper& wrapper) {
+    auto it = token_map_.insert({expr, wrapper});
+    ICHECK(it.second == true);
+
+    const std::vector<StorageToken*> tokens = TokenWrapper::FlattenTokens(wrapper);
+    for (const StorageToken* token : tokens) {
+      token2exprs_[token].push_back(expr);
+    }
+  }
+
+  const TokenWrapper& GetTokensWithAllocSiteCheck(const Expr& expr,
+                                                  const BindingBlockNode* cur_block) {
+    const TokenWrapper& wrapper = GetTokens(expr);
+    const std::vector<StorageToken*> tokens = TokenWrapper::FlattenTokens(wrapper);
+    for (StorageToken* token : tokens) {
+      auto it = token2block_.find(token);
+      ICHECK(it != token2block_.end());
+      if (it->second != cur_block) {
+        ClearTokens({token});
+      }
+    }
+    return token_map_[expr.get()];
+  }
+
+  void IncreaseRefCounter(const TokenWrapper& token_wrapper) {
+    const std::vector<StorageToken*>& tokens = TokenWrapper::FlattenTokens(token_wrapper);
+    for (StorageToken* token : tokens) {
+      token->ref_counter += 1;
+    }
+  }
+
+  void ClearTokens(const std::vector<StorageToken*>& tokens) {
+    for (const StorageToken* token : tokens) {
+      const std::vector<const ExprNode*>& exprs = token2exprs_[token];
+      for (const ExprNode* expr : exprs) {
+        token_map_[expr].RemoveToken(token);
+      }
+      token2exprs_.erase(token);
+      token2block_.erase(token);
+    }
+  }
+
+  /*! \brief The allocator */
+  support::Arena* arena_;
+  /*! \brief The binding block stack */
+  std::vector<const BindingBlockNode*> block_stack_;
+  /*! \brief The mapping from each Expr to its corresponding storage tokens */
+  std::unordered_map<const ExprNode*, TokenWrapper> token_map_;
+  /*! \brief The mapping from each token to the binding block where it is created */
+  std::unordered_map<const StorageToken*, const BindingBlockNode*> token2block_;
+  /*! \brief The mapping from each token to the Exprs that share this token */
+  std::unordered_map<const StorageToken*, std::vector<const ExprNode*>> token2exprs_;
+  /*! \brief An empty token map */
+  const TokenWrapper no_tokens_;
+};
+
+/**
+ * \brief Memory manager for flattened 1d memory (buffers)
+ * TODO: refine
+ */
+class TokenAllocator1D {
+ public:
+  /*!
+   * \brief Request a storage token for a given prototype.
+   * \param prototype. The prototype storage token.
+   * \return The result token.
+   */
+  StorageToken* Request(StorageToken* prototype) {
+    ICHECK_EQ(prototype->storage_id, -1);
+
+    // calculate the size;
+    int size = GetMemorySize(prototype);
+    // search memory block in [size / match_range_, size * match_range_)
+    auto begin = available_pool_.lower_bound(size / match_range_);
+    auto mid = available_pool_.lower_bound(size);
+    auto end = available_pool_.upper_bound(size * match_range_);
+    // search for memory blocks larger than requested
+    for (auto it = mid; it != end; ++it) {
+      StorageToken* available_token = it->second;
+      ICHECK_EQ(available_token->ref_counter, 0);
+      // Use exact matching strategy
+      ICHECK_LE(size, available_token->bytes);
+      available_token->ref_counter = prototype->ref_counter;
+      // find a exact match, erase from map and return
+      available_pool_.erase(it);
+      return available_token;
+    }
+    // then search for memory blocks smaller than requested space
+    for (auto it = mid; it != begin;) {
+      --it;
+      StorageToken* available_token = it->second;
+      ICHECK_EQ(available_token->ref_counter, 0);
+      // Use exact matching strategy
+      ICHECK_GE(size, available_token->bytes);
+      available_token->bytes = size;
+      available_token->ref_counter = prototype->ref_counter;
+      // erase from map and return
+      available_pool_.erase(it);
+      return available_token;
+    }
+    return nullptr;
+  }
+
+  /*!
+   * \brief Allocate a storage token by consuming prototype
+   * \param prototype The prototype token.
+   * \param size The size of memory being requested.
+   */
+  StorageToken* Alloc(StorageToken* prototype, int storage_id) {
+    ICHECK_EQ(prototype->storage_id, -1);
+    ICHECK(!prototype->storage.defined());
+    int size = GetMemorySize(prototype);
+    prototype->bytes = size;
+    prototype->storage_id = storage_id;
+    full_pool_.push_back(prototype);
+    return prototype;
+  }
+
+  /*!
+   * \brief Check if we can release token.
+   * \param token The token to be released.
+   */
+  void Release(StorageToken* token) {
+    ICHECK_GE(token->storage_id, 0);
+    ICHECK_GE(token->bytes, 0);
+    ICHECK_EQ(token->ref_counter, 0);
+    ICHECK(!token->storage.defined());
+    available_pool_.insert({token->bytes, token});
+  }
+
+ private:
+  /*!
+   * \brief ceil(size/word_size) to get number of words.
+   * \param size The original size.
+   * \param word_size The element size.
+   */
+  static int DivRoundUp(int size, int word_size) { return (size + word_size - 1) / word_size; }
+
+  /*!
+   * Todo: refine
+   * \brief Get the memory requirement.
+   * \param prototype The prototype token.
+   * \return The required memory size.
+   */
+  int GetMemorySize(StorageToken* prototype) {
+    ICHECK_EQ(prototype->storage_id, -1);
+    if (prototype->bytes != -1) {
+      return prototype->bytes;
+    }
+
+    int size = 1;
+    for (const PrimExpr& dim_len : prototype->shape) {
+      const int64_t* p_dim_len = tir::as_const_int(dim_len);
+      ICHECK_NOTNULL(p_dim_len);
+      size *= *p_dim_len;
+    }
+    size *= DivRoundUp(prototype->dtype.bits() * prototype->dtype.lanes(), 8);
+    prototype->bytes = size;
+    return size;
+  }
+
+ private:
+  // scale used for rough match
+  const int match_range_{16};
+  // free list of storage entry
+  std::multimap<int, StorageToken*> available_pool_;
+  // all the storage resources available
+  std::vector<StorageToken*> full_pool_;
+  /*! \brief Number of storages */
+  int n_storage_;
+};
+
+class StorageAllocator : public ExprVisitor {
+ public:
+  explicit StorageAllocator(std::unordered_map<const ExprNode*, TokenWrapper> token_map)
+      : token_map_(std::move(token_map)) {}
+
+  std::unordered_map<const CallNode*, StorageToken*> alloc_tensor2token;
+  std::unordered_map<const ExprNode*, std::vector<Var>> expr2killed_tensors;
+  std::unordered_map<const BindingBlockNode*, std::vector<const StorageToken*>> block2tokens;
+
+ private:
+  void VisitBindingBlock_(const BindingBlockNode* block) final {
+    block_stack_.push_back(block);
+    ExprVisitor::VisitBindingBlock_(block);
+    ICHECK(!block_stack_.empty());
+    ICHECK(block_stack_.back() == block);
+    block_stack_.pop_back();
+
+    for (const StorageToken* token : block2tokens[block]) {
+      ICHECK_EQ(token->ref_counter, 0);
+    }
+  }
+
+  void VisitBinding_(const VarBindingNode* binding) final {
+    const TokenWrapper& tokens = GetTokens(binding->value);
+    token_map_[binding->var.get()] = tokens;
+
+    if (const CallNode* call_alloc_tensor = binding->value.as<CallNode>()) {
+      auto it = alloc_tensor2token.find(call_alloc_tensor);
+      if (it != alloc_tensor2token.end()) {
+        auto it_insert = token2cur_tensor_.insert({it->second, binding->var});
+        ICHECK(it_insert.second == true);
+      }
+    }
+  }
+
+  void VisitExpr_(const CallNode* call) final {
+    static const Op& alloc_tensor_op = Op::Get("relax.builtin.alloc_tensor");
+    if (call->op == alloc_tensor_op) {
+      auto it = token_map_.find(call);
+      ICHECK(it != token_map_.end());
+      if (it->second.IsEmptyToken()) {
+        token_map_[call] = no_tokens_;
+        return;
+      }
+
+      const auto* attrs = call->attrs.as<AllocTensorAttrs>();
+      ICHECK(!it->second.is_tuple);
+      ICHECK(it->second.token != nullptr);
+      StorageToken* new_token = this->RequestOrAlloc(it->second.token, attrs->runtime_device_index);
+      // It doesn't make sense if a newly allocated tensor has 0 reference.
+      ICHECK_GT(new_token->ref_counter, 0);
+
+      alloc_tensor2token[call] = new_token;
+      token_map_[call] = TokenWrapper(/*is_tuple=*/false, /*field_tokens=*/{}, /*token=*/new_token);
+      ICHECK(!block_stack_.empty());
+      block2tokens[block_stack_.back()].push_back(new_token);
+      return;
+    }
+
+    for (const Expr& arg : call->args) {
+      const TokenWrapper& wrapper = GetTokens(arg);
+      const std::vector<StorageToken*> tokens = TokenWrapper::FlattenTokens(wrapper);
+      for (StorageToken* token : tokens) {
+        ICHECK_GT(token->ref_counter, 0);
+        token->ref_counter -= 1;
+        this->CheckForRelease(token, call);
+      }
+    }
+  }
+
+  void VisitExpr_(const TupleNode* tuple) final {
+    std::vector<TokenWrapper> tokens;
+    for (const Expr& field : tuple->fields) {
+      const TokenWrapper& field_tokens = GetTokens(field);
+      tokens.push_back(field_tokens);
+    }
+    token_map_[tuple] = TokenWrapper(/*is_tuple=*/true,                   //
+                                     /*field_tokens=*/std::move(tokens),  //
+                                     /*token=*/nullptr);
+  }
+
+  void VisitExpr_(const TupleGetItemNode* tuple_item) final {
+    ICHECK_GE(tuple_item->index, 0);
+
+    const TokenWrapper& wrapper = GetTokens(tuple_item->tuple);
+    ICHECK(wrapper.is_tuple);
+    if (static_cast<int>(wrapper.field_tokens.size()) > tuple_item->index) {
+      token_map_[tuple_item] = wrapper.field_tokens[tuple_item->index];
+    } else {
+      ICHECK(wrapper.IsEmptyToken());
+      token_map_[tuple_item] = no_tokens_;
+    }
+  }
+
+  const TokenWrapper& GetTokens(const Expr& expr) {
+    auto it = token_map_.find(expr.get());
+    ICHECK(it != token_map_.end());
+    return it->second;
+  }
+
+  StorageToken* RequestOrAlloc(StorageToken* prototype, int64_t virtual_device_idx) {
+    StorageToken* token = allocator_.Request(prototype);
+    if (token == nullptr) {
+      token = allocator_.Alloc(prototype, this->n_storage_++);
+    }
+    ICHECK_NOTNULL(token);
+    return token;
+  }
+
+  void CheckForRelease(StorageToken* token, const CallNode* release_site) {
+    ICHECK_GE(token->storage_id, 0);
+    ICHECK_GE(token->bytes, 0);
+    ICHECK_GE(token->ref_counter, 0);
+    ICHECK(!token->storage.defined());
+    if (token->ref_counter == 0) {
+      allocator_.Release(token);
+
+      auto it = token2cur_tensor_.find(token);
+      ICHECK(it != token2cur_tensor_.end());
+      expr2killed_tensors[release_site].push_back(it->second);
+      token2cur_tensor_.erase(it);
+    }
+  }
+
+  /*! \brief The binding block stack */
+  std::vector<const BindingBlockNode*> block_stack_;
+
+  std::unordered_map<const ExprNode*, TokenWrapper> token_map_;
+  /*! \brief An empty token map */
+  const TokenWrapper no_tokens_;
+  /*! \brief Number of allocated storages */
+  int n_storage_{0};
+  /*! \brief The 1D memory allocator */
+  TokenAllocator1D allocator_;
+
+  std::unordered_map<const StorageToken*, Var> token2cur_tensor_;
+};
+
+class StorageAllocationRewriter : public ExprMutator {
+ public:
+  explicit StorageAllocationRewriter(
+      std::unordered_map<const CallNode*, StorageToken*> alloc_tensor2token,
+      std::unordered_map<const ExprNode*, std::vector<Var>> expr2killed_tensors,
+      std::unordered_map<const BindingBlockNode*, std::vector<const StorageToken*>> block2tokens)
+      : alloc_tensor2token_(std::move(alloc_tensor2token)),
+        expr2killed_tensors_(std::move(expr2killed_tensors)),
+        block2tokens_(std::move(block2tokens)) {}
+
+ private:
+  BindingBlock VisitBindingBlock_(const BindingBlockNode* block) final {
+    builder_->BeginBindingBlock();
+    for (Binding binding : block->bindings) {
+      this->VisitBinding(binding);
+    }
+
+    for (const StorageToken* token : block2tokens_[block]) {
+      ICHECK(token->storage.defined());
+      this->builder_->Emit(MakeMemKillStorage(token->storage));
+    }
+
+    BindingBlock new_block = builder_->EndBlock();
+    return new_block;
+  }
+
+  void VisitBinding_(const VarBindingNode* binding) final {
+    Expr new_value = this->VisitExpr(binding->value);
+    Var new_var = this->VisitVarDef(binding->var);
+    ICHECK(!this->builder_->CurrentBlockIsDataFlow());
+
+    auto it = expr2killed_tensors_.find(new_value.get());
+
+    // fast path: reemit binding if nothing changes
+    if (new_var.same_as(binding->var) && new_value.same_as(binding->value)) {
+      ICHECK(it == expr2killed_tensors_.end());
+      this->builder_->Emit(GetRef<VarBinding>(binding));
+      return;
+    }
+
+    Var temp = WithShapeAndType(new_var, new_value->shape_, new_value->checked_type_);
+    if (!temp.same_as(new_var)) {
+      new_var = temp;
+      this->var_remap_[binding->var->vid] = new_var;
+    }
+    this->builder_->Emit(VarBinding(new_var, new_value));
+
+    if (it != expr2killed_tensors_.end()) {
+      for (const Var& var : it->second) {
+        Var new_var = Downcast<Var>(this->VisitExpr(var));
+        this->builder_->Emit(MakeMemKillTensor(new_var));
+      }
+    }
+  }
+
+  Expr VisitExpr_(const CallNode* call) final {
+    auto it = alloc_tensor2token_.find(call);
+    if (it != alloc_tensor2token_.end()) {
+      StorageToken* token = it->second;
+      const auto* attrs = call->attrs.as<AllocTensorAttrs>();
+      if (!token->storage.defined()) {
+        Constant size = relay::MakeConstantScalar(token->dtype, token->bytes);
+        Call alloc_storage = Downcast<Call>(
+            MakeAllocStorage(std::move(size), attrs->runtime_device_index, "global", token->dtype));
+        token->storage = builder_->Emit(alloc_storage);
+      }
+      return MakeMemAllocTensor(token->storage, call->args[0], /*offset=*/0, attrs->dtype);
+    }
+
+    return ExprMutator::VisitExpr_(call);
+  }
+
+  std::unordered_map<const CallNode*, StorageToken*> alloc_tensor2token_;
+  std::unordered_map<const ExprNode*, std::vector<Var>> expr2killed_tensors_;
+  std::unordered_map<const BindingBlockNode*, std::vector<const StorageToken*>> block2tokens_;
+};
+
+Expr VMGraphMemoryPlan(Function func) {
+  // First scan;
+  std::unordered_map<const ExprNode*, TokenWrapper> token_map = StorageAllocatorInit().Init(func);
+  // Second scan;
+  StorageAllocator allocator(std::move(token_map));
+  allocator(func);
+  // Rewrite
+  StorageAllocationRewriter rewriter(std::move(allocator.alloc_tensor2token),
+                                     std::move(allocator.expr2killed_tensors),
+                                     std::move(allocator.block2tokens));
+  func = Downcast<Function>(rewriter(func));
+  return func;
+}
+
+namespace transform {
+
+Pass VMGraphMemoryPlan() {
+  runtime::TypedPackedFunc<Function(Function, IRModule, PassContext)> pass_func =
+      [=](Function f, IRModule m, PassContext pc) {
+        return Downcast<Function>(VMGraphMemoryPlan(std::move(f)));
+      };
+  return CreateFunctionPass(pass_func, 0, "VMGraphMemoryPlan", {});
+}
+
+TVM_REGISTER_GLOBAL("relax.transform.VMGraphMemoryPlan").set_body_typed(VMGraphMemoryPlan);
+
+}  // namespace transform
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -503,8 +503,8 @@ void ExprMutator::VisitBinding_(const VarBindingNode* binding) {
 }
 
 void ExprMutator::VisitBinding_(const MatchShapeNode* binding) {
-  Expr new_value = this->VisitExpr(binding->value);
-  Expr new_pattern = this->VisitExpr(ShapeExpr(binding->pattern));
+  Expr new_value = this->builder_->Normalize(this->VisitExpr(binding->value));
+  Expr new_pattern = this->builder_->Normalize(this->VisitExpr(ShapeExpr(binding->pattern)));
 
   Var new_var;
   if (binding->var.defined()) {

--- a/src/relax/op/make_op.h
+++ b/src/relax/op/make_op.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *
+ * \file tvm/relax/op/make_op.h
+ * \brief Header of internal operator functions
+ * to assist in creating ops in C++
+ */
+
+#ifndef TVM_RELAX_OP_MAKE_OP_H_
+#define TVM_RELAX_OP_MAKE_OP_H_
+
+#include <tvm/relax/expr.h>
+
+namespace tvm {
+namespace relax {
+
+Expr MakeAllocStorage(Expr size, int64_t virtual_device_index, std::string storage_scope,
+                      DataType dtype);
+
+Expr MakeMemAllocTensor(Expr storage, Expr shape, int offset, DataType dtype);
+
+Expr MakeMemKillStorage(Expr storage);
+
+Expr MakeMemKillTensor(Expr tensor);
+
+}  // namespace relax
+}  // namespace tvm
+
+#endif  // TVM_RELAX_OP_MAKE_OP_H_

--- a/src/relax/op/make_op.h
+++ b/src/relax/op/make_op.h
@@ -41,6 +41,10 @@ Expr MakeMemKillStorage(Expr storage);
 
 Expr MakeMemKillTensor(Expr tensor);
 
+Expr MakeVMAllocStorage(Expr size, DataType dtype, int64_t runtime_device_index);
+
+Expr MakeVMAllocTensor(Expr storage, Expr shape, int offset, DataType dtype);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_vm_graph_memory_plan.py
+++ b/tests/python/relax/test_vm_graph_memory_plan.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import tvm.testing
+from tvm import relax, topi
+from tvm.ir import IRModule
+
+import numpy as np
+
+
+def apply_initializing_passes(mod: IRModule):
+    mod = relax.transform.ToNonDataflow()(mod)
+    mod = relax.transform.CallTIRRewrite()(mod)
+    return mod
+
+
+def test_minimum_example():
+    x = relax.Var("x", (2, 4), relax.DynTensorType(2, "float32"))
+    const_one = relax.const(1, "float32")
+
+    bb = relax.BlockBuilder()
+    with bb.function("main", [x]):
+        v0 = bb.emit_te(topi.exp, x)
+        v1 = bb.emit_te(topi.reshape, v0, (8,))
+        v2 = bb.emit_te(topi.nn.relu, v1)
+        v3 = bb.emit_te(topi.add, v2, const_one)
+        v4 = bb.emit_te(topi.nn.pad, v3, pad_before=[1], pad_after=[1], pad_value=1)
+        v5 = bb.emit_te(topi.log, v4)
+        bb.emit_func_output(v5)
+
+    mod = bb.get()
+    mod = apply_initializing_passes(mod)
+    mod = relax.transform.VMGraphMemoryPlan()(mod)
+    print("After plan:")
+    print(mod["main"].script())
+
+    dev = tvm.cpu(0)
+    exec = relax.vm.build(bb.get(), "llvm")
+    vm = relax.VirtualMachine(exec, dev)
+
+    x_np = np.random.rand(2, 4).astype("float32")
+    y_np = np.exp(x_np)
+    y_np = np.reshape(y_np, (8,))
+    y_np = np.maximum(y_np, 0.0)
+    y_np = np.add(y_np, 1)
+    pad_value = np.ones((1,)).astype("float32")
+    y_np = np.concatenate([pad_value, y_np, pad_value], axis=0)
+    y_np = np.log(y_np)
+
+    x_relax = tvm.nd.array(x_np, dev)
+    y_relax = vm["main"](x_relax)
+
+    tvm.testing.assert_allclose(y_relax.numpy(), y_np, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    test_minimum_example()


### PR DESCRIPTION
This PR introduces memory planning on block-level for Relax, which enables much memory reuse for intermediate results and thereby significantly reduces the total allocated memory.

This PR works for UNet and ResNet-18/50. To use it, you also need to cherry-pick this commit https://github.com/mlc-ai/relax/commit/451fa4d5ec555920b5dde41ed7deaf7a5023f948 for those memory primitives.

---

cc @jinhongyii @spectrometerHBH @junrushao @tqchen @Hzfengsy @YuchenJin @LeshengJin
