### PR TITLE
[CUTLASS] Convert Layout M1.1: Rules for binary ops

### DIFF
--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -61,7 +61,8 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs);
       .add_argument("lhs", "Tensor", "The left hand side tensor.")                \
       .add_argument("rhs", "Tensor", "The right hand side tensor.")               \
       .set_attr<FInferShape>("FInferShape", InferShapeBinaryBroadcast)            \
-      .set_attr<FInferType>("FInferType", InferTypeBinaryBroadcast)
+      .set_attr<FInferType>("FInferType", InferTypeBinaryBroadcast)               \
+      .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutBinaryEwise)
 
 #define RELAX_REGISTER_UNARY_OP(OpName)                               \
   TVM_REGISTER_GLOBAL("relax.op." OpName).set_body_typed([](Expr e) { \

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -115,6 +115,10 @@ InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutBinaryEwise(const Call& call,
+                                         const Map<String, Array<String>>& desired_layouts,
+                                         VarLayoutMap var_layout_map);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -200,8 +200,126 @@ def test_conv2d_relu_tanh():
             return gv3
 
     mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dReLUTanh)
-    print(mod.script())
     tvm.ir.assert_structural_equal(mod, conv2d_relu_tanh)
+
+
+@I.ir_module
+class conv2d_add:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"),
+        w: R.Tensor((4, 3, 3, 3), dtype="float32"),
+        bias: R.Tensor((2, 4, 26, 26), dtype="float32"),
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.transpose(bias, axes=[0, 2, 3, 1])
+        gv4: R.Tensor((2, 26, 26, 4), dtype="float32") = R.add(gv2, gv3)
+        gv5: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv4, axes=[0, 3, 1, 2])
+        return gv5
+
+
+def test_conv2d_add():
+    @I.ir_module
+    class Conv2dAdd:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"),
+            w: R.Tensor((4, 3, 3, 3), "float32"),
+            bias: R.Tensor((2, 4, 26, 26), "float32"),
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), "float32") = R.add(gv, bias)
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dAdd)
+    tvm.ir.assert_structural_equal(mod, conv2d_add)
+
+
+@I.ir_module
+class conv2d_add_relu_conv2d:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"),
+        w: R.Tensor((4, 3, 3, 3), dtype="float32"),
+        bias: R.Tensor((2, 4, 26, 26), dtype="float32"),
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.transpose(bias, axes=[0, 2, 3, 1])
+        gv4: R.Tensor((2, 26, 26, 4), dtype="float32") = R.add(gv2, gv3)
+        gv5: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv4)
+        gv6: R.Tensor((2, 24, 24, 4), dtype="float32") = R.nn.conv2d(
+            gv5,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv7: R.Tensor((2, 4, 24, 24), dtype="float32") = R.transpose(gv6, axes=[0, 3, 1, 2])
+        return gv7
+
+
+def test_conv2d_add_relu_conv2d():
+    @I.ir_module
+    class Conv2dAddReLUConv2d:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"),
+            w: R.Tensor((4, 3, 3, 3), "float32"),
+            bias: R.Tensor((2, 4, 26, 26), "float32"),
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), "float32") = R.add(gv, bias)
+            gv3: R.Tensor((2, 4, 26, 26), "float32") = R.nn.relu(gv2)
+            gv4: R.Tensor((2, 4, 24, 24), "float32") = R.nn.conv2d(
+                gv3, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            return gv4
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dAddReLUConv2d)
+    tvm.ir.assert_structural_equal(mod, conv2d_add_relu_conv2d)
 
 
 if __name__ == "__main__":
@@ -209,3 +327,5 @@ if __name__ == "__main__":
     test_conv2d_relu()
     test_relu_conv2d_relu()
     test_conv2d_relu_tanh()
+    test_conv2d_add()
+    test_conv2d_add_relu_conv2d()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [ ] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops https://github.com/mlc-ai/relax/pull/64
  - [x] M1.1:  Binary ops
  - [ ] M1.2: Tenary ops
- [ ] M2: Introduce rules for broadcastable ops which require manipulation of attrs
