### PR TITLE
[CUTLASS] Convert Layout M2.2: Rules for concat, split

### DIFF
--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -421,7 +421,8 @@ RELAY_REGISTER_OP("relax.concatenate")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input list of tensors.")
     .set_attr<FInferShape>("FInferShape", InferShapeConcatenate)
-    .set_attr<FInferType>("FInferType", InferTypeConcatenate);
+    .set_attr<FInferType>("FInferType", InferTypeConcatenate)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutConcatenate);
 
 Expr MakeConcatenate(Expr data, Optional<Integer> axis) {
   ObjectPtr<ConcatenateAttrs> attrs = make_object<ConcatenateAttrs>();

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -69,11 +69,12 @@ class LayoutConvertMutator : public ExprMutator {
         // This var already has the target layout
         return (*itt).second;
       }
-    } else {
-      auto it = other_var_map_.find(GetRef<Var>(op));
-      ICHECK(it != other_var_map_.end()) << "Cannot find var " << GetRef<Var>(op) << " in map";
+    }
+    auto it = other_var_map_.find(GetRef<Var>(op));
+    if (it != other_var_map_.end()) {
       return (*it).second;
     }
+    return ExprMutator::VisitExpr_(op);
   }
 
   Expr VisitExpr_(const VarNode* op) final { return VisitVars_(op); }

--- a/src/relax/transform/convert_layout.cc
+++ b/src/relax/transform/convert_layout.cc
@@ -43,6 +43,8 @@ class LayoutConvertMutator : public ExprMutator {
       if (const auto* type = param->checked_type().as<DynTensorTypeNode>()) {
         ICHECK(type->ndim > 0) << "Only support tensor with known rank";
         var_layout_map_[param].Set(InitialLayout(type->ndim), param);
+      } else {
+        other_var_map_[param] = param;
       }
     }
   }
@@ -67,8 +69,11 @@ class LayoutConvertMutator : public ExprMutator {
         // This var already has the target layout
         return (*itt).second;
       }
+    } else {
+      auto it = other_var_map_.find(GetRef<Var>(op));
+      ICHECK(it != other_var_map_.end()) << "Cannot find var " << GetRef<Var>(op) << " in map";
+      return (*it).second;
     }
-    return ExprMutator::VisitExpr_(op);
   }
 
   Expr VisitExpr_(const VarNode* op) final { return VisitVars_(op); }
