### PR TITLE
[Relax][Op] register gradients for some operators

### DIFF
--- a/python/tvm/relax/op/gradient.py
+++ b/python/tvm/relax/op/gradient.py
@@ -43,7 +43,6 @@ from tvm.relax.expr import Call, Var
 @register_gradient("relax.add")
 def add_grad(orig: Call, grad: Var):
     """Returns [grad, grad]."""
-    print(type(orig), type(grad))
     return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(grad, orig.args[1].shape)]
 
 
@@ -137,8 +136,7 @@ def sum_grad(orig: Call, grad: Var):
     axis = orig.attrs["axis"]
     keepdims = orig.attrs["keepdims"]
     if not keepdims and axis:
-        for ax in axis:
-            grad = expand_dims(grad, int(ax))
+        grad = expand_dims(grad, [int(ax) for ax in axis])
     return [broadcast_to(grad, orig.args[0].shape)]
 
 

--- a/python/tvm/relax/op/gradient.py
+++ b/python/tvm/relax/op/gradient.py
@@ -14,132 +14,131 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 """Gradient definitions for Relax operators"""
-from __future__ import annotations
-
 from tvm.relax import const
 from tvm.relay.op import register_gradient
 import tvm.relax.op.nn as nn
 from tvm.relax.op import (
-	sum,
-	less,
-	where,
-	collapse_sum_to,
-	log,
-	multiply,
-	divide,
-	negative,
-	subtract,
-	transpose,
-	sigmoid,
-	tanh,
-	ones,
-	zeros
+    sum,
+    less,
+    where,
+    collapse_sum_to,
+    log,
+    multiply,
+    divide,
+    negative,
+    subtract,
+    transpose,
+    sigmoid,
+    tanh,
+    ones,
+    zeros
 )
+from tvm.relax.expr import Call, Var
 
 
 @register_gradient("relax.add")
-def add_grad(orig, grad):
-	"""Returns [grad, grad]."""
-	return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(grad, orig.args[1].shape)]
+def add_grad(orig: Call, grad: Var):
+    """Returns [grad, grad]."""
+    print(type(orig), type(grad))
+    return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(grad, orig.args[1].shape)]
 
 
 @register_gradient("relax.subtract")
-def subtract_grad(orig, grad):
-	"""Returns [grad, -grad]."""
-	return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(negative(grad), orig.args[1].shape)]
+def subtract_grad(orig: Call, grad: Var):
+    """Returns [grad, -grad]."""
+    return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(negative(grad), orig.args[1].shape)]
 
 
 @register_gradient("relax.multiply")
-def multiply_grad(orig, grad):
-	"""Returns [grad * y, grad * x]."""
-	x, y = orig.args
-	return [collapse_sum_to(multiply(grad, y), x.shape), collapse_sum_to(multiply(grad, x), y.shape)]
+def multiply_grad(orig: Call, grad: Var):
+    """Returns [grad * y, grad * x]."""
+    x, y = orig.args
+    return [collapse_sum_to(multiply(grad, y), x.shape), collapse_sum_to(multiply(grad, x), y.shape)]
 
 
 @register_gradient("relax.transpose")
-def transpose_grad(orig, grad):
-	"""Returns grad transposed over the complement of original transpose axes"""
-	"""TODO: Do not support more than one dimensions"""
-	return [transpose(grad)]
+def transpose_grad(orig: Call, grad: Var):
+    """Returns grad transposed over the complement of original transpose axes"""
+    """TODO: Do not support more than one dimensions"""
+    return [transpose(grad)]
 
 
 @register_gradient("relax.nn.relu")
-def relu_grad(orig, grad):
-	"""Returns grad * (select(x < 0, 0, 1))."""
-	x = orig.args[0]
-	x_zeros = zeros(x.shape)
-	x_ones = ones(x.shape)
-	return [where(less(x, x_zeros), x_zeros, multiply(x_ones, grad))]
+def relu_grad(orig: Call, grad: Var):
+    """Returns grad * (select(x < 0, 0, 1))."""
+    x = orig.args[0]
+    x_zeros = zeros(x.shape)
+    x_ones = ones(x.shape)
+    return [where(less(x, x_zeros), x_zeros, multiply(x_ones, grad))]
 
 
 @register_gradient("relax.nn.matmul")
