### PR TITLE
[CUTLASS] Convert Layout M2.3 & M2.4

### DIFF
--- a/src/relax/op/image/resize.cc
+++ b/src/relax/op/image/resize.cc
@@ -35,7 +35,8 @@ RELAX_REGISTER_OP("relax.image.resize2d")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferShape>("FInferShape", InferShapeResize2d)
-    .set_attr<FInferType>("FInferType", InferTypeResize2d);
+    .set_attr<FInferType>("FInferType", InferTypeResize2d)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutResize2d);
 
 Expr MakeResize2D(Expr data, Array<PrimExpr> size, Array<FloatImm> roi, String layout,
                   String method, String coordinate_transformation_mode, String rounding_method,

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -107,7 +107,8 @@ RELAX_REGISTER_OP("relax.nn.batch_norm")
     .add_argument("moving_mean", "Tensor", "Running mean of input.")
     .add_argument("moving_var", "Tensor", "Running variance of input.")
     .set_attr<FInferShape>("FInferShape", InferShapeBatchNorm)
-    .set_attr<FInferType>("FInferType", InferTypeBatchNorm);
+    .set_attr<FInferType>("FInferType", InferTypeBatchNorm)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutBatchNorm);
 
 Expr MakeBatchNorm(Expr data, Expr gamma, Expr beta, Expr moving_mean, Expr moving_var,  //
                    int axis, double epsilon, bool center, bool scale) {

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -294,7 +294,8 @@ RELAX_REGISTER_OP("relax.nn.layer_norm")
     .add_argument("gamma", "Tensor", "The gamma scale factor.")
     .add_argument("beta", "Tensor", "The beta offset factor.")
     .set_attr<FInferShape>("FInferShape", InferShapeLayerNorm)
-    .set_attr<FInferType>("FInferType", InferTypeLayerNorm);
+    .set_attr<FInferType>("FInferType", InferTypeLayerNorm)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutLayerNorm);
 
 Expr MakeLayerNorm(Expr data, Expr gamma, Expr beta, Array<Integer> axis, double epsilon,
                    bool center, bool scale) {

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -240,7 +240,8 @@ RELAX_REGISTER_OP("relax.nn.dropout")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "Input to which dropout will be applied.")
     .set_attr<FInferShape>("FInferShape", InferShapeDropout)
-    .set_attr<FInferType>("FInferType", InferTypeDropout);
+    .set_attr<FInferType>("FInferType", InferTypeDropout)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise);
 
 Expr MakeDropout(Expr data, double rate) {
   ObjectPtr<DropoutAttrs> attrs = make_object<DropoutAttrs>();

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -119,7 +119,6 @@ Expr InferShapeMaxPool2d(const Call& call, DiagnosticContext diag_ctx) {
   }
 }
 
-
 RELAX_REGISTER_OP("relax.nn.max_pool2d")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor")
@@ -155,7 +154,8 @@ RELAX_REGISTER_OP("relax.nn.adaptive_avg_pool2d")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor")
     .set_attr<FInferShape>("FInferShape", InferShapeAdaptiveAvgPool2D)