@@ -97,14 +102,13 @@ class LayoutConvertMutator : public ExprMutator {
 
   // Convert the layout of the input arguments to the desired layout.
   // If input_layouts is not defined, the initial layout of the input arguments will be used.
-  size_t TransformArgs(Array<Expr> args, Optional<Array<Layout>> input_layouts, size_t offset,
+  size_t TransformArgs(Array<Expr> args, Array<Layout> input_layouts, size_t offset,
                        std::vector<Expr>* new_args) {
     for (size_t i = 0; i < args.size(); ++i) {
       if (const auto* var = args[i].as<VarNode>()) {
         const auto* type = var->checked_type().as<DynTensorTypeNode>();
         ICHECK(type != nullptr && !type->IsUnknownNdim()) << "Only support tensor with known rank";
-        Layout target_layout =
-            input_layouts.defined() ? input_layouts.value()[offset++] : InitialLayout(type->ndim);
+        Layout target_layout = input_layouts[offset++];
         auto it = var_layout_map_.find(GetRef<Var>(var));
         ICHECK(it != var_layout_map_.end()) << "Cannot find the layout of var: " << var;
         auto itt = it->second.find(target_layout.name());
@@ -128,8 +132,7 @@ class LayoutConvertMutator : public ExprMutator {
       } else if (const auto* constant = args[i].as<ConstantNode>()) {
         const auto* type = constant->checked_type().as<DynTensorTypeNode>();
         ICHECK(type != nullptr && !type->IsUnknownNdim()) << "Only support tensor with known rank";
-        Layout target_layout =
-            input_layouts.defined() ? input_layouts.value()[offset++] : InitialLayout(type->ndim);
+        Layout target_layout = input_layouts[offset++];
         Var converted_const = builder_->Emit(
             MakeTranspose(GetRef<Constant>(constant), LayoutToIntegers(target_layout)));
         new_args->push_back(converted_const);
@@ -150,6 +153,10 @@ class LayoutConvertMutator : public ExprMutator {
       }
       if (new_var->checked_type().as<DynTensorTypeNode>()) {
         this->UpdateLayoutMap(v, layout, new_var);
+      } else {
+        auto it = this->other_var_map_.find(v);
+        ICHECK(it == this->other_var_map_.end());
+        this->other_var_map_.insert({v, new_var});
       }
       return new_var;
     };
@@ -175,12 +182,18 @@ class LayoutConvertMutator : public ExprMutator {
           // We don't know how to convert the layout of this op.
           // Use the original layout.
           std::vector<Expr> new_args;
-          TransformArgs(call_node->args, NullOpt, 0, &new_args);
+          for (const auto& arg : call_node->args) {
+            new_args.push_back(VisitExpr(arg));
+          }
           const auto* type = binding->var->checked_type().as<DynTensorTypeNode>();
-          ICHECK(type != nullptr && !type->IsUnknownNdim())
-              << "Only support tensor with known rank";
-          emit(Call(call_node->op, new_args, call_node->attrs), binding->var,
-               InitialLayout(type->ndim));
+          int ndim;
+          if (type != nullptr) {
+            ICHECK(!type->IsUnknownNdim()) << "Only support tensor with known rank";
+            ndim = type->ndim;
+          } else {
+            ndim = 1;
+          }
+          emit(Call(call_node->op, new_args, call_node->attrs), binding->var, InitialLayout(ndim));
         }
       }
     } else {
@@ -189,6 +202,7 @@ class LayoutConvertMutator : public ExprMutator {
   }
 
   std::unordered_map<Var, Map<String, Var>, ObjectPtrHash, ObjectPtrEqual> var_layout_map_;
+  std::unordered_map<Var, Var, ObjectPtrHash, ObjectPtrEqual> other_var_map_;
   Map<String, Array<String>> desired_layouts_;
 };
 

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -147,6 +147,10 @@ InferLayoutOutput InferLayoutCumsum(const Call& call,
                                     const Map<String, Array<String>>& desired_layouts,
                                     VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutConcatenate(const Call& call,
+                                         const Map<String, Array<String>>& desired_layouts,
+                                         VarLayoutMap var_layout_map);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -765,6 +765,102 @@ def test_conv2d_cumsum_default_axis():
     tvm.ir.assert_structural_equal(mod, conv2d_cumsum_default_axis)
 
 
+@I.ir_module
+class conv2d_relu_concat:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv2)
+        gv4: R.Tensor((2, 26, 26, 8), dtype="float32") = R.concatenate((gv2, gv3), axis=3)
+        gv5: R.Tensor((2, 8, 26, 26), dtype="float32") = R.transpose(gv4, axes=[0, 3, 1, 2])
+        return gv5
+
+
+def test_conv2d_relu_concat():
+    @I.ir_module
+    class Conv2dReLUConcat:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), "float32") = R.nn.relu(gv)
+            gv3: R.Tensor((2, 8, 26, 26), "float32") = R.concatenate((gv, gv2), axis=1)
+            return gv3
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dReLUConcat)
+    tvm.ir.assert_structural_equal(mod, conv2d_relu_concat)
+
+
+@I.ir_module
+class conv2d_relu_concat_split:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tuple(R.Tensor(None, dtype="float32", ndim=4), R.Tensor(None, dtype="float32", ndim=4)):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.relu(gv2)
+        gv4: R.Tensor((2, 26, 26, 8), dtype="float32") = R.concatenate((gv2, gv3), axis=3)
+        gv5: R.Tensor((2, 8, 26, 26), dtype="float32") = R.transpose(gv4, axes=[0, 3, 1, 2])
+        gv6: R.Tuple(
+            R.Tensor((2, 4, 26, 26), dtype="float32"), R.Tensor((2, 4, 26, 26), dtype="float32")
+        ) = R.split(gv5, indices_or_sections=2, axis=1)
+        return gv6
+
+
+def test_conv2d_relu_concat_split():
+    @I.ir_module
+    class Conv2dReLUConcatSplit:
+        @R.function
+        def main(x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2: R.Tensor((2, 4, 26, 26), "float32") = R.nn.relu(gv)
+            gv3: R.Tensor((2, 8, 26, 26), "float32") = R.concatenate((gv, gv2), axis=1)
+            gv4 = R.split(gv3, indices_or_sections=2, axis=1)
+            return gv4
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dReLUConcatSplit)
+    tvm.ir.assert_structural_equal(mod, conv2d_relu_concat_split)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -781,3 +877,5 @@ if __name__ == "__main__":
     test_conv2d_strided_slice()
     test_conv2d_cumsum()
     test_conv2d_cumsum_default_axis()
+    test_conv2d_relu_concat()
+    test_conv2d_relu_concat_split()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [x] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops https://github.com/mlc-ai/relax/pull/64
  - [x] M1.1:  Binary ops https://github.com/mlc-ai/relax/pull/65
  - [x] M1.2: Tenary ops https://github.com/mlc-ai/relax/pull/66
- [ ] M2: Introduce rules for broadcastable ops which require manipulation of attrs
  - [x] M2.0: reduce ops https://github.com/mlc-ai/relax/pull/68
  - [x] M2.1: transpose, expand-dims, squeeze, strided_slice, take, cumsum https://github.com/mlc-ai/relax/pull/69
  - [x] M2.2: concat, split https://github.com/mlc-ai/relax/pull/70
  - [ ] M2.3: dropout, cast, wrapparam, init
  - [ ] M2.4: MaxPool2D, softmax, BatchNorm, LayerNorm, resize2d