-def matmul_grad(orig, grad):
-	"""Returns [grad' @ tensor_b, tensor_a @ grad']."""
-	tensor_a, tensor_b = orig.args
-	return [
-		collapse_sum_to(nn.matmul(grad, transpose(tensor_b)), tensor_a.shape),
-		collapse_sum_to(nn.matmul(transpose(tensor_a), grad), tensor_b.shape),
-	]
+def matmul_grad(orig: Call, grad: Var):
+    """Returns [grad' @ tensor_b, tensor_a @ grad']."""
+    tensor_a, tensor_b = orig.args
+    return [
+        collapse_sum_to(nn.matmul(grad, transpose(tensor_b)), tensor_a.shape),
+        collapse_sum_to(nn.matmul(transpose(tensor_a), grad), tensor_b.shape),
+    ]
 
 
 @register_gradient("relax.sum")
-def sum_grad(orig, grad):
-	"""Returns [grad * ones(x.shape)]."""
-	return [multiply(grad, ones(orig.args[0].shape))]
+def sum_grad(orig: Call, grad: Var):
+    """Returns [grad * ones(x.shape)]."""
+    return [multiply(grad, ones(orig.args[0].shape))]
 
 
 @register_gradient("relax.nn.softmax")
-def softmax_grad(orig, grad):
-	"""Gradient of softmax."""
-	return [multiply(subtract(grad, sum(multiply(grad, orig), orig.attrs.axis, True)), orig)]
+def softmax_grad(orig: Call, grad: Var):
+    """Gradient of softmax."""
+    return [multiply(subtract(grad, sum(multiply(grad, orig), orig.attrs.axis, True)), orig)]
 
 
 @register_gradient("relax.nn.cross_entropy")
-def cross_entropy_grad(orig, grad):
-	"""Gradient of cross_entropy.
+def cross_entropy_grad(orig: Call, grad: Var):
+    """Gradient of cross_entropy.
 
-		z = relax.nn.cross_entropy(x, y)
+        z = relax.nn.cross_entropy(x, y)
 
-	Returns [- grad * y / x, - grad * log(x)].
-	"""
-	x, y = orig.args
-	return [negative(multiply(grad, divide(y, x))), negative(multiply(grad, log(x)))]
+    Returns [- grad * y / x, - grad * log(x)].
+    """
+    x, y = orig.args
+    return [negative(multiply(grad, divide(y, x))), negative(multiply(grad, log(x)))]
 
 
 @register_gradient("relax.nn.softmax_cross_entropy")
-def softmax_cross_entropy_grad(orig, grad):
-	"""Gradient of softmax_cross_entropy.
+def softmax_cross_entropy_grad(orig: Call, grad: Var):
+    """Gradient of softmax_cross_entropy.
 
-		z = relax.nn.softmax_cross_entropy(x, y)
+        z = relax.nn.softmax_cross_entropy(x, y)
 
-	This gradient is based on the assumption that sum(y)=1.
-	Returns [grad * (y - softmax(x)), grad * (-log(-softmax(x)))].
-	"""
-	y_hat = nn.softmax(orig.args[0])
-	return [multiply(grad, subtract(y_hat, orig.args[1])), multiply(grad, negative(log(y_hat)))]
+    This gradient is based on the assumption that sum(y)=1.
+    Returns [grad * (y - softmax(x)), grad * (-log(-softmax(x)))].
+    """
+    y_hat = nn.softmax(orig.args[0])
+    return [multiply(grad, subtract(y_hat, orig.args[1])), multiply(grad, negative(log(y_hat)))]
 
 
 @register_gradient("relax.sigmoid")
-def sigmoid_grad(orig, grad):
-	"""Gradient of sigmoid.
+def sigmoid_grad(orig: Call, grad: Var):
+    """Gradient of sigmoid.
 
