### PR TITLE
[CUTLASS] Convert Layout M2.1: Rules for transpose, expand-dims, squeeze, strided_slice, take, cumsum

### DIFF
--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -39,7 +39,8 @@ RELAX_REGISTER_OP("relax.transpose")
     .set_num_inputs(1)
     .add_argument("data", "nD Tensor", "input tensor to be transposed")
     .set_attr<FInferShape>("FInferShape", InferShapeTranspose)
-    .set_attr<FInferType>("FInferType", InferTypeTranspose);
+    .set_attr<FInferType>("FInferType", InferTypeTranspose)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutTranspose);
 
 Expr MakeTranspose(Expr data, Optional<Array<Integer>> axes) {
   ObjectPtr<TransposeAttrs> attrs = make_object<TransposeAttrs>();
@@ -1002,16 +1003,14 @@ TVM_REGISTER_GLOBAL("relax.op.ones").set_body_typed(MakeOnes);
 
 Expr InferShapeOnesZeros(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 1) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Ones or zeros op should have 1 argument");
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Ones or zeros op should have 1 argument");
   }
   return call->args[0];
 }
 
 Type InferTypeOnesZeros(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 1) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "Ones or zeros op should have 1 argument");
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "Ones or zeros op should have 1 argument");
   }
 
   const auto* shape_type = call->args[0]->checked_type().as<ShapeTypeNode>();
@@ -1125,7 +1124,8 @@ RELAX_REGISTER_UNARY_OP("zeros_like");
 RELAX_REGISTER_OP("relax.collapse_sum_like")
     .set_num_inputs(2)
     .add_argument("data", "Tensor", "The input tensor.")
-    .add_argument("collapse_target", "Tensor", "The tensor whose shape is the shape to collapse to.")
+    .add_argument("collapse_target", "Tensor",
+                  "The tensor whose shape is the shape to collapse to.")
     .set_attr<FInferShape>("FInferShape", InferShapeCollapseSumLike)
     .set_attr<FInferType>("FInferType", InferTypeCollapseSumLike);
 
@@ -1138,7 +1138,8 @@ TVM_REGISTER_GLOBAL("relax.op.collapse_sum_like").set_body_typed(MakeCollapseSum
 
 Expr InferShapeCollapseSumLike(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "collapse_sum_like op should have 2 arguments");
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "collapse_sum_like op should have 2 arguments");
   }
 
   Expr shape = call->args[1]->shape();
@@ -1152,7 +1153,8 @@ Expr InferShapeCollapseSumLike(const Call& call, DiagnosticContext diag_ctx) {
 
 Type InferTypeCollapseSumLike(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "collapse_sum_like op should have 2 arguments");
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "collapse_sum_like op should have 2 arguments");
   }
 
   auto* input_ty = call->args[1]->checked_type().as<DynTensorTypeNode>();
@@ -1180,10 +1182,10 @@ Expr MakeCollapseSumTo(Expr data, Expr shape) {
 
 TVM_REGISTER_GLOBAL("relax.op.collapse_sum_to").set_body_typed(MakeCollapseSumTo);
 
-
 Expr InferShapeCollapseSumTo(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "collapse_sum_to op should have 2 arguments");
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "collapse_sum_to op should have 2 arguments");
   }
 
   return call->args[1];