-    .set_attr<FInferType>("FInferType", InferTypeUnaryBroadcast);
+    .set_attr<FInferType>("FInferType", InferTypeUnaryBroadcast)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutAdaptiveAvgPool2D);
 
 Expr MakeAdaptiveAvgPool2D(Expr data, Optional<Array<PrimExpr>> output_size, String layout) {
   ObjectPtr<AdaptivePool2DAttrs> attrs = make_object<AdaptivePool2DAttrs>();

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -737,7 +737,8 @@ RELAX_REGISTER_OP("relax.cast")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor")
     .set_attr<FInferShape>("FInferShape", InferShapeCast)
-    .set_attr<FInferType>("FInferType", InferTypeCast);
+    .set_attr<FInferType>("FInferType", InferTypeCast)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise);
 
 Expr MakeCast(Expr data, DataType dtype) {
   ObjectPtr<CastAttrs> attrs = make_object<CastAttrs>();
@@ -780,7 +781,8 @@ RELAX_REGISTER_OP("relax.wrap_param")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor")
     .set_attr<FInferShape>("FInferShape", InferShapeWrapParam)
-    .set_attr<FInferType>("FInferType", InferTypeWrapParam);
+    .set_attr<FInferType>("FInferType", InferTypeWrapParam)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutUnaryEwise);
 
 Expr MakeWrapParam(Expr data, DataType dtype) {
   ObjectPtr<WrapParamAttrs> attrs = make_object<WrapParamAttrs>();

--- a/src/relax/op/tensor/transform.cc
+++ b/src/relax/op/tensor/transform.cc
@@ -1327,7 +1327,8 @@ RELAX_REGISTER_OP("relax.split")
     .set_num_inputs(1)
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attr<FInferShape>("FInferShape", InferShapeSplit)
-    .set_attr<FInferType>("FInferType", InferTypeSplit);
+    .set_attr<FInferType>("FInferType", InferTypeSplit)
+    .set_attr<FRelaxInferLayout>("FRelaxInferLayout", InferLayoutSplit);
 
 Expr MakeSplit(Expr data, ObjectRef indices_or_sections, int axis) {
   ObjectPtr<SplitAttrs> attrs = make_object<SplitAttrs>();

--- a/src/relax/transform/infer_layout_utils.cc
+++ b/src/relax/transform/infer_layout_utils.cc
@@ -108,6 +108,29 @@ InferLayoutOutput InferLayoutConv2d(const Call& call,
   return InferLayoutOutput({data_layout, weight_layout}, {output_layout}, Attrs(new_attrs));
 }
 
+InferLayoutOutput InferLayoutPool2d(const Call& call,
+                                    const Map<String, Array<String>>& desired_layouts,
+                                    VarLayoutMap var_layout_map) {
+  const OpNode* op_node = call->op.as<OpNode>();
+  ICHECK(op_node != nullptr && op_node->name == "relax.nn.max_pool2d") << "Invalid Call";
+  const auto& it = desired_layouts.find(op_node->name);
+  ICHECK(it == desired_layouts.end()) << "Unsupported desired layout for " << op_node->name;
+  ICHECK_EQ(call->args.size(), 1) << "Invalid Call";
+  const auto* type = call->args[0]->checked_type().as<DynTensorTypeNode>();
+  ICHECK(type != nullptr) << "Invalid Call";
+  ICHECK(type->ndim == 4) << "Invalid Call";
+  const auto* attrs = call->attrs.as<MaxPool2DAttrs>();
+  ICHECK(attrs) << "Invalid Call";
+
+  Layout layout = GetOneValidLayout(var_layout_map, call->args[0]);
+  ObjectPtr<MaxPool2DAttrs> new_attrs = make_object<MaxPool2DAttrs>(*attrs);
+  new_attrs->layout = TransposeLike(attrs->layout, InitialLayout(4), layout).name();
+  new_attrs->out_layout = TransposeLike(attrs->out_layout == "" ? attrs->layout : attrs->out_layout,
+                                        InitialLayout(4), layout)
+                              .name();
+  return InferLayoutOutput({layout}, {layout}, Attrs(new_attrs));
+}
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map) {

--- a/src/relax/transform/infer_layout_utils.cc
+++ b/src/relax/transform/infer_layout_utils.cc
@@ -131,6 +131,26 @@ InferLayoutOutput InferLayoutPool2d(const Call& call,
   return InferLayoutOutput({layout}, {layout}, Attrs(new_attrs));
 }
 
+InferLayoutOutput InferLayoutAdaptiveAvgPool2D(const Call& call,
+                                               const Map<String, Array<String>>& desired_layouts,
+                                               VarLayoutMap var_layout_map) {
+  const OpNode* op_node = call->op.as<OpNode>();
+  ICHECK(op_node != nullptr && op_node->name == "relax.nn.adaptive_avg_pool2d") << "Invalid Call";
+  const auto& it = desired_layouts.find(op_node->name);
+  ICHECK(it == desired_layouts.end()) << "Unsupported desired layout for " << op_node->name;
+  ICHECK_EQ(call->args.size(), 1) << "Invalid Call";
+  const auto* type = call->args[0]->checked_type().as<DynTensorTypeNode>();
+  ICHECK(type != nullptr) << "Invalid Call";
+  ICHECK(type->ndim == 4) << "Invalid Call";
+  const auto* attrs = call->attrs.as<AdaptivePool2DAttrs>();
+  ICHECK(attrs) << "Invalid Call";
+
+  Layout layout = GetOneValidLayout(var_layout_map, call->args[0]);
+  ObjectPtr<AdaptivePool2DAttrs> new_attrs = make_object<AdaptivePool2DAttrs>(*attrs);
+  new_attrs->layout = TransposeLike(attrs->layout, InitialLayout(4), layout).name();
+  return InferLayoutOutput({layout}, {layout}, Attrs(new_attrs));
+}
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map) {

--- a/src/relax/transform/infer_layout_utils.cc
+++ b/src/relax/transform/infer_layout_utils.cc
@@ -228,6 +228,35 @@ InferLayoutOutput InferLayoutBatchNorm(const Call& call,
       {{layout, initial_layouts[3], initial_layouts[4]}}, Attrs(new_attrs));
 }
 
+InferLayoutOutput InferLayoutLayerNorm(const Call& call,
+                                       const Map<String, Array<String>>& desired_layouts,
+                                       VarLayoutMapWrapper var_layout_map) {
+  const OpNode* op_node = call->op.as<OpNode>();
+  ICHECK(op_node != nullptr && op_node->name == "relax.nn.layer_norm") << "Invalid Call";
+  const auto& it = desired_layouts.find(op_node->name);
+  ICHECK(it == desired_layouts.end()) << "Unsupported desired layout for " << op_node->name;
+  ICHECK_EQ(call->args.size(), 3) << "Invalid Call";
+  std::vector<NLayout> initial_layouts;
+  for (size_t i = 0; i < 3; ++i) {
+    const auto* type = call->args[i]->checked_type().as<DynTensorTypeNode>();
+    ICHECK(type != nullptr) << "Invalid Call";
+    initial_layouts.push_back(InitialLayout(type->ndim));
+  }
+  const auto* attrs = call->attrs.as<LayerNormAttrs>();
+  ICHECK(attrs) << "Invalid Call";
+
+  Layout layout = GetOneValidLayout(var_layout_map, call->args[0]);
+  ObjectPtr<LayerNormAttrs> new_attrs = make_object<LayerNormAttrs>(*attrs);
+  std::vector<Integer> new_axis;
+  for (const auto& axis : attrs->axis) {
+    int axis_int = (axis.IntValue() + layout.ndim()) % layout.ndim();
+    new_axis.push_back(layout.name().find('A' + axis_int));
+  }
+  new_attrs->axis = new_axis;
+  return InferLayoutOutput({layout, initial_layouts[1], initial_layouts[2]}, {layout},
+                           Attrs(new_attrs));
+}
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMapWrapper var_layout_map) {

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -111,6 +111,10 @@ InferLayoutOutput InferLayoutConv2d(const Call& call,
                                     const Map<String, Array<String>>& desired_layouts,
                                     VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutPool2d(const Call& call,
+                                    const Map<String, Array<String>>& desired_layouts,
+                                    VarLayoutMap var_layout_map);
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map);

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -32,6 +32,8 @@
 #include <tvm/relax/op_attr_types.h>
 #include <tvm/tir/data_layout.h>
 
+#include "../op/tensor/transform.h"
+
 namespace tvm {
 namespace relax {
 
@@ -212,6 +214,10 @@ InferLayoutOutput InferLayoutCumsum(const Call& call,
 InferLayoutOutput InferLayoutConcatenate(const Call& call,
                                          const Map<String, Array<String>>& desired_layouts,
                                          VarLayoutMapWrapper var_layout_map);
+
+InferLayoutOutput InferLayoutSplit(const Call& call,
+                                   const Map<String, Array<String>>& desired_layouts,
+                                   VarLayoutMapWrapper var_layout_map);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -175,6 +175,10 @@ InferLayoutOutput InferLayoutBatchNorm(const Call& call,
                                        const Map<String, Array<String>>& desired_layouts,
                                        VarLayoutMapWrapper var_layout_map);
 
+InferLayoutOutput InferLayoutLayerNorm(const Call& call,
+                                       const Map<String, Array<String>>& desired_layouts,
+                                       VarLayoutMapWrapper var_layout_map);
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMapWrapper var_layout_map);

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -86,7 +86,17 @@ struct NLayoutEqual {
   }
 };
 
-using LayoutMap = std::unordered_map<NLayout, Var, ObjectPtrHash, NLayoutEqual>;
+struct NLayoutHash {
+  size_t operator()(const NLayout& a) const {
+    std::string res = "";
+    auto fvisit = [&res](const Layout& l) { res += l.name(); };
+    ForEachLeaf(a, fvisit);
+    String str = String(res);
+    return String::HashBytes(str.data(), str.size());
+  }
+};
+
+using LayoutMap = std::unordered_map<NLayout, Var, NLayoutHash, NLayoutEqual>;
 using VarLayoutMap = std::unordered_map<Var, LayoutMap, ObjectPtrHash, ObjectPtrEqual>;
 
 class VarLayoutMapWrapperNode : public Object {

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -179,6 +179,10 @@ InferLayoutOutput InferLayoutLayerNorm(const Call& call,
                                        const Map<String, Array<String>>& desired_layouts,
                                        VarLayoutMapWrapper var_layout_map);
 
+InferLayoutOutput InferLayoutResize2d(const Call& call,
+                                      const Map<String, Array<String>>& desired_layouts,
+                                      VarLayoutMapWrapper var_layout_map);
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMapWrapper var_layout_map);

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -115,6 +115,10 @@ InferLayoutOutput InferLayoutPool2d(const Call& call,
                                     const Map<String, Array<String>>& desired_layouts,
                                     VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutAdaptiveAvgPool2D(const Call& call,
+                                               const Map<String, Array<String>>& desired_layouts,
+                                               VarLayoutMap var_layout_map);
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map);

--- a/src/relax/transform/infer_layout_utils.h
+++ b/src/relax/transform/infer_layout_utils.h
@@ -119,6 +119,10 @@ InferLayoutOutput InferLayoutAdaptiveAvgPool2D(const Call& call,
                                                const Map<String, Array<String>>& desired_layouts,
                                                VarLayoutMap var_layout_map);
 
+InferLayoutOutput InferLayoutSoftmax(const Call& call,
+                                     const Map<String, Array<String>>& desired_layouts,
+                                     VarLayoutMap var_layout_map);
+
 InferLayoutOutput InferLayoutUnaryEwise(const Call& call,
                                         const Map<String, Array<String>>& desired_layouts,
                                         VarLayoutMap var_layout_map);

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -969,6 +969,51 @@ def test_conv2d_avgpool2d():
     tvm.ir.assert_structural_equal(mod, conv2d_avgpool2d)
 
 
+@I.ir_module
+class conv2d_softmax:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.softmax(gv2, axis=3)
+        gv4: R.Tensor((2, 4, 26, 26), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
+        return gv4
+
+
+def test_conv2d_softmax():
+    @I.ir_module
+    class Conv2dSoftmax:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2 = R.nn.softmax(gv, axis=1)
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dSoftmax)
+    tvm.ir.assert_structural_equal(mod, conv2d_softmax)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -989,3 +1034,4 @@ if __name__ == "__main__":
     test_conv2d_relu_concat_split()
     test_conv2d_maxpool2d()
     test_conv2d_avgpool2d()
+    test_conv2d_softmax()

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -1144,6 +1144,64 @@ def test_conv2d_layernorm():
     tvm.ir.assert_structural_equal(mod, conv2d_layernorm)
 
 
+@I.ir_module
+class conv2d_resize2d:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"),
+        w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 52, 52, 4), dtype="float32") = R.image.resize2d(
+            gv2,
+            size=[52, 52],
+            roi=[0.000000, 0.000000, 0.000000, 0.000000],
+            layout="NHWC",
+            method="linear",
+            coordinate_transformation_mode="half_pixel",
+            rounding_method="round",
+            cubic_alpha=-0.5,
+            cubic_exclude=0,
+            extrapolation_value=0,
+        )
+        gv4: R.Tensor((2, 4, 52, 52), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
+        return gv4
+
+
+def test_conv2d_resize2d():
+    @I.ir_module
+    class Conv2dResize2d:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"),
+            w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2 = R.image.resize2d(gv, size=[52, 52], layout="NCHW")
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dResize2d)
+    tvm.ir.assert_structural_equal(mod, conv2d_resize2d)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -1167,3 +1225,4 @@ if __name__ == "__main__":
     test_conv2d_softmax()
     test_conv2d_batchnorm()
     test_conv2d_layernorm()