-		y = relax.sigmoid(x)
+        y = relax.sigmoid(x)
 
-	Returns [grad * sigmoid(x) * (1 - sigmoid(x))].
-	"""
-	out = sigmoid(orig.args[0])
-	return [multiply(grad, multiply(out, subtract(ones(orig.args[0].shape), out)))]
+    Returns [grad * sigmoid(x) * (1 - sigmoid(x))].
+    """
+    out = sigmoid(orig.args[0])
+    return [multiply(grad, multiply(out, subtract(ones(orig.args[0].shape), out)))]
 
 
 @register_gradient("relax.tanh")
-def tanh_grad(orig, grad):
-	"""Gradient of tanh.
+def tanh_grad(orig: Call, grad: Var):
+    """Gradient of tanh.
 
-		y = relax.tanh(x)
+        y = relax.tanh(x)
 
-	Returns [grad * (1 - tanh(x) * tanh(x))].
-	"""
-	out = tanh(orig.args[0])
-	return [multiply(grad, subtract(ones(orig.args[0].shape), multiply(out, out)))]
+    Returns [grad * (1 - tanh(x) * tanh(x))].
+    """
+    out = tanh(orig.args[0])
+    return [multiply(grad, subtract(ones(orig.args[0].shape), multiply(out, out)))]