@@ -1191,7 +1193,8 @@ Expr InferShapeCollapseSumTo(const Call& call, DiagnosticContext diag_ctx) {
 
 Type InferTypeCollapseSumTo(const Call& call, DiagnosticContext diag_ctx) {
   if (call->args.size() != 2) {
-    diag_ctx.EmitFatal(Diagnostic::Error(call->span) << "collapse_sum_to op should have 2 arguments");
+    diag_ctx.EmitFatal(Diagnostic::Error(call->span)
+                       << "collapse_sum_to op should have 2 arguments");
   }
 
   const auto* orig_type = call->args[0]->checked_type().as<DynTensorTypeNode>();
@@ -1266,10 +1269,8 @@ Expr InferShapeWhere(const Call& call, DiagnosticContext diag_ctx) {
     return ShapeExpr(Array<PrimExpr>(output_shape.rbegin(), output_shape.rend()));
   };
 
-  return binary_broadcast(
-    binary_broadcast(call->args[1]->shape(), call->args[2]->shape()),
-    call->args[0]->shape()
-  );
+  return binary_broadcast(binary_broadcast(call->args[1]->shape(), call->args[2]->shape()),
+                          call->args[0]->shape());
   // TODO(chaofanlin): runtime shape inference
 }
 
@@ -1286,8 +1287,10 @@ Type InferTypeWhere(const Call& call, DiagnosticContext diag_ctx) {
   auto* t2 = y_type.as<DynTensorTypeNode>();
   if (!t0 || !t1 || !t2) {
     diag_ctx.EmitFatal(Diagnostic::Error(call->span)
-                       << "All three arguments of where: condtion, x and y should be DynTensor for broadcasting, but got "
-                       << condition_type->GetTypeKey()  << ", " << x_type->GetTypeKey() << " and " << y_type->GetTypeKey());
+                       << "All three arguments of where: condtion, x and y should be DynTensor for "
+                          "broadcasting, but got "
+                       << condition_type->GetTypeKey() << ", " << x_type->GetTypeKey() << " and "
+                       << y_type->GetTypeKey());
   }
 
   DataType output_dtype;

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -1536,7 +1536,8 @@ RELAX_REGISTER_OP("relax.strided_slice")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferShape>("FInferShape", InferShapeStridedSlice)
-    .set_attr<FInferType>("FInferType", InferTypeStridedSlice);
+    .set_attr<FInferType>("FInferType", InferTypeStridedSlice)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutStridedSlice);
 
 Expr MakeStridedSlice(Expr data,                          //
                       Array<PrimExpr> begin,              //

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -627,7 +627,8 @@ RELAX_REGISTER_OP("relax.cumsum")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferShape>("FInferShape", InferShapeCumsum)
-    .set_attr<FInferType>("FInferType", InferTypeCumsum);
+    .set_attr<FInferType>("FInferType", InferTypeCumsum)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutCumsum);
 
 Expr MakeCumsum(Expr data, Optional<Integer> axis) {
   ObjectPtr<CumsumAttrs> attrs = make_object<CumsumAttrs>();

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -221,7 +221,8 @@ RELAX_REGISTER_OP("relax.expand_dims")
     .set_attrs_type<ExpandDimsAttrs>()
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferShape>("FInferShape", InferShapeExpandDims)
-    .set_attr<FInferType>("FInferType", InferTypeExpandDims);
+    .set_attr<FInferType>("FInferType", InferTypeExpandDims)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutExpandDims);
 
 Expr MakeExpandDims(Expr data, Array<Integer> axis) {
   ObjectPtr<ExpandDimsAttrs> attrs = make_object<ExpandDimsAttrs>();

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -311,7 +311,8 @@ RELAX_REGISTER_OP("relax.squeeze")
     .set_attrs_type<SqueezeAttrs>()
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferShape>("FInferShape", InferShapeSqueeze)
-    .set_attr<FInferType>("FInferType", InferTypeSqueeze);
+    .set_attr<FInferType>("FInferType", InferTypeSqueeze)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutSqueeze);
 
 Expr MakeSqueeze(Expr data, Optional<Array<Integer>> axis) {
   ObjectPtr<SqueezeAttrs> attrs = make_object<SqueezeAttrs>();

--- a/src/relax/transform/infer_layout_utils.cc
+++ b/src/relax/transform/infer_layout_utils.cc
@@ -211,8 +211,7 @@ InferLayoutOutput InferLayoutReduce(const Call& call,
   const auto* attrs = call->attrs.as<ReduceAttrs>();
   ICHECK(attrs != nullptr) << "Invalid Call";
   const auto* type = call->args[0]->checked_type().as<DynTensorTypeNode>();
-  ICHECK(type != nullptr) << "Invalid Call";
-  ICHECK(!type->IsUnknownNdim()) << "Invalid Call";
+  ICHECK(type != nullptr && !type->IsUnknownNdim()) << "Invalid Call";
 
   Array<Integer> axis;
   if (attrs->axis.defined()) {
@@ -265,8 +264,7 @@ InferLayoutOutput InferLayoutTranspose(const Call& call,
   const auto* attrs = call->attrs.as<TransposeAttrs>();
   ICHECK(attrs != nullptr) << "Invalid Call";
   const auto* type = call->args[0]->checked_type().as<DynTensorTypeNode>();
-  ICHECK(type != nullptr) << "Invalid Call";
-  ICHECK(!type->IsUnknownNdim()) << "Invalid Call";
+  ICHECK(type != nullptr && !type->IsUnknownNdim()) << "Invalid Call";
 
   Layout exisiting_layout = GetOneValidLayout(var_layout_map, call->args[0]);
   Array<Integer> order;
@@ -304,8 +302,7 @@ InferLayoutOutput InferLayoutExpandDims(const Call& call,
   const auto* attrs = call->attrs.as<ExpandDimsAttrs>();
   ICHECK(attrs != nullptr) << "Invalid Call";
   const auto* type = call->args[0]->checked_type().as<DynTensorTypeNode>();
-  ICHECK(type != nullptr) << "Invalid Call";
-  ICHECK(!type->IsUnknownNdim()) << "Invalid Call";
+  ICHECK(type != nullptr && !type->IsUnknownNdim()) << "Invalid Call";
 
   Layout exisiting_layout = GetOneValidLayout(var_layout_map, call->args[0]);
   int ndim = type->ndim;
@@ -331,6 +328,61 @@ InferLayoutOutput InferLayoutExpandDims(const Call& call,
     }
   }
   return InferLayoutOutput({exisiting_layout}, {Layout(output_layout)}, Attrs(call->attrs));
+}
+
+InferLayoutOutput InferLayoutSqueeze(const Call& call,
+                                     const Map<String, Array<String>>& desired_layouts,
+                                     VarLayoutMap var_layout_map) {
+  const OpNode* op_node = call->op.as<OpNode>();
+  ICHECK(op_node != nullptr) << "Invalid Call";
+  const auto& it = desired_layouts.find(op_node->name);
+  ICHECK(it == desired_layouts.end()) << "Unsupported desired layout for " << op_node->name;
+  ICHECK_EQ(call->args.size(), 1) << "Invalid Call";
+
+  const auto* attrs = call->attrs.as<SqueezeAttrs>();
+  ICHECK(attrs != nullptr) << "Invalid Call";
+  const auto* type = call->args[0]->checked_type().as<DynTensorTypeNode>();
+  const auto* shape = call->args[0]->shape().as<ShapeExprNode>();
+  ICHECK(type != nullptr && !type->IsUnknownNdim()) << "Invalid Call";
+  ICHECK(shape != nullptr) << "Invalid Call";
+
+  Array<Integer> axis;
+  if (attrs->axis.defined()) {
+    axis = attrs->axis.value();
+  } else {
+    axis.reserve(type->ndim);
+    for (int i = 0; i < type->ndim; ++i) {
+      if (tir::is_one(shape->values[i])) {
+        axis.push_back(Integer(i));
+      }
+    }
+  }
+
+  std::string axis_str(type->ndim, '0');
+  for (const auto& iter : axis) {
+    axis_str[iter->value] = '1';
+  }
+  for (int i = 0, j = 0; i < type->ndim; ++i) {
+    if (axis_str[i] != '1') {
+      axis_str[i] = 'A' + j++;
+    }
+  }
+
+  Layout exisiting_layout = GetOneValidLayout(var_layout_map, call->args[0]);
+  String new_axis_str = TransposeStrLike(axis_str, InitialLayout(type->ndim), exisiting_layout);
+  Array<Integer> new_axis;
+  for (size_t i = 0; i < new_axis_str.size(); ++i) {
+    if (new_axis_str.at(i) == '1') {
+      new_axis.push_back(Integer(i));
+    }
+  }
+  std::string output_layout = new_axis_str;
+  output_layout.erase(std::remove(output_layout.begin(), output_layout.end(), '1'),
+                      output_layout.end());
+
+  ObjectPtr<SqueezeAttrs> new_attrs = make_object<SqueezeAttrs>(*attrs);
+  new_attrs->axis = new_axis;
+  return InferLayoutOutput({exisiting_layout}, {output_layout}, Attrs(new_attrs));
 }
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -130,6 +130,10 @@ InferLayoutOutput InferLayoutReduce(const Call& call,
 InferLayoutOutput InferLayoutTranspose(const Call& call,
                                        const Map<String, Array<String>>& desired_layouts,
                                        VarLayoutMap var_layout_map);
+
+InferLayoutOutput InferLayoutExpandDims(const Call& call,
+                                        const Map<String, Array<String>>& desired_layouts,
+                                        VarLayoutMap var_layout_map);
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -127,6 +127,9 @@ InferLayoutOutput InferLayoutReduce(const Call& call,
                                     const Map<String, Array<String>>& desired_layouts,
                                     VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutTranspose(const Call& call,
+                                       const Map<String, Array<String>>& desired_layouts,
+                                       VarLayoutMap var_layout_map);
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -142,6 +142,11 @@ InferLayoutOutput InferLayoutSqueeze(const Call& call,
 InferLayoutOutput InferLayoutStridedSlice(const Call& call,
                                           const Map<String, Array<String>>& desired_layouts,
                                           VarLayoutMap var_layout_map);
+
+InferLayoutOutput InferLayoutCumsum(const Call& call,
+                                    const Map<String, Array<String>>& desired_layouts,
+                                    VarLayoutMap var_layout_map);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -138,6 +138,10 @@ InferLayoutOutput InferLayoutExpandDims(const Call& call,
 InferLayoutOutput InferLayoutSqueeze(const Call& call,
                                      const Map<String, Array<String>>& desired_layouts,
                                      VarLayoutMap var_layout_map);
+
+InferLayoutOutput InferLayoutStridedSlice(const Call& call,
+                                          const Map<String, Array<String>>& desired_layouts,
+                                          VarLayoutMap var_layout_map);
 }  // namespace relax
 }  // namespace tvm
 

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -134,6 +134,10 @@ InferLayoutOutput InferLayoutTranspose(const Call& call,
 InferLayoutOutput InferLayoutExpandDims(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map);
+
+InferLayoutOutput InferLayoutSqueeze(const Call& call,
+                                     const Map<String, Array<String>>& desired_layouts,
+                                     VarLayoutMap var_layout_map);
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -675,6 +675,96 @@ def test_conv2d_strided_slice():
     tvm.ir.assert_structural_equal(mod, conv2d_strided_slice)
 
 
+@I.ir_module
+class conv2d_cumsum:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.cumsum(gv2, axis=3)
+        gv4: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv2, axes=[0, 3, 1, 2])
+        return gv4
+
+
+def test_conv2d_cumsum():
+    @I.ir_module
+    class Conv2dCumsum:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), dtype="float32") = R.cumsum(gv, axis=1)
+            return gv
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dCumsum)
+    tvm.ir.assert_structural_equal(mod, conv2d_cumsum)
+
+
+@I.ir_module
+class conv2d_cumsum_default_axis:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=1):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv2, axes=[0, 3, 1, 2])
+        gv4: R.Tensor((5408,), dtype="float32") = R.cumsum(gv3, axis=None)
+        return gv4
+
+
+def test_conv2d_cumsum_default_axis():
+    @I.ir_module
+    class Conv2dCumsumDefaultAxis:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=1):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2 = R.cumsum(gv)
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dCumsumDefaultAxis)
+    tvm.ir.assert_structural_equal(mod, conv2d_cumsum_default_axis)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -689,3 +779,5 @@ if __name__ == "__main__":
     test_conv2d_expand_dims()
     test_conv2d_expand_dims_squeeze()
     test_conv2d_strided_slice()
