### PR TITLE
[FIX][Pass] concurrent modification in RemoveUnusedVars

### DIFF
--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -222,7 +222,7 @@ class RemoveUnusedVars : public ExprMutator {
               users.erase(unused[i]);
               // remove def site.
               for (const auto& key: users_keys) {  // remove use site.
-                ICHECK(users.count(key)) << "remove unused algorithm internal error.";
+                ICHECK(users.count(key)) << "the key " << key << " is expected to be in the mapping users.";
                 Array<Var> cur_users = users[key];
                 auto it = std::find(cur_users.begin(), cur_users.end(), unused[i]);
                 if (it != cur_users.end()) {

--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -218,13 +218,15 @@ class RemoveUnusedVars : public ExprMutator {
             for (size_t i = prev_size; i < unused.size(); ++i) {
               users.erase(unused[i]);
               // remove def site.
+              auto updated = Map<Var, Array<Var>>();
               for (auto kv : users) {  // remove use site.
                 auto it = std::find(kv.second.begin(), kv.second.end(), unused[i]);
                 if (it != kv.second.end()) {
                   kv.second.erase(it);
-                  users.Set(kv.first, std::move(kv.second));
+                  updated.Set(kv.first, std::move(kv.second));
                 }
               }
+              users = std::move(Merge(users, updated));
             }
           } while (prev_size != unused.size());  // changed? => continue.
 

--- a/src/relax/ir/binding_rewrite.cc
+++ b/src/relax/ir/binding_rewrite.cc
@@ -222,6 +222,7 @@ class RemoveUnusedVars : public ExprMutator {
               users.erase(unused[i]);
               // remove def site.
               for (const auto& key: users_keys) {  // remove use site.
+                ICHECK(users.count(key)) << "remove unused algorithm internal error.";
                 Array<Var> cur_users = users[key];
                 auto it = std::find(cur_users.begin(), cur_users.end(), unused[i]);
                 if (it != cur_users.end()) {


### PR DESCRIPTION
When running RemoveUnusedVars (i.e. remove_all_unused), in some cases the map users will raise Concurrent modification error. This commit fixed it by changing the logic to "iterate the map first and update it later".