### PR TITLE
[CUTLASS] Convert Layout M1.2: Rules for ternary ops

### DIFF
--- a/src/relax/op/tensor/ternary.cc
+++ b/src/relax/op/tensor/ternary.cc
@@ -33,7 +33,8 @@ RELAX_REGISTER_OP("relax.ewise_fma")
     .add_argument("e2", "Expr", "The input expression")
     .add_argument("e3", "Expr", "The input expression")
     .set_attr<FInferShape>("FInferShape", InferShapeEwiseFMA)
-    .set_attr<FInferType>("FInferType", InferTypeEwiseFMA);
+    .set_attr<FInferType>("FInferType", InferTypeEwiseFMA)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutTernaryEwise);
 
 Expr MakeEwiseFma(Expr expr1, Expr expr2, Expr expr3) {
   static const Op& op = Op::Get("relax.ewise_fma");

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -119,6 +119,10 @@ InferLayoutOutput InferLayoutBinaryEwise(const Call& call,
                                          const Map<String, Array<String>>& desired_layouts,
                                          VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutTernaryEwise(const Call& call,
+                                          const Map<String, Array<String>>& desired_layouts,
+                                          VarLayoutMap var_layout_map);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -322,6 +322,78 @@ def test_conv2d_add_relu_conv2d():
     tvm.ir.assert_structural_equal(mod, conv2d_add_relu_conv2d)
 
 
+@I.ir_module
+class conv2d_fma_relu_conv2d:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"),
+        w: R.Tensor((4, 3, 3, 3), dtype="float32"),
+        scale: R.Tensor((2, 4, 26, 26), dtype="float32"),
+        bias: R.Tensor((2, 4, 26, 26), dtype="float32"),
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.transpose(scale, axes=[0, 2, 3, 1])
+        gv4: R.Tensor((2, 26, 26, 4), dtype="float32") = R.transpose(bias, axes=[0, 2, 3, 1])
+        gv5: R.Tensor((2, 26, 26, 4), dtype="float32") = R.ewise_fma(gv2, gv3, gv4)
+        gv6: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv5)
+        gv7: R.Tensor((2, 24, 24, 4), dtype="float32") = R.nn.conv2d(
+            gv6,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv8: R.Tensor((2, 4, 24, 24), dtype="float32") = R.transpose(gv7, axes=[0, 3, 1, 2])
+        return gv8
+
+
+def test_conv2d_fma_relu_conv2d():
+    @I.ir_module
+    class Conv2dFmaReLUConv2d:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"),
+            w: R.Tensor((4, 3, 3, 3), "float32"),
+            scale: R.Tensor((2, 4, 26, 26), dtype="float32"),
+            bias: R.Tensor((2, 4, 26, 26), "float32"),
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), "float32") = R.ewise_fma(gv, scale, bias)
+            gv3: R.Tensor((2, 4, 26, 26), "float32") = R.nn.relu(gv2)
+            gv4: R.Tensor((2, 4, 24, 24), "float32") = R.nn.conv2d(
+                gv3, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            return gv4
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dFmaReLUConv2d)
+    tvm.ir.assert_structural_equal(mod, conv2d_fma_relu_conv2d)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -329,3 +401,4 @@ if __name__ == "__main__":
     test_conv2d_relu_tanh()
     test_conv2d_add()
     test_conv2d_add_relu_conv2d()
+    test_conv2d_fma_relu_conv2d()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [x] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops https://github.com/mlc-ai/relax/pull/64
  - [x] M1.1:  Binary ops https://github.com/mlc-ai/relax/pull/65
  - [x] M1.2: Tenary ops https://github.com/mlc-ai/relax/pull/66
- [ ] M2: Introduce rules for broadcastable ops which require manipulation of attrs