+    test_conv2d_cumsum()
+    test_conv2d_cumsum_default_axis()

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -483,6 +483,50 @@ def test_conv2d_sum_keepdim():
     tvm.ir.assert_structural_equal(mod, conv2d_sum_keepdim)
 
 
+@I.ir_module
+class conv2d_transpose:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((26, 26, 4, 2), dtype="float32") = R.transpose(gv2, axes=[2, 1, 3, 0])
+        return gv3
+
+
+def test_conv2d_transpose():
+    @I.ir_module
+    class Conv2dT:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((26, 26, 4, 2), "float32") = R.transpose(gv, axes=[3, 2, 1, 0])
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dT)
+    tvm.ir.assert_structural_equal(mod, conv2d_transpose)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -493,3 +537,4 @@ if __name__ == "__main__":
     test_conv2d_fma_relu_conv2d()
     test_conv2d_sum()
     test_conv2d_sum_keepdim()
+    test_conv2d_transpose()

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -527,6 +527,54 @@ def test_conv2d_transpose():
     tvm.ir.assert_structural_equal(mod, conv2d_transpose)
 
 
+@I.ir_module
+class conv2d_expand_dims:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=6):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 1, 26, 1, 26, 4), dtype="float32") = R.expand_dims(gv2, axis=[-3, 1])
+        gv4: R.Tensor((2, 1, 4, 1, 26, 26), dtype="float32") = R.transpose(
+            gv3, axes=[0, 1, 5, 3, 2, 4]
+        )
+        return gv4
+
+
+def test_conv2d_expand_dims():
+    @I.ir_module
+    class Conv2dExpandDims:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=6):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 1, 4, 1, 26, 26), "float32") = R.expand_dims(gv, axis=(-3, 1))
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dExpandDims)
+    print(mod.script())
+    tvm.ir.assert_structural_equal(mod, conv2d_expand_dims)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -538,3 +586,4 @@ if __name__ == "__main__":
     test_conv2d_sum()
     test_conv2d_sum_keepdim()
     test_conv2d_transpose()
