### PR TITLE
[Relax][Op] More new relax operators!

### DIFF
--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -625,3 +625,41 @@ def adaptive_avg_pool2d(
                 )
         output_size = temp_size
     return _ffi_api.adaptive_avg_pool2d(data, output_size, layout)
+
+
+def cross_entropy(predictions: Expr, targets: Expr) -> Expr:
+    """CrossEntropy without logits.
+
+    Parameters
+    ----------
+    predictions : relax.Expr
+      The predictions.
+
+    targets : relax.Expr
+      The targets.
+
+    Returns
+    -------
+    result : relax.Expr
+      The computed result.
+    """
+    return _ffi_api.cross_entropy(predictions, targets)
+
+
+def softmax_cross_entropy(predictions: Expr, targets: Expr) -> Expr:
+    """Computes the softmax cross entropy between predictions and targets.
+
+    Parameters
+    ----------
+    predictions : relax.Expr
+      The predictions.
+
+    targets : relax.Expr
+      The targets.
+
+    Returns
+    -------
+    result : relax.Expr
+      The computed result.
+    """
+    return _ffi_api.softmax_cross_entropy(predictions, targets)

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -222,6 +222,40 @@ def log(data: Expr) -> Expr:
     return _ffi_api.log(data)
 
 
+def sigmoid(data: Expr) -> Expr:
+    """Compute elementwise sigmoid of data.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input data
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    return _ffi_api.sigmoid(data)
+
+
+def less(lhs: Expr, rhs: Expr) -> Expr:
+    """Broadcasted elementwise test for (lhs < rhs).
+
+    Parameters
+    ----------
+    lhs : relax.Expr
+        The left hand side input data
+    rhs : relax.Expr
+        The right hand side input data
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    return _ffi_api.less(lhs, rhs)
+
+
 def unique(
     data: Expr,
     sorted: bool = True,

--- a/python/tvm/relax/op/transform.py
+++ b/python/tvm/relax/op/transform.py
@@ -648,3 +648,44 @@ def collapse_sum_to(
     """
     shape = _convert_shape_to_expr(shape)
     return _ffi_api.collapse_sum_to(data, shape)
+
+
+def where(condition: Expr, x: Expr, y: Expr) -> Expr:
+    """Selecting elements from either x or y depending on the value of the
+    condition.
+
+    .. note::
+        Shapes of condition, x, and y must be broadcastable to a common shape.
+        Semantics follow numpy where function
+        https://numpy.org/doc/stable/reference/generated/numpy.where.html
+
+    Parameters
+    ----------
+    condition : relax.Expr
+        Where True, yield x, otherwise yield y
+
+    x : relax.Expr
+        The first array or scalar to be selected.
+
+    y : relax.Expr
+        The second array or scalar to be selected.
+
+    Returns
+    -------
+    result : relax.Expr
+        The selected array. The output shape is the broadcasted shape from
+        condition, x, and y.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        x = [[1, 2], [3, 4]]
+        y = [[5, 6], [7, 8]]
+        condition = [[0, 1], [-1, 0]]
+        relax.where(conditon, x, y) = [[5, 2], [3, 8]]
+
+        condition = [[1], [0]]
+        relax.where(conditon, x, y) = [[1, 2], [7, 8]]
+    """
+    return _ffi_api.where(condition, x, y)

--- a/python/tvm/relax/transform/op_legalizer.py
+++ b/python/tvm/relax/transform/op_legalizer.py
@@ -87,6 +87,14 @@ def _sqrt(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
     return bb.call_te(topi.sqrt, args[0])
 
 
+def _sigmoid(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
+    return bb.call_te(topi.sigmoid, args[0])
+
+
+def _less(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
+    return bb.call_te(topi.less, args[0], args[1])
+
+
 def _nn_relu(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
     return bb.call_te(topi.nn.relu, args[0])
 
@@ -225,6 +233,10 @@ def _strided_slice(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shap
     )
 
 
+def _where(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
+    return bb.call_te(topi.where, args[0], args[1], args[2])
+
+
 def _nn_max_pool2d(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
     return bb.call_te(
         topi.nn.pool2d,
@@ -340,6 +352,20 @@ def _nn_adaptive_max_pool2d(bb: BlockBuilder, args: List[Expr], attrs: Attrs, ou
     )
 
 
+def _cross_entropy(x, y):
+    return -topi.sum(topi.log(x) * y)
+
+
+def _nn_cross_entropy(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
+    return bb.call_te(cross_entropy, args[0], args[1])
+
+
+def _nn_softmax_cross_entropy(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
+    def softmax_cross_entropy(x, y):
+        return cross_entropy(topi.nn.softmax(x), y)
+    return bb.call_te(softmax_cross_entropy, args[0], args[1])
+
+
 def _sum(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
     return bb.call_te(topi.sum, args[0], attrs.axis, attrs.keepdims)
 
@@ -379,6 +405,8 @@ op_legalization_map = {
     ir.Op.get("relax.sin"): _sin,
     ir.Op.get("relax.cos"): _cos,
     ir.Op.get("relax.sqrt"): _sqrt,
+    ir.Op.get("relax.sigmoid"): _sigmoid,
+    ir.Op.get("relax.less"): _less,
     ir.Op.get("relax.nn.relu"): _nn_relu,
     ir.Op.get("relax.nn.gelu"): _nn_gelu,
     ir.Op.get("relax.nn.silu"): _nn_silu,
@@ -400,6 +428,7 @@ op_legalization_map = {
     ir.Op.get("relax.collapse_sum_to"): _collapse_sum_to,
     ir.Op.get("relax.split"): _split,
     ir.Op.get("relax.strided_slice"): _strided_slice,
+    ir.Op.get("relax.where"): _where,
     ir.Op.get("relax.broadcast_to"): _broadcast_to,
     ir.Op.get("relax.nn.max_pool2d"): _nn_max_pool2d,
     ir.Op.get("relax.nn.batch_norm"): _nn_batch_norm,
@@ -408,6 +437,8 @@ op_legalization_map = {
     ir.Op.get("relax.nn.softmax"): _nn_softmax,
     ir.Op.get("relax.nn.flatten"): _nn_flatten,
     ir.Op.get("relax.nn.adaptive_avg_pool2d"): _nn_adaptive_max_pool2d,
+    ir.Op.get("relax.nn.cross_entropy"): _nn_cross_entropy,
+    ir.Op.get("relax.nn.softmax_cross_entropy"): _nn_softmax_cross_entropy,
     ir.Op.get("relax.sum"): _sum,
     ir.Op.get("relax.mean"): _mean,
     ir.Op.get("relax.image.resize2d"): _image_resize2d,

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -85,6 +85,11 @@ from tvm.relax.op import (
     unique,
     memory,
     variance,
+    where,
+    less,
+    sigmoid,
+    cross_entropy,
+    softmax_cross_entropy,
 )
 from tvm.relax.ty import ObjectType, ShapeType, DynTensorType
 from tvm.relax.utils import convert_to_expr
@@ -532,4 +537,9 @@ __all__ = [
     "tensor",
     "zeros",
     "zeros_like",
+    "where",
+    "less",
+    "sigmoid",
+    "cross_entropy",
+    "softmax_cross_entropy",
 ]

--- a/src/relax/op/nn/nn.h
+++ b/src/relax/op/nn/nn.h
@@ -138,6 +138,11 @@ Expr InferShapeMatmul(const Call& call, DiagnosticContext diag_ctx);
 
 Type InferTypeMatmul(const Call& call, DiagnosticContext diag_ctx);
 
+/* relax.nn.cross_entropy */
+Expr InferShapeCrossEntropy(const Call& call, DiagnosticContext diag_ctx);
+
+Type InferTypeCrossEntropy(const Call& call, DiagnosticContext diag_ctx);
+
 }  // namespace relax
 }  // namespace tvm
 #endif  // TVM_RELAX_OP_NN_NN_H_

--- a/src/relax/op/tensor/binary.h
+++ b/src/relax/op/tensor/binary.h
@@ -39,6 +39,8 @@ namespace relax {
 Type InferTypeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx);
 Expr InferShapeBinaryBroadcast(const Call& call, DiagnosticContext diag_ctx);
 
+Type InferTypeLess(const Call& call, DiagnosticContext diag_ctx);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/relax/op/tensor/transform.h
+++ b/src/relax/op/tensor/transform.h
@@ -108,6 +108,11 @@ Expr InferShapeCollapseSumTo(const Call& call, DiagnosticContext diag_ctx);
 
 Type InferTypeCollapseSumTo(const Call& call, DiagnosticContext diag_ctx);
 
+/* relax.where */
+Expr InferShapeWhere(const Call& call, DiagnosticContext diag_ctx);
+
+Type InferTypeWhere(const Call& call, DiagnosticContext diag_ctx);
+
 /* relax.split */
 Expr InferShapeSplit(const Call& call, DiagnosticContext diag_ctx);
 

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -73,6 +73,9 @@ RELAX_REGISTER_UNARY_OP("negative");
 /* relax.tanh */
 RELAX_REGISTER_UNARY_OP("tanh");
 
+/* relax.sigmoid */
+RELAX_REGISTER_UNARY_OP("sigmoid");
+
 TVM_REGISTER_NODE_TYPE(UniqueAttrs);
 
 RELAX_REGISTER_OP("relax.unique")

--- a/tests/python/relax/test_relax_tensor_ops.py
+++ b/tests/python/relax/test_relax_tensor_ops.py
@@ -653,5 +653,78 @@ def test_adaptive_avg_pool2d():
     tvm.ir.assert_structural_equal(bb.get()["main"], expected)
 
 
+def test_sigmoid():
+    @R.function
+    def expected(x: R.Tensor((2, 3), "float32")) -> R.Tensor(None, "float32", ndim=2):
+        gv: R.Tensor((2, 3), "float32") = R.sigmoid(x)
+        return gv
+
+    x = relax.Var("x", [2, 3], relax.DynTensorType(ndim=2, dtype="float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [x]):
+        gv = bb.emit(relax.op.sigmoid(x))
+        bb.emit_func_output(gv)
+
+    expected = expected.with_attr("global_symbol", "main")
+    tvm.ir.assert_structural_equal(bb.get()["main"], expected)
+
+
+def test_less():
+    @R.function
+    def expected(
+        x: R.Tensor((2, 3), "float32"), y: R.Tensor((2, 1), "float32")
+    ) -> R.Tensor(None, "bool", ndim=2):
+        gv: R.Tensor((2, 3), "bool") = R.less(x, y)
+        return gv
+
+    x = relax.Var("x", [2, 3], relax.DynTensorType(ndim=2, dtype="float32"))
+    y = relax.Var("y", [2, 1], relax.DynTensorType(ndim=2, dtype="float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [x, y]):
+        gv = bb.emit(relax.op.less(x, y))
+        bb.emit_func_output(gv)
+
+    expected = expected.with_attr("global_symbol", "main")
+    tvm.ir.assert_structural_equal(bb.get()["main"], expected)
+
+
+def test_cross_entropy():
+    @R.function
+    def expected(
+        predictions: R.Tensor((2, 3), "float32"), targets: R.Tensor((2, 3), "float32")
+    ) -> R.Tensor(None, "float32", ndim=0):
+        gv: R.Tensor((), "float32") = R.cross_entropy(predictions, targets)
+        return gv
+
+    predictions = relax.Var("predictions", [2, 3], relax.DynTensorType(ndim=2, dtype="float32"))
+    targets = relax.Var("targets", [2, 3], relax.DynTensorType(ndim=2, dtype="float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [predictions, targets]):
+        gv = bb.emit(relax.op.nn.cross_entropy(predictions, targets))
+        bb.emit_func_output(gv)
+
+    expected = expected.with_attr("global_symbol", "main")
+    tvm.ir.assert_structural_equal(bb.get()["main"], expected)
+
+
+def test_softmax_cross_entropy():
+    @R.function
+    def expected(
+        predictions: R.Tensor((2, 3), "float32"), targets: R.Tensor((2, 3), "float32")
+    ) -> R.Tensor(None, "float32", ndim=0):
+        gv: R.Tensor((), "float32") = R.softmax_cross_entropy(predictions, targets)
+        return gv
+
+    predictions = relax.Var("predictions", [2, 3], relax.DynTensorType(ndim=2, dtype="float32"))
+    targets = relax.Var("targets", [2, 3], relax.DynTensorType(ndim=2, dtype="float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("main", [predictions, targets]):
+        gv = bb.emit(relax.op.nn.softmax_cross_entropy(predictions, targets))
+        bb.emit_func_output(gv)
+
+    expected = expected.with_attr("global_symbol", "main")
+    tvm.ir.assert_structural_equal(bb.get()["main"], expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR adds:
- `relax.where` (transform)
- `relax.less` (tensor, binary)
- `relax.sigmoid` (tensor, unary)
- `relax.nn.cross_entropy` (nn)
- `relax.nn.softmax_cross_entropy` (nn)

Tests about their creation and legalization are all passed.

PS: `relax.where` is a ternary broadcast op. Given that currently there is no good solution to do runtime shape inference, I leave this case and return `RuntimeDepShape` for now. Further discussions and solutions to this issue is needed.