### PR TITLE
[CUTLASS] Convert Layout M2.0: Rules for reduce ops

### DIFF
--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -89,7 +89,8 @@ bool EqualCheck(const PrimExpr& lhs, const PrimExpr& rhs);
       .set_num_inputs(1)                                                            \
       .add_argument("expr", "Tensor", "The input tensor")                           \
       .set_attr<FInferShape>("FInferShape", InferShapeReduction)                    \
-      .set_attr<FInferType>("FInferType", InferTypeReduction)
+      .set_attr<FInferType>("FInferType", InferTypeReduction)                       \
+      .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutReduce)
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -123,6 +123,10 @@ InferLayoutOutput InferLayoutTernaryEwise(const Call& call,
                                           const Map<String, Array<String>>& desired_layouts,
                                           VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutReduce(const Call& call,
+                                    const Map<String, Array<String>>& desired_layouts,
+                                    VarLayoutMap var_layout_map);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -394,6 +394,95 @@ def test_conv2d_fma_relu_conv2d():
     tvm.ir.assert_structural_equal(mod, conv2d_fma_relu_conv2d)
 
 
+@I.ir_module
+class conv2d_sum:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=2):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 4), dtype="float32") = R.sum(gv2, axis=[1, 2], keepdims=False)
+        return gv3
+
+
+def test_conv2d_sum():
+    @I.ir_module
+    class Conv2dSum:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=2):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4), "float32") = R.sum(gv, axis=[2, 3])
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dSum)
+    tvm.ir.assert_structural_equal(mod, conv2d_sum)
+
+
+@I.ir_module
+class conv2d_sum_keepdim:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 1, 1, 4), dtype="float32") = R.sum(gv2, axis=[1, 2], keepdims=True)
+        gv4: R.Tensor((2, 4, 1, 1), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
+        return gv4
+
+
+def test_conv2d_sum_keepdim():
+    @I.ir_module
+    class Conv2dSumKeepDim:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 1, 1), "float32") = R.sum(gv, axis=[2, 3], keepdims=True)
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dSumKeepDim)
+    tvm.ir.assert_structural_equal(mod, conv2d_sum_keepdim)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -402,3 +491,5 @@ if __name__ == "__main__":
     test_conv2d_add()
     test_conv2d_add_relu_conv2d()
     test_conv2d_fma_relu_conv2d()
+    test_conv2d_sum()
+    test_conv2d_sum_keepdim()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [x] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops https://github.com/mlc-ai/relax/pull/64
  - [x] M1.1:  Binary ops https://github.com/mlc-ai/relax/pull/65
  - [x] M1.2: Tenary ops https://github.com/mlc-ai/relax/pull/66
- [ ] M2: Introduce rules for broadcastable ops which require manipulation of attrs
  - [x] M2.0: reduce ops https://github.com/mlc-ai/relax/pull/68
  - [ ] M2.1: transpose, expand-dims, squeeze, strided_slice, take
  - [ ] M2.2: concat, split
  - [ ] M2.3: dropout, cast, wrapparam, init
  - [ ] M2.4: MaxPool2D, softmax, BatchNorm, LayerNorm, cumsum, resize2d