+    test_conv2d_expand_dims()

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -571,8 +571,54 @@ def test_conv2d_expand_dims():
             return gv2
 
     mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dExpandDims)
-    print(mod.script())
     tvm.ir.assert_structural_equal(mod, conv2d_expand_dims)
+
+
+@I.ir_module
+class conv2d_expand_dims_squeeze:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 1, 26, 1, 26, 4), dtype="float32") = R.expand_dims(gv2, axis=[-3, 1])
+        gv4: R.Tensor((2, 26, 26, 4), dtype="float32") = R.squeeze(gv3, axis=[1, 3])
+        gv5: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv4, axes=[0, 3, 1, 2])
+        return gv5
+
+
+def test_conv2d_expand_dims_squeeze():
+    @I.ir_module
+    class Conv2dExpandDimsSqueeze:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 1, 4, 1, 26, 26), "float32") = R.expand_dims(gv, axis=(-3, 1))
+            gv3: R.Tensor((2, 4, 26, 26), "float32") = R.squeeze(gv2, axis=[1, 3])
+            return gv3
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dExpandDimsSqueeze)
+    tvm.ir.assert_structural_equal(mod, conv2d_expand_dims_squeeze)
 
 
 if __name__ == "__main__":
@@ -587,3 +633,4 @@ if __name__ == "__main__":
     test_conv2d_sum_keepdim()
     test_conv2d_transpose()
     test_conv2d_expand_dims()