+    test_conv2d_resize2d()

--- a/tests/python/relax/test_transform_convert_layout.py
+++ b/tests/python/relax/test_transform_convert_layout.py
@@ -861,6 +861,67 @@ def test_conv2d_relu_concat_split():
     tvm.ir.assert_structural_equal(mod, conv2d_relu_concat_split)
 
 
+@I.ir_module
+class conv2d_maxpool2d:
+    @R.function
+    def main(
+        x: R.Tensor((2, 3, 28, 28), dtype="float32"), w: R.Tensor((4, 3, 3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=4):
+        # block 0
+        gv: R.Tensor((2, 28, 28, 3), dtype="float32") = R.transpose(x, axes=[0, 2, 3, 1])
+        gv1: R.Tensor((4, 3, 3, 3), dtype="float32") = R.transpose(w, axes=[0, 2, 3, 1])
+        gv2: R.Tensor((2, 26, 26, 4), dtype="float32") = R.nn.conv2d(
+            gv,
+            gv1,
+            strides=[1, 1],
+            padding=[0, 0, 0, 0],
+            dilation=[1, 1],
+            groups=1,
+            channels=None,
+            kernel_size=[3, 3],
+            data_layout="NHWC",
+            kernel_layout="OHWI",
+            out_layout="NHWC",
+            out_dtype="float32",
+        )
+        gv3: R.Tensor((2, 13, 13, 4), dtype="float32") = R.nn.max_pool2d(
+            gv2,
+            pool_size=[2, 2],
+            strides=[2, 2],
+            dilation=[1, 1],
+            padding=[0, 0, 0, 0],
+            layout="NHWC",
+            out_layout="NHWC",
+            ceil_mode=False,
+        )
+        gv4: R.Tensor((2, 4, 13, 13), dtype="float32") = R.transpose(gv3, axes=[0, 3, 1, 2])
+        return gv4
+
+
+def test_conv2d_maxpool2d():
+    @I.ir_module
+    class Conv2dMaxPool2d:
+        @R.function
+        def main(
+            x: R.Tensor((2, 3, 28, 28), "float32"), w: R.Tensor((4, 3, 3, 3), "float32")
+        ) -> R.Tensor(None, "float32", ndim=4):
+            gv: R.Tensor((2, 4, 26, 26), "float32") = R.nn.conv2d(
+                x, w, kernel_size=[3, 3], out_dtype="float32"
+            )
+            gv2 = R.nn.max_pool2d(
+                gv,
+                pool_size=[2, 2],
+                strides=[2, 2],
+                padding=[0, 0],
+                layout="NCHW",
+                out_layout="NCHW",
+            )
+            return gv2
+
+    mod = ConvertLayout({"relax.nn.conv2d": ["NHWC", "OHWI"]})(Conv2dMaxPool2d)
+    tvm.ir.assert_structural_equal(mod, conv2d_maxpool2d)
+
+
 if __name__ == "__main__":
     test_conv2d()
     test_conv2d_relu()
@@ -879,3 +940,4 @@ if __name__ == "__main__":
     test_conv2d_cumsum_default_axis()
     test_conv2d_relu_concat()
     test_conv2d_relu_concat_split()
+    test_conv2d_maxpool2d()


### PR DESCRIPTION
- [x] M0: Introduce Convert Layout pass and the rule to convert Conv2D layout https://github.com/mlc-ai/relax/pull/63
- [x] M1: Introduce rules for layout agnostic ops that are directly propagatable.
  - [x] M1.0: Unary ops https://github.com/mlc-ai/relax/pull/64
  - [x] M1.1:  Binary ops https://github.com/mlc-ai/relax/pull/65
  - [x] M1.2: Tenary ops https://github.com/mlc-ai/relax/pull/66
- [x] M2: Introduce rules for broadcastable ops which require manipulation of attrs
  - [x] M2.0: reduce ops https://github.com/mlc-ai/relax/pull/68
  - [x] M2.1: transpose, expand-dims, squeeze, strided_slice, take, cumsum https://github.com/mlc-ai/relax/pull/69
  - [x] M2.2: concat, split https://github.com/mlc-ai/relax/pull/70
  - [x] M2.3: dropout, cast, wrapparam, init https://github.com/mlc-ai/relax/pull/71
  - [x] M2.4: MaxPool2D, AdaptiveAvgPool2D, softmax, BatchNorm, LayerNorm, resize2d https://github.com/mlc-ai/relax/pull/71