### PR TITLE
[CUTLASS] Convert Layout M1.0: Rules for unary ops

### DIFF
--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -60,7 +60,7 @@ with the layer input to produce a tensor of outputs.
     .set_attrs_type<Conv2DAttrs>()
     .set_attr<FInferShape>("FInferShape", InferShapeConv2D)
     .set_attr<FInferType>("FInferType", InferTypeConv2D)
-    .set_attr<FTVMRelaxInferLayoutType>("FTVMRelaxInferLayoutType", InferLayoutConv2d);
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConv2d);
 
 Expr InferShapeConv2D(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -30,6 +30,8 @@
 #include <tvm/relay/expr.h>
 #include <tvm/relay/op.h>
 
+#include "../transform/infer_layout_utils.h"
+
 namespace tvm {
 namespace relax {
 
@@ -70,7 +72,8 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs);
       .set_num_inputs(1)                                              \
       .add_argument("e", "Tensor", "The input tensor.")               \
       .set_attr<FInferShape>("FInferShape", InferShapeUnaryBroadcast) \
-      .set_attr<FInferType>("FInferType", InferTypeUnaryBroadcast)
+      .set_attr<FInferType>("FInferType", InferTypeUnaryBroadcast)    \
+      .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise)
 
 #define RELAX_REGISTER_REDUCTION_OP(OpName)                                         \
   TVM_REGISTER_GLOBAL("relax.op." OpName)                                           \

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -158,11 +158,10 @@ class LayoutConvertMutator : public ExprMutator {
       const OpNode* op_node = call_node->op.as<OpNode>();
       if (op_node != nullptr) {
         Op op = Downcast<Op>(GetRef<Op>(op_node));
-        const auto infer_layout_map =
-            Op::GetAttrMap<FTVMRelaxInferLayoutType>("FTVMRelaxInferLayoutType");
+        const auto infer_layout_map = Op::GetAttrMap<FRelaxInferLayout>("FRelaxInferLayout");
         if (infer_layout_map.count(op)) {
           // Infer the layout convertion from the input layouts and the desired layouts.
-          FTVMRelaxInferLayoutType f = infer_layout_map[op];
+          FRelaxInferLayout f = infer_layout_map[op];
           InferLayoutOutput layouts = f(GetRef<Call>(call_node), desired_layouts_, var_layout_map_);
           ICHECK_EQ(layouts->output_layouts.size(), 1) << "Only support single output op for now";
           // Convert the layout of inputs

--- a/src/relax/transform/infer_layout_utils.cc
+++ b/src/relax/transform/infer_layout_utils.cc
@@ -98,5 +98,17 @@ InferLayoutOutput InferLayoutConv2d(const Call& call,
   return InferLayoutOutput({data_layout, weight_layout}, {output_layout}, Attrs(new_attrs));
 }
 
+InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
+                                        const Map<String, Array<String>>& desired_layouts,
+                                        VarLayoutMap var_layout_map) {
+  const OpNode* op_node = call->op.as<OpNode>();
+  ICHECK(op_node != nullptr) << "Invalid Call";
+  const auto& it = desired_layouts.find(op_node->name);
+  ICHECK(it == desired_layouts.end()) << "Unsupported desired layout for " << op_node->name;
+  ICHECK_EQ(call->args.size(), 1) << "Invalid Call";
+  Layout layout = GetOneValidLayout(var_layout_map, call->args[0]);
+  return InferLayoutOutput({layout}, {layout}, Attrs(call->attrs));
+}
+
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -79,7 +79,7 @@ using VarLayoutMap = Map<relax::Var, Map<String, relax::Var>>;
  * \param desired_layouts The desired layouts of the operator.
  * \param var_layout_map The layout of the variables.
  */
-using FTVMRelaxInferLayoutType = runtime::TypedPackedFunc<InferLayoutOutput(
+using FRelaxInferLayout = runtime::TypedPackedFunc<InferLayoutOutput(
     const Call& call, const Map<String, Array<String>>& desired_layouts,
     VarLayoutMap var_layout_map)>;
 
@@ -110,6 +110,10 @@ Layout GetOneValidLayout(VarLayoutMap var_layout_map, const Expr& arg);
 InferLayoutOutput InferLayoutConv2d(const Call& call,
                                     const Map<String, Array<String>>& desired_layouts,
                                     VarLayoutMap var_layout_map);
+
+InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
+                                        const Map<String, Array<String>>& desired_layouts,
+                                        VarLayoutMap var_layout_map);
 
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -87,8 +87,8 @@ class conv2d_relu:
             out_layout="NHWC",
             out_dtype="float32",
         )
-        gv3: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv2, axes=[0, 3, 1, 2])
-        gv4: R.Tensor((2, 4, 26, 26), dtype="float32") = R.nn.relu(gv3)
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv2)
+        gv4: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
         return gv4
 
 
@@ -133,8 +133,8 @@ class relu_conv2d_relu:
             out_layout="NHWC",
             out_dtype="float32",
         )
-        gv4: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
-        gv5: R.Tensor((2, 4, 26, 26), dtype="float32") = R.nn.relu(gv4)
+        gv4: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv3)
+        gv5: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv4, axes=[0, 3, 1, 2])
         return gv5
 
 
@@ -156,7 +156,56 @@ def test_relu_conv2d_relu():
     tvm.ir.assert_structural_equal(mod, relu_conv2d_relu)
 
 
+@I.ir_module
+class conv2d_relu_tanh:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv2)
+        gv4: R.Tensor((2, 26, 26, 4), dtype="float32") = R.tanh(gv3)
+        gv5: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv4, axes=[0, 3, 1, 2])
+        return gv5
+
+
+def test_conv2d_relu_tanh():
+    @I.ir_module
+    class Conv2dReLUTanh:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), "float32") = R.nn.relu(gv)
+            gv3: R.Tensor((2, 4, 26, 26), "float32") = R.tanh(gv2)
+            return gv3
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dReLUTanh)
+    print(mod.script())
+    tvm.ir.assert_structural_equal(mod, conv2d_relu_tanh)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
     test_relu_conv2d_relu()
+    test_conv2d_relu_tanh()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [ ] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops
  - [ ] M1.1:  Binary ops
  - [ ] M1.2: Tenary ops
- [ ] M2: Introduce rules for broadcastable ops which require manipulation of attrs