+    test_conv2d_expand_dims_squeeze()

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -621,6 +621,60 @@ def test_conv2d_expand_dims_squeeze():
     tvm.ir.assert_structural_equal(mod, conv2d_expand_dims_squeeze)
 
 
+@I.ir_module
+class conv2d_strided_slice:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 9, 7, 2), dtype="float32") = R.strided_slice(
+            gv2,
+            begin=[0, 0, 0],
+            end=[4, 26, 26],
+            strides=[2, 3, 4],
+            axes=[3, 1, 2],
+            slice_mode="end",
+        )
+        gv4: R.Tensor((2, 2, 9, 7), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
+        return gv4
+
+
+def test_conv2d_strided_slice():
+    @I.ir_module
+    class Conv2dStridedSlice:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 2, 9, 7), dtype="float32") = R.strided_slice(
+                gv, begin=[0, 0, 0], end=[4, 26, 26], strides=[2, 3, 4], axes=[1, 2, 3]
+            )
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dStridedSlice)
+    tvm.ir.assert_structural_equal(mod, conv2d_strided_slice)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -634,3 +688,4 @@ if __name__ == "__main__":
     test_conv2d_transpose()
     test_conv2d_expand_dims()
     test_conv2d_expand_dims_squeeze()
+    test_conv2d_strided_slice()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [x] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops https://github.com/mlc-ai/relax/pull/64
  - [x] M1.1:  Binary ops https://github.com/mlc-ai/relax/pull/65
  - [x] M1.2: Tenary ops https://github.com/mlc-ai/relax/pull/66
- [ ] M2: Introduce rules for broadcastable ops which require manipulation of attrs
  - [x] M2.0: reduce ops https://github.com/mlc-ai/relax/pull/68
  - [x] M2.1: transpose, expand-dims, squeeze, strided_slice, take, cumsum https://github.com/mlc-ai/relax/pull/69
  - [ ] M2.2: concat, split
  - [ ] M2.3: dropout, cast, wrapparam, init
  - [ ] M2.4: MaxPool2D, softmax, BatchNorm, LayerNorm, resize2d