--- a/python/tvm/relax/op/gradient.py
+++ b/python/tvm/relax/op/gradient.py
@@ -1,0 +1,145 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Gradient definitions for Relax operators"""
+from __future__ import annotations
+
+from tvm.relax import const
+from tvm.relay.op import register_gradient
+import tvm.relax.op.nn as nn
+from tvm.relax.op import (
+	sum,
+	less,
+	where,
+	collapse_sum_to,
+	log,
+	multiply,
+	divide,
+	negative,
+	subtract,
+	transpose,
+	sigmoid,
+	tanh,
+	ones,
+	zeros
+)
+
+
+@register_gradient("relax.add")
+def add_grad(orig, grad):
+	"""Returns [grad, grad]."""
+	return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(grad, orig.args[1].shape)]
+
+
+@register_gradient("relax.subtract")
+def subtract_grad(orig, grad):
+	"""Returns [grad, -grad]."""
+	return [collapse_sum_to(grad, orig.args[0].shape), collapse_sum_to(negative(grad), orig.args[1].shape)]
+
+
+@register_gradient("relax.multiply")
+def multiply_grad(orig, grad):
+	"""Returns [grad * y, grad * x]."""
+	x, y = orig.args
+	return [collapse_sum_to(multiply(grad, y), x.shape), collapse_sum_to(multiply(grad, x), y.shape)]
+
+
+@register_gradient("relax.transpose")
+def transpose_grad(orig, grad):
+	"""Returns grad transposed over the complement of original transpose axes"""
+	"""TODO: Do not support more than one dimensions"""
+	return [transpose(grad)]
+
+
+@register_gradient("relax.nn.relu")
+def relu_grad(orig, grad):
+	"""Returns grad * (select(x < 0, 0, 1))."""
+	x = orig.args[0]
+	x_zeros = zeros(x.shape)
+	x_ones = ones(x.shape)
+	return [where(less(x, x_zeros), x_zeros, multiply(x_ones, grad))]
+
+
+@register_gradient("relax.nn.matmul")
+def matmul_grad(orig, grad):
+	"""Returns [grad' @ tensor_b, tensor_a @ grad']."""
+	tensor_a, tensor_b = orig.args
+	return [
+		collapse_sum_to(nn.matmul(grad, transpose(tensor_b)), tensor_a.shape),
+		collapse_sum_to(nn.matmul(transpose(tensor_a), grad), tensor_b.shape),
+	]
+
+
+@register_gradient("relax.sum")
+def sum_grad(orig, grad):
+	"""Returns [grad * ones(x.shape)]."""
+	return [multiply(grad, ones(orig.args[0].shape))]
+
+
+@register_gradient("relax.nn.softmax")
+def softmax_grad(orig, grad):
+	"""Gradient of softmax."""
+	return [multiply(subtract(grad, sum(multiply(grad, orig), orig.attrs.axis, True)), orig)]
+
+
+@register_gradient("relax.nn.cross_entropy")
+def cross_entropy_grad(orig, grad):
+	"""Gradient of cross_entropy.
+
+		z = relax.nn.cross_entropy(x, y)
+
+	Returns [- grad * y / x, - grad * log(x)].
+	"""
+	x, y = orig.args
+	return [negative(multiply(grad, divide(y, x))), negative(multiply(grad, log(x)))]
+
+
+@register_gradient("relax.nn.softmax_cross_entropy")
+def softmax_cross_entropy_grad(orig, grad):
+	"""Gradient of softmax_cross_entropy.
+
+		z = relax.nn.softmax_cross_entropy(x, y)
+
+	This gradient is based on the assumption that sum(y)=1.
+	Returns [grad * (y - softmax(x)), grad * (-log(-softmax(x)))].
+	"""
+	y_hat = nn.softmax(orig.args[0])
+	return [multiply(grad, subtract(y_hat, orig.args[1])), multiply(grad, negative(log(y_hat)))]
+
+
+@register_gradient("relax.sigmoid")
+def sigmoid_grad(orig, grad):
+	"""Gradient of sigmoid.
+
+		y = relax.sigmoid(x)
+
+	Returns [grad * sigmoid(x) * (1 - sigmoid(x))].
+	"""
+	out = sigmoid(orig.args[0])
+	return [multiply(grad, multiply(out, subtract(ones(orig.args[0].shape), out)))]
+
+
+@register_gradient("relax.tanh")
+def tanh_grad(orig, grad):
+	"""Gradient of tanh.
+
+		y = relax.tanh(x)
+
+	Returns [grad * (1 - tanh(x) * tanh(x))].
+	"""
+	out = tanh(orig.args[0])
+	return [multiply(grad, subtract(ones(orig.args[0].shape), multiply(out, out)))]

--- a/python/tvm/relax/transform/op_legalizer.py
+++ b/python/tvm/relax/transform/op_legalizer.py
@@ -382,7 +382,8 @@ def _mean(bb: BlockBuilder, args: List[Expr], attrs: Attrs, output_shape: Expr):
     shape_prod = tvm.tir.const(1, "int32")
     axis = attrs.axis if attrs.axis is not None else range(0, len(args[0].shape))
     for dim in axis:
-        shape_prod = shape_prod * args[0].shape[dim.value]
+        ax = len(args[0].shape) + dim.value if dim.value < 0 else dim.value
+        shape_prod = shape_prod * args[0].shape[ax]
     sum_var = bb.emit_te(topi.sum, args[0], axis, attrs.keepdims)
     return bb.call_te(topi.divide, sum_var, shape_prod)
 

--- a/src/printer/relax_script_printer.cc
+++ b/src/printer/relax_script_printer.cc
@@ -350,7 +350,6 @@ Doc RelaxScriptPrinter::VisitNode_(const relax::SeqExprNode* op) {
 Doc RelaxScriptPrinter::VisitNode_(const relax::FunctionNode* op) {
   Optional<String> gsymbol = op->GetAttr<String>(tvm::attr::kGlobalSymbol);
   if (gsymbol) {
-    ICHECK_EQ(gsymbol.value(), relax_func_name_);
     return PrintFunctionDef(Doc::Text(relax_func_name_), GetRef<relax::Function>(op),
                             /*is_global=*/true);
   } else {

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -1488,7 +1488,7 @@ Expr InferShapeBroadcastTo(const Call& call, DiagnosticContext diag_ctx) {
                          << "The broadcast_to operator expects the input new shape is broadcast "
                             "compatible with the shape of the input data. However, on the last but "
                          << i << " dimension, the input data shape has length " << prev_len
-                         << " while the nwe shape has length " << new_len
+                         << " while the new shape has length " << new_len
                          << ", which are not compatible");
     }
   }

--- a/tests/python/relax/test_numeric_gradient.py
+++ b/tests/python/relax/test_numeric_gradient.py
@@ -85,28 +85,28 @@ def relax_check_gradients(op_func, op_name, input_numpy, target, dev, output_sha
 
 @tvm.testing.parametrize_targets("llvm")
 def test_add(target, dev):
-    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
-        relax.op.add, "relax.add", [data1_numpy, data2_numpy], target, dev, (16, 16)
+        relax.op.add, "relax.add", [data1_numpy, data2_numpy], target, dev, (3, 3)
     )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_subtract(target, dev):
-    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
-        relax.op.subtract, "relax.subtract", [data1_numpy, data2_numpy], target, dev, (16, 16)
+        relax.op.subtract, "relax.subtract", [data1_numpy, data2_numpy], target, dev, (3, 3)
     )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_multiply(target, dev):
-    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
-        relax.op.multiply, "relax.multiply", [data1_numpy, data2_numpy], target, dev, (16, 16)
+        relax.op.multiply, "relax.multiply", [data1_numpy, data2_numpy], target, dev, (3, 3)
     )
 
 
@@ -134,8 +134,8 @@ def test_transpose_with_axes(target, dev):
 
 @tvm.testing.parametrize_targets("llvm")
 def test_relu(target, dev):
-    data1_numpy = np.random.uniform(-1, 1, (16, 16)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.relu, "relax.nn.relu", [data1_numpy], target, dev, (16, 16))
+    data1_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.relu, "relax.nn.relu", [data1_numpy], target, dev, (3, 3))
 
 
 @tvm.testing.parametrize_targets("llvm")
@@ -190,16 +190,46 @@ def test_matmul_5_4(target, dev):
 
 @tvm.testing.parametrize_targets("llvm")
 def test_softmax(target, dev):
-    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
-        relax.op.nn.softmax, "relax.nn.softmax", [data1_numpy], target, dev, (16, 16)
+        relax.op.nn.softmax, "relax.nn.softmax", [data1_numpy], target, dev, (3, 3)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sum(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(relax.op.sum, "relax.sum", [data1_numpy], target, dev, ())
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sum_with_axis(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.sum, "relax.sum", [data1_numpy], target, dev, (2, 4), axis=[1, 3]
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sum_keepdims(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.sum, "relax.sum", [data1_numpy], target, dev, (3, 1), keepdims=True, axis=1
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_softmax_with_axis(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.softmax, "relax.nn.softmax", [data1_numpy], target, dev, (3, 3), axis=1
     )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_cross_entropy(target, dev):
-    data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
-    data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data1_numpy = np.random.randint(1, 16, (3,)).astype(np.float32)
+    data2_numpy = np.random.randint(1, 16, (3,)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.cross_entropy,
         "relax.nn.cross_entropy",
@@ -212,8 +242,8 @@ def test_cross_entropy(target, dev):
 
 @tvm.testing.parametrize_targets("llvm")
 def test_softmax_cross_entropy(target, dev):
-    data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
-    data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data1_numpy = np.random.randint(1, 16, (3,)).astype(np.float32)
+    data2_numpy = np.random.randint(1, 16, (3,)).astype(np.float32)
     data2_numpy /= np.sum(data2_numpy)
     relax_check_gradients(
         relax.op.nn.softmax_cross_entropy,
@@ -227,14 +257,14 @@ def test_softmax_cross_entropy(target, dev):
 
 @tvm.testing.parametrize_targets("llvm")
 def test_sigmoid(target, dev):
-    data_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
-    relax_check_gradients(relax.op.sigmoid, "relax.sigmoid", [data_numpy], target, dev, (10,))
+    data_numpy = np.random.randint(1, 16, (3,)).astype(np.float32)
+    relax_check_gradients(relax.op.sigmoid, "relax.sigmoid", [data_numpy], target, dev, (3,))
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_tanh(target, dev):
-    data_numpy = np.random.randint(1, 16, (16, 16)).astype(np.float32)
-    relax_check_gradients(relax.op.tanh, "relax.tanh", [data_numpy], target, dev, (16, 16))
+    data_numpy = np.random.randint(1, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(relax.op.tanh, "relax.tanh", [data_numpy], target, dev, (3, 3))
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_numeric_gradient.py
+++ b/tests/python/relax/test_numeric_gradient.py
@@ -34,10 +34,16 @@ def relax_check_gradients(op_func, op_name, input_numpy, target, dev, output_sha
     # prepare input
     for i in range(len(input_numpy)):
         param_vars.append(
-            relax.Var("x_" + str(i), input_numpy[i].shape, relax.DynTensorType(ndim=len(input_numpy[i].shape), dtype="float32"))
+            relax.Var(
+                "x_" + str(i),
+                input_numpy[i].shape,
+                relax.DynTensorType(ndim=len(input_numpy[i].shape), dtype="float32"),
+            )
         )
         input_ndarray.append(tvm.nd.array(input_numpy[i]))
-    grad_var = relax.Var("grad", output_shape, relax.DynTensorType(ndim=len(output_shape), dtype="float32"))
+    grad_var = relax.Var(
+        "grad", output_shape, relax.DynTensorType(ndim=len(output_shape), dtype="float32")
+    )
 
     # get gradient
     op = Op.get(op_name)
@@ -69,7 +75,10 @@ def relax_check_gradients(op_func, op_name, input_numpy, target, dev, output_sha
 
     ex_1 = relax.vm.build(lower_grad_mod, target)
     vm_1 = relax.VirtualMachine(ex_1, dev)
-    result = vm_1[func_name](*[tvm.nd.array(i) for i in input_numpy], tvm.nd.array(np.ones(output_shape).astype(np.float32)))
+    result = vm_1[func_name](
+        *[tvm.nd.array(i) for i in input_numpy],
+        tvm.nd.array(np.ones(output_shape).astype(np.float32)),
+    )
 
     check_numerical_grads(forward, input_numpy, [i.numpy() for i in result])
 
@@ -78,33 +87,49 @@ def relax_check_gradients(op_func, op_name, input_numpy, target, dev, output_sha
 def test_add(target, dev):
     data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    relax_check_gradients(relax.op.add, "relax.add", [data1_numpy, data2_numpy], target, dev, (16, 16))
+    relax_check_gradients(
+        relax.op.add, "relax.add", [data1_numpy, data2_numpy], target, dev, (16, 16)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_subtract(target, dev):
     data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    relax_check_gradients(relax.op.subtract, "relax.subtract", [data1_numpy, data2_numpy], target, dev, (16, 16))
+    relax_check_gradients(
+        relax.op.subtract, "relax.subtract", [data1_numpy, data2_numpy], target, dev, (16, 16)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_multiply(target, dev):
     data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    relax_check_gradients(relax.op.multiply, "relax.multiply", [data1_numpy, data2_numpy], target, dev, (16, 16))
+    relax_check_gradients(
+        relax.op.multiply, "relax.multiply", [data1_numpy, data2_numpy], target, dev, (16, 16)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_transpose(target, dev):
     data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.transpose, "relax.transpose",  [data1_numpy], target, dev, (5, 4, 3, 2))
+    relax_check_gradients(
+        relax.op.transpose, "relax.transpose", [data1_numpy], target, dev, (5, 4, 3, 2)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_transpose_with_axes(target, dev):
     data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.transpose, "relax.transpose",  [data1_numpy], target, dev, (2, 5, 4, 3), axes=(0, 3, 2, 1))
+    relax_check_gradients(
+        relax.op.transpose,
+        "relax.transpose",
+        [data1_numpy],
+        target,
+        dev,
+        (2, 5, 4, 3),
+        axes=(0, 3, 2, 1),
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
@@ -117,50 +142,72 @@ def test_relu(target, dev):
 def test_matmul_2_2(target, dev):
     data1_numpy = np.random.randint(0, 16, (7, 8)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (8, 10)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (7, 10))
+    relax_check_gradients(
+        relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (7, 10)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_matmul_1_1(target, dev):
     data1_numpy = np.random.randint(0, 16, (4,)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (4,)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, ())
+    relax_check_gradients(
+        relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, ()
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_matmul_1_4(target, dev):
     data1_numpy = np.random.randint(0, 16, (4,)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 5))
+    relax_check_gradients(
+        relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 5)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_matmul_4_1(target, dev):
     data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (5,)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 4))
+    relax_check_gradients(
+        relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 4)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_matmul_5_4(target, dev):
     data1_numpy = np.random.randint(0, 16, (2, 3, 1, 4, 5)).astype(np.float32)
     data2_numpy = np.random.randint(0, 16, (3, 2, 5, 6)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 2, 4, 6))
+    relax_check_gradients(
+        relax.op.nn.matmul,
+        "relax.nn.matmul",
+        [data1_numpy, data2_numpy],
+        target,
+        dev,
+        (2, 3, 2, 4, 6),
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_softmax(target, dev):
     data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.softmax, "relax.nn.softmax",
-        [data1_numpy], target, dev, (16, 16))
+    relax_check_gradients(
+        relax.op.nn.softmax, "relax.nn.softmax", [data1_numpy], target, dev, (16, 16)
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_cross_entropy(target, dev):
     data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.cross_entropy, "relax.nn.cross_entropy",
-        [data1_numpy, data2_numpy], target, dev, ())
+    relax_check_gradients(
+        relax.op.nn.cross_entropy,
+        "relax.nn.cross_entropy",
+        [data1_numpy, data2_numpy],
+        target,
+        dev,
+        (),
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")
@@ -168,8 +215,14 @@ def test_softmax_cross_entropy(target, dev):
     data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
     data2_numpy /= np.sum(data2_numpy)
-    relax_check_gradients(relax.op.nn.softmax_cross_entropy, "relax.nn.softmax_cross_entropy",
-        [data1_numpy, data2_numpy], target, dev, ())
+    relax_check_gradients(
+        relax.op.nn.softmax_cross_entropy,
+        "relax.nn.softmax_cross_entropy",
+        [data1_numpy, data2_numpy],
+        target,
+        dev,
+        (),
+    )
 
 
 @tvm.testing.parametrize_targets("llvm")

--- a/tests/python/relax/test_numeric_gradient.py
+++ b/tests/python/relax/test_numeric_gradient.py
@@ -1,0 +1,149 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import numpy as np
+import pytest
+import tvm
+from tvm import relax
+from tvm.relax.transform.op_legalizer import OperatorLegalizer
+from tvm.testing.utils import check_numerical_grads
+from tvm.ir.op import Op
+import tvm.relax.op.gradient
+
+
+def relax_check_gradients(op_func, op_name, input_numpy, target, dev, output_shape):
+    """
+        Generate module and run it to check numberic gradients.
+    """
+
+    func_name = "main"
+    param_vars = []
+    input_ndarray = []
+
+    # prepare input
+    for i in range(len(input_numpy)):
+        param_vars.append(
+            relax.Var("x_" + str(i), input_numpy[i].shape, relax.DynTensorType(ndim=len(input_numpy[i].shape), dtype="float32"))
+        )
+        input_ndarray.append(tvm.nd.array(input_numpy[i]))
+    grad_var = relax.Var("grad", output_shape, relax.DynTensorType(ndim=len(output_shape), dtype="float32"))
+
+    # get gradient
+    op = Op.get(op_name)
+    op_grad_func = op.get_attr("FPrimalGradient")
+    call = op_func(*param_vars)
+    grad_call = relax.Tuple(op_grad_func(call, grad_var))
+
+    bb = relax.BlockBuilder()
+    with bb.function(func_name, param_vars):
+        with bb.dataflow():
+            out = bb.emit_output(call)
+        bb.emit_func_output(out)
+    mod = bb.get()
+    lower_mod = OperatorLegalizer(mod).transform()
+
+    def forward(*inputs):
+        ex_0 = relax.vm.build(lower_mod, target)
+        vm_0 = relax.VirtualMachine(ex_0, dev)
+        result = vm_0[func_name](*[tvm.nd.array(i) for i in inputs])
+        return np.sum(result.numpy())
+
+    bb1 = relax.BlockBuilder()
+    with bb1.function(func_name, param_vars + [grad_var]):
+        with bb1.dataflow():
+            out = bb1.emit_output(grad_call)
+        bb1.emit_func_output(out)
+    grad_mod = bb1.get()
+    lower_grad_mod = OperatorLegalizer(grad_mod).transform()
+
+    ex_1 = relax.vm.build(lower_grad_mod, target)
+    vm_1 = relax.VirtualMachine(ex_1, dev)
+    result = vm_1[func_name](*[tvm.nd.array(i) for i in input_numpy], tvm.nd.array(np.ones(output_shape).astype(np.float32)))
+
+    check_numerical_grads(forward, input_numpy, [i.numpy() for i in result])
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_add(target, dev):
+    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.add, "relax.add", [data1_numpy, data2_numpy], target, dev, (16, 16))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_subtract(target, dev):
+    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.subtract, "relax.subtract", [data1_numpy, data2_numpy], target, dev, (16, 16))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_transpose(target, dev):
+    data1_numpy = np.random.randint(0, 16, (5, 10)).astype(np.float32)
+    relax_check_gradients(relax.op.transpose, "relax.transpose",  [data1_numpy], target, dev, (10, 5))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_relu(target, dev):
+    data1_numpy = np.random.uniform(-1, 1, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.relu, "relax.nn.relu", [data1_numpy], target, dev, (16, 16))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_matmul(target, dev):
+    data1_numpy = np.random.randint(0, 16, (7, 8)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (8, 10)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.matmul, "relax.nn.matmul", [data1_numpy, data2_numpy], target, dev, (7, 10))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_softmax(target, dev):
+    data1_numpy = np.random.randint(0, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.softmax, "relax.nn.softmax",
+        [data1_numpy], target, dev, (16, 16))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_cross_entropy(target, dev):
+    data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.cross_entropy, "relax.nn.cross_entropy",
+        [data1_numpy, data2_numpy], target, dev, ())
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_softmax_cross_entropy(target, dev):
+    data1_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data2_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    data2_numpy /= np.sum(data2_numpy)
+    relax_check_gradients(relax.op.nn.softmax_cross_entropy, "relax.nn.softmax_cross_entropy",
+        [data1_numpy, data2_numpy], target, dev, ())
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sigmoid(target, dev):
+    data_numpy = np.random.randint(1, 16, (10,)).astype(np.float32)
+    relax_check_gradients(relax.op.sigmoid, "relax.sigmoid", [data_numpy], target, dev, (10,))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_tanh(target, dev):
+    data_numpy = np.random.randint(1, 16, (16, 16)).astype(np.float32)
+    relax_check_gradients(relax.op.tanh, "relax.tanh", [data_numpy], target, dev, (16, 16))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/python/relax/test_numeric_gradient.py
+++ b/tests/python/relax/test_numeric_gradient.py
@@ -25,9 +25,7 @@ import tvm.relax.op.gradient
 
 
 def relax_check_gradients(op_func, op_name, input_numpy, target, dev, output_shape):
-    """
-        Generate module and run it to check numberic gradients.
-    """
+    """Generate module and run it to check numberic gradients."""
 
     func_name = "main"
     param_vars = []


### PR DESCRIPTION
This PR registers gradients using `relay.op.register_gradient` for the following relax operators:
- `add`
- `subtract`
- `transpose`
- `relu`
- `nn.matmul`
- `nn.softmax`
- `nn.cross_entropy`
- `nn.softmax_cross_entropy`
- `sigmoid`
- `tanh`

Numeric tests are passed for these implementations. (Running this test may take a period of time, approximately 1~2 min).