### PR TITLE
[Op][NN2] BatchNorm, LayerNorm, Matmul, Dropout, CrossEntropy

### DIFF
--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -222,6 +222,57 @@ struct AssertOpAttrs : public tvm::AttrsNode<AssertOpAttrs> {
   }
 };
 
+/*! \brief Attributes used in batch_norm operator */
+struct BatchNormAttrs : public tvm::AttrsNode<BatchNormAttrs> {
+  int axis;
+  double epsilon;
+  bool center;
+  bool scale;
+
+  TVM_DECLARE_ATTRS(BatchNormAttrs, "relax.attrs.BatchNormAttrs") {
+    TVM_ATTR_FIELD(axis).describe("The axis along which the normalization is applied.");
+    TVM_ATTR_FIELD(epsilon).describe("Small float added to variance to avoid dividing by zero");
+    TVM_ATTR_FIELD(center).describe(
+        "Indicating if the beta offset will be added to the normalized tensor.");
+    TVM_ATTR_FIELD(scale).describe("Indicating if the gamma scale will be multiplied.");
+  }
+};  // struct BatchNormAttrs
+
+/*! \brief Attributes used in layer_norm operator */
+struct LayerNormAttrs : public tvm::AttrsNode<LayerNormAttrs> {
+  Array<Integer> axes;
+  double epsilon;
+  bool center;
+  bool scale;
+
+  TVM_DECLARE_ATTRS(LayerNormAttrs, "relax.attrs.LayerNormAttrs") {
+    TVM_ATTR_FIELD(axes).describe("The axes that along which the normalization is applied.");
+    TVM_ATTR_FIELD(epsilon).describe("Small float added to variance to avoid dividing by zero");
+    TVM_ATTR_FIELD(center).describe(
+        "Indicating if the beta offset will be added to the normalized tensor.");
+    TVM_ATTR_FIELD(scale).describe("Indicating if the gamma scale will be multiplied.");
+  }
+};  // struct LayerNormAttrs
+
+/*! \brief Attributes for matmul operator */
+struct MatmulAttrs : public tvm::AttrsNode<MatmulAttrs> {
+  DataType out_dtype;
+
+  TVM_DECLARE_ATTRS(MatmulAttrs, "relax.attrs.MatmulAttrs") {
+    TVM_ATTR_FIELD(out_dtype).describe("The data type of the output tensor");
+  }
+};  // struct MatmulAttrs
+
+/*! \brief Attributes used in dropout operator */
+struct DropoutAttrs : public tvm::AttrsNode<DropoutAttrs> {
+  double rate;
+
+  TVM_DECLARE_ATTRS(DropoutAttrs, "relax.attrs.DropoutAttrs") {
+    TVM_ATTR_FIELD(rate).describe(
+        "Fraction of the input that gets dropped out during training time");
+  }
+};  // struct DropoutAttrs
+
 }  // namespace relax
 }  // namespace tvm
 #endif  // TVM_RELAX_OP_ATTR_TYPES_H_

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -391,7 +391,7 @@ def batch_norm(
         The beta offset factor.
 
     moving_mean : relax.Expr
-        Running mean of input,
+        Running mean of input.
 
     moving_var : relax.Expr
         Running variance of input.

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Relax Neural Network (NN) operators"""
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from tvm.ir.expr import PrimExpr
 
@@ -326,3 +326,258 @@ def softmax(data: Expr, axis: int = -1) -> Expr:
         The computed result.
     """
     return _ffi_api.softmax(data, axis)  # type: ignore
+
+
+def batch_norm(
+    data: Expr,
+    gamma: Expr,
+    beta: Expr,
+    moving_mean: Expr,
+    moving_var: Expr,
+    axis: int,
+    epsilon: float = 1e-5,
+    center: bool = True,
+    scale: bool = True,
+) -> Expr:
+    r"""
+    Batch normalization layer (Ioffe and Szegedy, 2014).
+    Normalizes the input at each batch, i.e. applies a transformation
+    that maintains the mean activation close to 0 and the activation
+    standard deviation close to 1.
+
+    .. math::
+
+        data\_mean[i] = mean(data[:,i,:,...]) \\
+        data\_var[i] = var(data[:,i,:,...])
+
+    Then compute the normalized output, which has the same shape as input, as following:
+
+    .. math::
+
+        out[:,i,:,...] = \frac{data[:,i,:,...] - data\_mean[i]}{\sqrt{data\_var[i]+\epsilon}}
+            * gamma[i] + beta[i]
+
+    Both *mean* and *var* returns a scalar by treating the input as a vector.
+
+    Assume the input has size *k* on axis 1, then both ``gamma`` and ``beta``
+    have shape *(k,)*.
+
+    Besides the inputs and the outputs, this operator accepts two auxiliary
+    states, ``moving_mean`` and ``moving_var``, which are *k*-length
+    vectors. They are global statistics for the whole dataset, which are updated by
+
+    .. code:: python
+
+        moving_mean = moving_mean * momentum + data_mean * (1 - momentum)
+        moving_var = moving_var * momentum + data_var * (1 - momentum)
+
+    The parameter ``axis`` specifies which axis of the input shape denotes
+    the 'channel' (separately normalized groups).  The default is 1.
+    Specifying -1 sets the channel axis to be the last item in the input shape.
+
+    .. note::
+
+        This operator can be optimized away for inference.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input data to the operator.
+
+    gamma : relax.Expr
+        The gamma scale factor.
+
+    beta : relax.Expr
+        The beta offset factor.
+
+    moving_mean : relax.Expr
+        Running mean of input,
+
+    moving_var : relax.Expr
+        Running variance of input.
+
+    axis : int
+        The axis along which the normalization is applied.
+
+    epsilon : float
+        Small float added to variance to avoid dividing by zero.
+
+    center : bool
+        Indicating if the beta offset will be added to the normalized tensor.
+
+    scale : bool
+        Indicating if the gamma scale will be multiplied.
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    return _ffi_api.batch_norm(  # type: ignore
+        data, gamma, beta, moving_mean, moving_var, axis, epsilon, center, scale
+    )
+
+
+def layer_norm(
+    data: Expr,
+    gamma: Expr,
+    beta: Expr,
+    axes: Union[int, List[int]],
+    epsilon: float = 1e-5,
+    center: bool = True,
+    scale: bool = True,
+) -> Expr:
+    r"""
+    Layer normalization (Lei Ba and et al., 2016).
+    Applies layer normalization to the n-dimensional input array.
+    This operator takes an n-dimensional input array and normalizes
+    the input using the given axis:
+
+    .. math::
+
+        out = \frac{data - mean(data, axis)}{\sqrt{var(data, axis)+\epsilon}}
+            * gamma + beta
+
+    Unlike batch normalization, the mean and var are computed along the channel dimension.
+
+    Assume the input has size k on axis 1, then both gamma and beta have shape (k,).
+
+    .. note::
+
+        This operator can be optimized away for inference.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        Input to which layer_norm will be applied.
+
+    gamma : relax.Expr
+        The gamma scale factor.
+
+    beta : relax.Expr
+        The beta offset factor.
+
+    axes : Union[int, List[int]]
+        The axes that along which the normalization is applied.
+
+    epsilon : float
+        Small float added to variance to avoid dividing by zero.
+
+    center : bool
+        Indicating if the beta offset will be added to the normalized tensor.
+
+    scale : bool
+        Indicating if the gamma scale will be multiplied.
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    if isinstance(axes, int):
+        axes = [axes]
+    return _ffi_api.layer_norm(data, gamma, beta, axes, epsilon, center, scale)  # type: ignore
+
+
+def matmul(a: Expr, b: Expr, out_dtype: Optional[str] = None) -> Expr:
+    """General matrix multiplication of two tensors.
+
+    (The below is copied from torch.matmul)
+    The behavior depends on the dimensionality of the tensors as follows:
+    * If both tensors are 1-dimensional, the dot product (scalar) is returned.
+    * If both arguments are 2-dimensional, the matrix-matrix product is returned.
+    * If the first argument is 1-dimensional and the second argument is 2-dimensional,
+      a 1 is prepended to its dimension for the purpose of the matrix multiply. After the
+      matrix multiply, the prepended dimension is removed.
+    * If the first argument is 2-dimensional and the second argument is 1-dimensional,
+      the matrix-vector product is returned.
+    * If both arguments are at least 1-dimensional and at least one argument is N-dimensional
+      (where N > 2), then a batched matrix multiply is returned. If the first argument is
+      1-dimensional, a 1 is prepended to its dimension for the purpose of the batched
+      matrix multiply and removed after. If the second argument is 1-dimensional, a 1 is
+      appended to its dimension for the purpose of the batched matrix multiple and remove
+      after. The non-matrix (i.e. batch) dimensions are broadcasted (and thus must be
+      broadcastable). For example, if `a` is a `(j, 1, n, n)` tensor and `b` is a `(k, n, n)`
+      tensor, the result will be a `(j, k, n, n)` tensor.
+
+    Parameters
+    ----------
+    a : relax.Expr
+        The left operand of the matmul.
+
+    b : relax.Expr
+        The right operand of the matmul.
+
+    out_dtype: Optional[str]
+        The data type of the matmul result.
+        When it is not specified, the output dtype will be the the same as input dtype.
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result.
+    """
+    return _ffi_api.matmul(a, b, out_dtype)  # type: ignore
+
+
+def dropout(data: Expr, rate: float = 0.5) -> Expr:
+    """Applies the dropout operation to the input array.
+
+    During training, each element of the input is set to zero with
+    probability ``p``. The whole array is scaled by ``1/(1-p)``
+    to keep the expected sum of the input unchanged.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input data to the operator.
+
+    rate : float
+        The probability for an element to be reset to 0.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result of dropout, which is a tuple of two tensors.
+        The first one is the original tensor and the second one is a
+        mask tensor (1.0 where element not dropped, 0.0 where dropped)
+    """
+    return _ffi_api.dropout(data, rate)  # type: ignore
+
+
+def cross_entropy(predictions: Expr, targets: Expr) -> Expr:
+    """CrossEntropy without logits.
+
+    Parameters
+    ----------
+    predictions : relax.Expr
+      The predictions.
+
+    targets : relax.Expr
+      The targets.
+
+    Returns
+    -------
+    result : relax.Expr
+      The computed result.
+    """
+    return _ffi_api.cross_entropy(predictions, targets)  # type: ignore
+
+
+def softmax_cross_entropy(predictions: Expr, targets: Expr) -> Expr:
+    """Computes the softmax cross entropy between predictions and targets.
+
+    Parameters
+    ----------
+    predictions : relax.Expr
+      The predictions.
+
+    targets : relax.Expr
+      The targets.
+
+    Returns
+    -------
+    result : relax.Expr
+      The computed result.
+    """
+    return _ffi_api.softmax_cross_entropy(predictions, targets)  # type: ignore

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -77,3 +77,23 @@ class AdaptivePool2DAttrs(Attrs):
 @tvm._ffi.register_object("relax.attrs.SoftmaxAttrs")
 class SoftmaxAttrs(Attrs):
     """Attributes for nn.softmax"""
+
+
+@tvm._ffi.register_object("relax.attrs.BatchNormAttrs")
+class BatchNormAttrs(Attrs):
+    """Attributes used in batch_norm operator"""
+
+
+@tvm._ffi.register_object("relax.attrs.LayerNormAttrs")
+class LayerNormAttrs(Attrs):
+    """Attributes used in layer_norm operator"""
+
+
+@tvm._ffi.register_object("relax.attrs.MatmulAttrs")
+class MatmulAttrs(Attrs):
+    """Attributes for matmul operator"""
+
+
+@tvm._ffi.register_object("relax.attrs.DropoutAttrs")
+class DropoutAttrs(Attrs):
+    """Attributes for dropout operator"""

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -57,7 +57,10 @@ Expr MakeConv2D(Expr data, Expr weight, Array<PrimExpr> strides, Array<PrimExpr>
 TVM_REGISTER_GLOBAL("relax.op.nn.conv2d").set_body_typed(MakeConv2D);
 
 StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
-  auto [data_sinfo, weight_sinfo] = GetBinaryInputTensorStructInfo(call, ctx, /*op_name=*/"Conv2D");
+  Array<TensorStructInfo> input_sinfo =
+      GetInputTensorStructInfo(call, ctx, /*input_names=*/{"data", "weight"}, /*op_name=*/"Conv2D");
+  TensorStructInfo data_sinfo = input_sinfo[0];
+  TensorStructInfo weight_sinfo = input_sinfo[1];
 
   const auto* attrs = call->attrs.as<Conv2DAttrs>();
   auto [data_layout, data2NCHW] = CheckTensorLayout(call, ctx, attrs->data_layout,  //
@@ -91,7 +94,7 @@ StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
   arith::Analyzer* analyzer = ctx->GetAnalyzer();
   PrimExpr input_channel_data = data_NCHW_shape[1];
   PrimExpr input_channel_kernel = weight_OIHW_shape[1];
-  if (analyzer->CanProve(input_channel_data - input_channel_kernel != 0)) {
+  if (analyzer->CanProve(input_channel_data != input_channel_kernel)) {
     ctx->ReportFatal(Diagnostic::Error(call->span)
                      << "The channel size of the data should equal to the input channel size of "
                         "the weight. However, the data channel size is "

--- a/src/relax/op/nn/convolution.cc
+++ b/src/relax/op/nn/convolution.cc
@@ -57,29 +57,25 @@ Expr MakeConv2D(Expr data, Expr weight, Array<PrimExpr> strides, Array<PrimExpr>
 TVM_REGISTER_GLOBAL("relax.op.nn.conv2d").set_body_typed(MakeConv2D);
 
 StructInfo InferStructInfoConv2d(const Call& call, const BlockBuilder& ctx) {
-  Array<TensorStructInfo> input_sinfo =
-      GetInputTensorStructInfo(call, ctx, /*input_names=*/{"data", "weight"}, /*op_name=*/"Conv2D");
+  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
   TensorStructInfo data_sinfo = input_sinfo[0];
   TensorStructInfo weight_sinfo = input_sinfo[1];
 
   const auto* attrs = call->attrs.as<Conv2DAttrs>();
   auto [data_layout, data2NCHW] = CheckTensorLayout(call, ctx, attrs->data_layout,  //
                                                     /*tgt_layout=*/"NCHW",          //
-                                                    /*op_name=*/"Conv2D",           //
                                                     /*tensor_name=*/"data");
   auto [weight_layout, weight2OIHW] = CheckTensorLayout(call, ctx, attrs->kernel_layout,  //
                                                         /*tgt_layout=*/"OIHW",            //
-                                                        /*op_name=*/"Conv2D",             //
                                                         /*tensor_name=*/"kernel");
   auto [out_layout, out2NCHW] = CheckTensorLayout(call, ctx, attrs->out_layout,  //
                                                   /*tgt_layout=*/"NCHW",         //
-                                                  /*op_name=*/"Conv2D",          //
                                                   /*tensor_name=*/"output");
 
   Optional<ShapeExpr> data_shape =
-      CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout, /*op_name=*/"Conv2D");
+      CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout);
   Optional<ShapeExpr> weight_shape =
-      CheckNdimPerLayoutAndGetShape(call, ctx, weight_sinfo, weight_layout, /*op_name=*/"Conv2D");
+      CheckNdimPerLayoutAndGetShape(call, ctx, weight_sinfo, weight_layout);
 
   DataType out_dtype = attrs->out_dtype.is_void()
                            ? InferBinaryArithOpOutDtype(call, ctx, data_sinfo, weight_sinfo)

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -48,16 +48,8 @@ StructInfo InferStructInfoSoftmax(const Call& call, const BlockBuilder& ctx) {
   if (data_sinfo->IsUnknownNdim()) {
     return data_sinfo;
   }
-
   const auto* attrs = call->attrs.as<SoftmaxAttrs>();
-  int axis = attrs->axis;
-  int ndim = data_sinfo->ndim;
-  if (axis < -ndim || axis >= ndim) {
-    ctx->ReportFatal(Diagnostic::Error(call)
-                     << "The input axis " << axis << " is out of range. The input tensor has "
-                     << ndim << " dimensions, so axis should be in range [" << -ndim << ", " << ndim
-                     << ").");
-  }
+  CheckAxisInRange(call, ctx, data_sinfo->ndim, attrs->axis, /*op_name=*/"Softmax");
 
   return data_sinfo;
 }
@@ -67,6 +59,338 @@ TVM_REGISTER_OP("relax.nn.softmax")
     .add_argument("data", "Tensor", "The input tensor.")
     .set_attrs_type<SoftmaxAttrs>()
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoSoftmax);
+
+bool NormCheckDtypeAndShape(const Call& call, const BlockBuilder& ctx,
+                            const Array<TensorStructInfo>& input_sinfo,
+                            const Array<String>& input_names, Array<Integer> axes,
+                            const String& op_name) {
+  TensorStructInfo data_sinfo = input_sinfo[0];
+  int n_input = input_sinfo.size();
+
+  if (!data_sinfo->IsUnknownNdim()) {
+    axes = CheckAxesInRangeNonRepetitive(call, ctx, data_sinfo->ndim, axes, op_name);
+  }
+  int n_axis = axes.size();
+
+  for (int i = 1; i < n_input; ++i) {
+    if (input_sinfo[i]->dtype != data_sinfo->dtype) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << op_name
+                       << " requires all the input tensors to have the same dtype. However, the "
+                       << input_names[i] << " has dtype " << input_sinfo[i]->dtype
+                       << " which is other than the input data's dtype " << data_sinfo->dtype);
+    } else if (input_sinfo[i]->ndim != n_axis) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << op_name << " requires the input " << input_names[i]
+                       << " to have as many dimensions as the length of input axes. However, the "
+                          "given one has ndim "
+                       << input_sinfo[i]->ndim << ", which is other than the length of axes "
+                       << n_axis);
+    }
+  }
+
+  std::vector<Array<PrimExpr>> axis_lengths;
+  axis_lengths.reserve(n_input);
+  if (const auto* data_shape = data_sinfo->shape.as<ShapeExprNode>()) {
+    std::vector<PrimExpr> lengths;
+    lengths.reserve(n_axis);
+    for (int d = 0; d < n_axis; ++d) {
+      lengths.push_back(data_shape->values[axes[d]->value]);
+    }
+    axis_lengths.push_back(lengths);
+  }
+  for (int i = 1; i < n_input; ++i) {
+    if (const auto* shape = input_sinfo[i]->shape.as<ShapeExprNode>()) {
+      axis_lengths.push_back(shape->values);
+    }
+  }
+
+  arith::Analyzer* analyzer = ctx->GetAnalyzer();
+  for (int i = 1; i < static_cast<int>(axis_lengths.size()); ++i) {
+    for (int d = 0; d < n_axis; ++d) {
+      if (analyzer->CanProve(axis_lengths[0][d] != axis_lengths[i][d])) {
+        ctx->ReportFatal(Diagnostic::Error(call)
+                         << op_name
+                         << " requires the input gamma, beta, etc., to have size same as the "
+                            "lengths of the data on the given axes. However, there exists "
+                         << axis_lengths[0] << " and " << axis_lengths[i] << " that are unequal.");
+      } else if (!analyzer->CanProveEqual(axis_lengths[0][d], axis_lengths[i][d])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/* relax.nn.batch_norm */
+TVM_REGISTER_NODE_TYPE(BatchNormAttrs);
+
+Expr MakeBatchNorm(Expr data, Expr gamma, Expr beta, Expr moving_mean, Expr moving_var,  //
+                   int axis, double epsilon, bool center, bool scale) {
+  ObjectPtr<BatchNormAttrs> attrs = make_object<BatchNormAttrs>();
+  attrs->axis = axis;
+  attrs->epsilon = epsilon;
+  attrs->center = center;
+  attrs->scale = scale;
+
+  static const Op& op = Op::Get("relax.nn.batch_norm");
+  return Call(op,
+              {std::move(data), std::move(gamma), std::move(beta), std::move(moving_mean),
+               std::move(moving_var)},
+              Attrs{attrs}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.batch_norm").set_body_typed(MakeBatchNorm);
+
+StructInfo InferStructInfoBatchNorm(const Call& call, const BlockBuilder& ctx) {
+  static const Array<String>& input_names{"data", "gamma", "beta", "moving_mean", "moving_var"};
+  Array<TensorStructInfo> input_sinfo =
+      GetInputTensorStructInfo(call, ctx, /*input_names=*/input_names, /*op_name=*/"BatchNorm");
+
+  const auto* attrs = call->attrs.as<BatchNormAttrs>();
+  bool unknown_shape = NormCheckDtypeAndShape(call, ctx, input_sinfo, input_names, {attrs->axis},
+                                              /*op_name=*/"BatchNorm");
+
+  DataType dtype = input_sinfo[0]->dtype;
+  if (unknown_shape) {
+    return TupleStructInfo({TensorStructInfo(dtype, input_sinfo[0]->ndim),
+                            TensorStructInfo(dtype, /*ndim=*/1),
+                            TensorStructInfo(dtype, /*ndim=*/1)});
+  } else {
+    return TupleStructInfo({input_sinfo[0], input_sinfo[3], input_sinfo[4]});
+  }
+}
+
+TVM_REGISTER_OP("relax.nn.batch_norm")
+    .set_attrs_type<BatchNormAttrs>()
+    .set_num_inputs(5)
+    .add_argument("data", "Tensor", "Input to which batch_norm will be applied.")
+    .add_argument("gamma", "Tensor", "The gamma scale factor.")
+    .add_argument("beta", "Tensor", "The beta offset factor.")
+    .add_argument("moving_mean", "Tensor", "Running mean of input.")
+    .add_argument("moving_var", "Tensor", "Running variance of input.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBatchNorm);
+
+/* relax.nn.layer_norm */
+TVM_REGISTER_NODE_TYPE(LayerNormAttrs);
+
+Expr MakeLayerNorm(Expr data, Expr gamma, Expr beta, Array<Integer> axes, double epsilon,
+                   bool center, bool scale) {
+  ObjectPtr<LayerNormAttrs> attrs = make_object<LayerNormAttrs>();
+  attrs->axes = std::move(axes);
+  attrs->epsilon = epsilon;
+  attrs->center = center;
+  attrs->scale = scale;
+
+  static const Op& op = Op::Get("relax.nn.layer_norm");
+  return Call(op, {std::move(data), std::move(gamma), std::move(beta)}, Attrs{attrs}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.layer_norm").set_body_typed(MakeLayerNorm);
+
+StructInfo InferStructInfoLayerNorm(const Call& call, const BlockBuilder& ctx) {
+  static const Array<String>& input_names{"data", "gamma", "beta"};
+  Array<TensorStructInfo> input_sinfo =
+      GetInputTensorStructInfo(call, ctx, /*input_names=*/input_names,
+                               /*op_name=*/"LayerNorm");
+
+  const auto* attrs = call->attrs.as<LayerNormAttrs>();
+  bool unknown_shape = NormCheckDtypeAndShape(call, ctx, input_sinfo, input_names, attrs->axes,
+                                              /*op_name=*/"LayerNorm");
+
+  return unknown_shape ? TensorStructInfo(input_sinfo[0]->dtype, input_sinfo[0]->ndim)
+                       : input_sinfo[0];
+}
+
+TVM_REGISTER_OP("relax.nn.layer_norm")
+    .set_attrs_type<LayerNormAttrs>()
+    .set_num_inputs(3)
+    .add_argument("data", "Tensor", "Input to which batch_norm will be applied.")
+    .add_argument("gamma", "Tensor", "The gamma scale factor.")
+    .add_argument("beta", "Tensor", "The beta offset factor.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoLayerNorm);
+
+/* relax.nn.matmul */
+TVM_REGISTER_NODE_TYPE(MatmulAttrs);
+
+Expr MakeMatmul(Expr a, Expr b, DataType out_dtype) {
+  ObjectPtr<MatmulAttrs> attrs = make_object<MatmulAttrs>();
+  attrs->out_dtype = out_dtype;
+
+  static const Op& op = Op::Get("relax.nn.matmul");
+  return Call(op, {std::move(a), std::move(b)}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.matmul").set_body_typed(MakeMatmul);
+
+StructInfo InferStructInfoMatmul(const Call& call, const BlockBuilder& ctx) {
+  Array<TensorStructInfo> input_sinfo =
+      GetInputTensorStructInfo(call, ctx, /*input_names=*/{"lhs", "rhs"}, /*op_name=*/"Matmul");
+  TensorStructInfo lhs_sinfo = input_sinfo[0];
+  TensorStructInfo rhs_sinfo = input_sinfo[1];
+
+  const auto* attrs = call->attrs.as<MatmulAttrs>();
+  DataType out_dtype = attrs->out_dtype.is_void()
+                           ? InferBinaryArithOpOutDtype(call, ctx, lhs_sinfo, rhs_sinfo)
+                           : attrs->out_dtype;
+
+  if (lhs_sinfo->IsUnknownNdim() || rhs_sinfo->IsUnknownNdim()) {
+    return TensorStructInfo(out_dtype, kUnknownNDim);
+  }
+  int lhs_ndim = lhs_sinfo->ndim;
+  int rhs_ndim = rhs_sinfo->ndim;
+  if (lhs_ndim == 0 || rhs_ndim == 0) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Matmul requires both input to have at least 1 dimension. However, "
+                     << (lhs_ndim == 0 ? "lhs" : "rhs") << " is a 0-rank tensor.");
+  }
+
+  int lhs_prepended = 0;
+  int rhs_appended = 0;
+  if (lhs_ndim == 1) {
+    lhs_ndim = 2;
+    lhs_prepended = 1;
+  }
+  if (rhs_ndim == 1) {
+    rhs_ndim = 2;
+    rhs_appended = 1;
+  }
+  int output_ndim = std::max(lhs_ndim, rhs_ndim) - lhs_prepended - rhs_appended;
+
+  const auto* lhs_shape = lhs_sinfo->shape.as<ShapeExprNode>();
+  const auto* rhs_shape = rhs_sinfo->shape.as<ShapeExprNode>();
+  if (lhs_shape == nullptr || rhs_shape == nullptr) {
+    return TensorStructInfo(out_dtype, output_ndim);
+  }
+
+  Array<PrimExpr> lhs_shape_prefix{lhs_shape->values.begin(),
+                                   lhs_shape->values.end() - 2 + lhs_prepended};
+  Array<PrimExpr> rhs_shape_prefix{rhs_shape->values.begin(),
+                                   rhs_shape->values.end() - 2 + rhs_appended};
+  Optional<Array<PrimExpr>> output_shape_prefix = InferBinaryBroadcastShape(
+      call, ctx, lhs_shape_prefix, rhs_shape_prefix, /*op_name=*/"Matmul");
+  if (!output_shape_prefix.defined()) {
+    return TensorStructInfo(out_dtype, output_ndim);
+  }
+
+  arith::Analyzer* analyzer = ctx->GetAnalyzer();
+  PrimExpr lhs_reduction_length = lhs_shape->values[lhs_sinfo->ndim - 1];
+  PrimExpr rhs_reduction_length = rhs_shape->values[rhs_ndim - 2];
+  if (analyzer->CanProve(lhs_reduction_length != rhs_reduction_length)) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Matmul requires the reduction length of lhs and rhs to be equal. However, "
+                        "the reduction lengths of lhs and rhs are "
+                     << lhs_reduction_length << " and " << rhs_reduction_length
+                     << " respectively.");
+  }
+
+  Array<PrimExpr> output_shape = output_shape_prefix.value();
+  if (!lhs_prepended) {
+    output_shape.push_back(lhs_shape->values[lhs_ndim - 2]);
+  }
+  if (!rhs_appended) {
+    output_shape.push_back(rhs_shape->values[rhs_ndim - 1]);
+  }
+  ICHECK_EQ(static_cast<int>(output_shape.size()), output_ndim);
+  return TensorStructInfo(ShapeExpr(output_shape), out_dtype);
+}
+
+TVM_REGISTER_OP("relax.nn.matmul")
+    .set_num_inputs(2)
+    .add_argument("a", "Tensor", "The left operand of the matmul.")
+    .add_argument("b", "Tensor", "The right operand of the matmul.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoMatmul);
+
+/* relax.nn.dropout */
+TVM_REGISTER_NODE_TYPE(DropoutAttrs);
+
+Expr MakeDropout(Expr data, double rate) {
+  ObjectPtr<DropoutAttrs> attrs = make_object<DropoutAttrs>();
+  attrs->rate = rate;
+
+  static const Op& op = Op::Get("relax.nn.dropout");
+  return Call(op, {std::move(data)}, Attrs{attrs}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.dropout").set_body_typed(MakeDropout);
+
+StructInfo InferStructInfoDropout(const Call& call, const BlockBuilder& ctx) {
+  TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx, /*op_name=*/"Dropout");
+  return TupleStructInfo({data_sinfo, data_sinfo});
+}
+
+TVM_REGISTER_OP("relax.nn.dropout")
+    .set_attrs_type<DropoutAttrs>()
+    .set_num_inputs(1)
+    .add_argument("data", "Tensor", "Input to which dropout will be applied.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoDropout);
+
+// Structure info inference for cross entropy and softmax cross entropy
+StructInfo InferStructInfoCrossEntropy(const Call& call, const BlockBuilder& ctx) {
+  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(
+      call, ctx, /*input_names=*/{"prediction", "target"}, /*op_name=*/"Loss function");
+  TensorStructInfo pred_sinfo = input_sinfo[0];
+  TensorStructInfo tgt_sinfo = input_sinfo[1];
+
+  DataType dtype = InferBinaryArithOpOutDtype(call, ctx, pred_sinfo, tgt_sinfo);
+
+  if (pred_sinfo->ndim != 2) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Cross entropy requires the input prediction to have exactly two "
+                        "dimensions. However, the given prediction have "
+                     << pred_sinfo->ndim);
+  }
+  if (tgt_sinfo->ndim != 2) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Cross entropy requires the input target to have exactly two "
+                        "dimensions. However, the given prediction have "
+                     << tgt_sinfo->ndim);
+  }
+
+  const auto* pred_shape = pred_sinfo->shape.as<ShapeExprNode>();
+  const auto* tgt_shape = tgt_sinfo->shape.as<ShapeExprNode>();
+  if (pred_shape == nullptr || tgt_shape == nullptr) {
+    return TensorStructInfo(ShapeExpr(Array<PrimExpr>()), dtype);
+  }
+
+  arith::Analyzer* analyzer = ctx->GetAnalyzer();
+  if (analyzer->CanProve(pred_shape->values[0] != tgt_shape->values[0]) ||
+      analyzer->CanProve(pred_shape->values[1] != tgt_shape->values[1])) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Cross entropy requires the input prediction and target tensors to have "
+                        "the same shape. However, the prediction has shape "
+                     << pred_sinfo->shape << " while the target has shape " << tgt_sinfo->shape);
+  }
+  return TensorStructInfo(ShapeExpr(Array<PrimExpr>()), dtype);
+}
+
+/* relax.nn.cross_entropy */
+Expr MakeCrossEntropy(Expr predictions, Expr targets) {
+  static const Op& op = Op::Get("relax.nn.cross_entropy");
+  return Call(op, {std::move(predictions), std::move(targets)}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.cross_entropy").set_body_typed(MakeCrossEntropy);
+
+TVM_REGISTER_OP("relax.nn.cross_entropy")
+    .set_num_inputs(2)
+    .add_argument("predictions", "Tensor", "The predictions.")
+    .add_argument("targets", "Tensor", "The targets.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCrossEntropy);
+
+/* relax.nn.softmax_cross_entropy */
+Expr MakeSoftmaxCrossEntropy(Expr predictions, Expr targets) {
+  static const Op& op = Op::Get("relax.nn.softmax_cross_entropy");
+  return Call(op, {std::move(predictions), std::move(targets)}, {}, {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.softmax_cross_entropy").set_body_typed(MakeSoftmaxCrossEntropy);
+
+TVM_REGISTER_OP("relax.nn.softmax_cross_entropy")
+    .set_num_inputs(2)
+    .add_argument("predictions", "Tensor", "The predictions.")
+    .add_argument("targets", "Tensor", "The targets.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCrossEntropy);
 
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/nn/nn.cc
+++ b/src/relax/op/nn/nn.cc
@@ -233,7 +233,7 @@ StructInfo InferStructInfoMatmul(const Call& call, const BlockBuilder& ctx) {
   int rhs_ndim = rhs_sinfo->ndim;
   if (lhs_ndim == 0 || rhs_ndim == 0) {
     ctx->ReportFatal(Diagnostic::Error(call)
-                     << "Matmul requires both input to have at least 1 dimension. However, "
+                     << "Matmul requires both inputs to have at least 1 dimension. However, "
                      << (lhs_ndim == 0 ? "lhs" : "rhs") << " is a 0-rank tensor.");
   }
 

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include <unordered_map>
-
 #include "../op_common.h"
 
 namespace tvm {
@@ -84,7 +82,6 @@ StructInfo InferStructInfoMaxPool2D(const Call& call, const BlockBuilder& ctx) {
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);
 
-  std::unordered_map<char, PrimExpr> output_shape;
   PrimExpr input_h = data_NCHW_shape[2];
   PrimExpr input_w = data_NCHW_shape[3];
   PrimExpr kernel_h = attrs->pool_size[0];

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -62,20 +62,18 @@ Expr MakeMaxPool2D(Expr data, Array<PrimExpr> pool_size, Array<PrimExpr> strides
 TVM_REGISTER_GLOBAL("relax.op.nn.max_pool2d").set_body_typed(MakeMaxPool2D);
 
 StructInfo InferStructInfoMaxPool2D(const Call& call, const BlockBuilder& ctx) {
-  TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx, /*op_name=*/"MaxPool2D");
+  TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
 
   const auto* attrs = call->attrs.as<MaxPool2DAttrs>();
   auto [data_layout, data2NCHW] = CheckTensorLayout(call, ctx, attrs->layout,  //
                                                     /*tgt_layout=*/"NCHW",     //
-                                                    /*op_name=*/"MaxPool2D",   //
                                                     /*tensor_name=*/"data");
   auto [out_layout, out2NCHW] = CheckTensorLayout(call, ctx, attrs->out_layout,  //
                                                   /*tgt_layout=*/"NCHW",         //
-                                                  /*op_name=*/"MaxPool2D",       //
                                                   /*tensor_name=*/"output");
 
   Optional<ShapeExpr> data_shape =
-      CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout, /*op_name=*/"MaxPool2D");
+      CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout);
   if (!data_shape.defined()) {
     return TensorStructInfo(data_sinfo->dtype, out_layout.ndim());
   }
@@ -135,21 +133,18 @@ Expr MakeAdaptiveAvgPool2D(Expr data, Optional<Array<PrimExpr>> output_size, Str
 TVM_REGISTER_GLOBAL("relax.op.nn.adaptive_avg_pool2d").set_body_typed(MakeAdaptiveAvgPool2D);
 
 StructInfo InferStructInfoAdaptiveAvgPool2D(const Call& call, const BlockBuilder& ctx) {
-  TensorStructInfo data_sinfo =
-      GetUnaryInputTensorStructInfo(call, ctx, /*op_name=*/"AdaptiveAvgPool2D");
+  TensorStructInfo data_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
 
   const auto* attrs = call->attrs.as<AdaptivePool2DAttrs>();
-  auto [data_layout, data2NCHW] = CheckTensorLayout(call, ctx, attrs->layout,         //
-                                                    /*tgt_layout=*/"NCHW",            //
-                                                    /*op_name=*/"AdaptiveAvgPool2D",  //
+  auto [data_layout, data2NCHW] = CheckTensorLayout(call, ctx, attrs->layout,  //
+                                                    /*tgt_layout=*/"NCHW",     //
                                                     /*tensor_name=*/"data");
-  auto [out_layout, out2NCHW] = CheckTensorLayout(call, ctx, attrs->out_layout,     //
-                                                  /*tgt_layout=*/"NCHW",            //
-                                                  /*op_name=*/"AdaptiveAvgPool2D",  //
+  auto [out_layout, out2NCHW] = CheckTensorLayout(call, ctx, attrs->out_layout,  //
+                                                  /*tgt_layout=*/"NCHW",         //
                                                   /*tensor_name=*/"output");
 
-  Optional<ShapeExpr> data_shape = CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout,
-                                                                 /*op_name=*/"AdaptiveAvgPool2D");
+  Optional<ShapeExpr> data_shape =
+      CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout);
   if (!data_shape.defined()) {
     return TensorStructInfo(data_sinfo->dtype, out_layout.ndim());
   }

--- a/src/relax/op/op_common.cc
+++ b/src/relax/op/op_common.cc
@@ -87,6 +87,7 @@ Optional<Array<PrimExpr>> InferBinaryBroadcastShape(const Call& call, const Bloc
 
 Array<Integer> CheckAxesInRangeNonRepetitive(const Call& call, const BlockBuilder& ctx, int ndim,
                                              const Array<Integer>& axes) {
+  ICHECK_NE(ndim, kUnknownNDim) << "The ndim is required to be known for this function.";
   std::vector<bool> appeared_dims_set;
   Array<Integer> axes_non_neg;
   appeared_dims_set.resize(ndim, /*value=*/false);

--- a/src/relax/op/op_common.cc
+++ b/src/relax/op/op_common.cc
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "op_common.h"
+
+#include <algorithm>
+
+namespace tvm {
+namespace relax {
+
+Array<TensorStructInfo> GetInputTensorStructInfo(const Call& call, const BlockBuilder& ctx,
+                                                 const Array<String>& input_names,
+                                                 const String& op_name) {
+  int n_input = input_names.size();
+  if (static_cast<int>(call->args.size()) != n_input) {
+    ctx->ReportFatal(Diagnostic::Error(call) << op_name << " op should have 2 arguments");
+  }
+  Array<TensorStructInfo> input_tensor_sinfo;
+  input_tensor_sinfo.reserve(n_input);
+  for (int i = 0; i < n_input; ++i) {
+    const auto* sinfo = GetStructInfoAs<TensorStructInfoNode>(call->args[i]);
+    if (sinfo == nullptr) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << op_name << " requires the input " << input_names[i]
+                       << " to be Tensor. However, the given one is "
+                       << call->args[i]->struct_info_->GetTypeKey());
+    }
+    input_tensor_sinfo.push_back(GetRef<TensorStructInfo>(sinfo));
+  }
+  return input_tensor_sinfo;
+}
+
+Optional<Array<PrimExpr>> InferBinaryBroadcastShape(const Call& call, const BlockBuilder& ctx,
+                                                    const Array<PrimExpr>& lhs_shape,
+                                                    const Array<PrimExpr>& rhs_shape,
+                                                    const String& op_name) {
+  arith::Analyzer* analyzer = ctx->GetAnalyzer();
+  int lhs_ndim = lhs_shape.size();
+  int rhs_ndim = rhs_shape.size();
+  int max_ndim = std::max(lhs_ndim, rhs_ndim);
+
+  std::vector<PrimExpr> output_shape;
+  output_shape.reserve(max_ndim);
+
+  int i = 1;
+  for (; i <= std::min(lhs_ndim, rhs_ndim); ++i) {
+    const PrimExpr& dim0 = lhs_shape[lhs_ndim - i];
+    const PrimExpr& dim1 = rhs_shape[rhs_ndim - i];
+    const auto* int_dim0 = dim0.as<IntImmNode>();
+    const auto* int_dim1 = dim1.as<IntImmNode>();
+    if (int_dim0 != nullptr && int_dim0->value == 1) {
+      output_shape.push_back(dim1);
+    } else if (int_dim1 != nullptr && int_dim1->value == 1) {
+      output_shape.push_back(dim0);
+    } else if (analyzer->CanProveEqual(dim0, dim1)) {
+      output_shape.push_back(dim0);
+    } else if (int_dim0 && int_dim1 && int_dim0->value != int_dim1->value) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << "In " << op_name << ", the lhs shape at dim " << lhs_ndim - i << " is "
+                       << dim0 << " and the rhs shape at dim " << rhs_ndim - i << " is " << dim1
+                       << ", which are not broadcastable.");
+    } else {
+      // Use simple fallback when shape mismatch.
+      return NullOpt;
+    }
+  }
+  auto& longer_shape = (lhs_ndim > rhs_ndim) ? lhs_shape : rhs_shape;
+  for (; i <= max_ndim; ++i) {
+    output_shape.push_back(longer_shape[max_ndim - i]);
+  }
+  return Array<PrimExpr>(output_shape.rbegin(), output_shape.rend());
+}
+
+Array<Integer> CheckAxesInRangeNonRepetitive(const Call& call, const BlockBuilder& ctx, int ndim,
+                                             const Array<Integer>& axes, const String op_name) {
+  std::vector<bool> appeared_dims_set;
+  Array<Integer> axes_non_neg;
+  appeared_dims_set.resize(ndim);
+  axes_non_neg.reserve(axes.size());
+  for (const Integer& axis : axes) {
+    int _axis = axis->value;
+    if (_axis < -ndim || _axis >= ndim) {
+      ctx->ReportFatal(Diagnostic::Error(call) << "In " << op_name << ", the input axis " << _axis
+                                               << " is out of range. The input tensor has " << ndim
+                                               << " dimensions, so axis should be in range ["
+                                               << -ndim << ", " << ndim << ").");
+    } else if (_axis < 0) {
+      _axis = ndim + _axis;
+    }
+
+    if (appeared_dims_set[_axis]) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << "In " << op_name
+                       << ", the input axes is required to be non-repetitive. However, there are "
+                          "multiple given axes referring to axis "
+                       << _axis);
+    }
+    appeared_dims_set[_axis] = true;
+    axes_non_neg.push_back(Integer(_axis));
+  }
+  return axes_non_neg;
+}
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -42,7 +42,7 @@ namespace relax {
 
 /*!
  * \brief Get the tensor struct info of the operator input.
- * \param call call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \return The tensor struct info of each input.
  * \note This function require every input to be Tensor. The number of call arguments is required
@@ -52,7 +52,7 @@ Array<TensorStructInfo> GetInputTensorStructInfo(const Call& call, const BlockBu
 
 /*!
  * \brief Get the tensor struct info of the unary operator input.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \return The tensor struct info of the unary operator input.
  * \throw Throw exception if the number of input is not one, or the struct info of the input is not
@@ -90,7 +90,7 @@ inline StructInfo InferStructInfoUnary(const Call& call, const BlockBuilder& ctx
 
 /*!
  * \brief Infer the output datatype for binary arithmetic operators.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \param lhs_sinfo The struct info of the left operand
  * \param rhs_sinfo The struct info of the right operand
@@ -112,7 +112,7 @@ inline DataType InferBinaryArithOpOutDtype(const Call& call, const BlockBuilder&
 
 /*!
  * \brief Infer the output shape for binary broadcast operators.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \param lhs_shape The shape of the lhs operand.
  * \param rhs_shape The shape of the rhs operand.
@@ -150,7 +150,7 @@ inline Array<PrimExpr> GetCompletePadding2D(Array<PrimExpr> padding) {
  * \brief Check if the given tensor layout can be converted to the given target layout.
  * If convertible, return the tensor layout and the bijective conversion in tir::Layout and
  * tir::BijectiveLayout accordingly.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \param tensor_layout The tensor layout to be checked
  * \param tgt_layout The target layout to be matched
@@ -177,7 +177,7 @@ inline std::pair<tir::Layout, tir::BijectiveLayout> CheckTensorLayout(const Call
 /*!
  * \brief Check if the given tensor struct info has expected ndim per the given layout (or the ndim
  * is unknown), and try to cast the shape to ShapeExpr.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \param sinfo The input tensor struct info to be checked.
  * \param layout The layout that the given tensor is expected to have.
@@ -198,9 +198,9 @@ inline Optional<ShapeExpr> CheckNdimPerLayoutAndGetShape(const Call& call, const
 /*!
  * \brief Check if the given array of axes are all in range and non-repetitive with regards to the
  * given ndim. And convert all axes to non-negative index.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
- * \param ndim The ndim constraint.
+ * \param ndim The ndim constraint, which is required to be known already.
  * \param axes The axis indices to be checked
  * \return The input axes in non-negative indexing.
  */
@@ -210,7 +210,7 @@ Array<Integer> CheckAxesInRangeNonRepetitive(const Call& call, const BlockBuilde
 /*!
  * \brief Check if the given axis is in range with regards to the given ndim. And convert it to
  * non-negative index.
- * \param call The Call of the binary tensor operators.
+ * \param call The context Call to the operator.
  * \param ctx The error reporting context.
  * \param ndim The ndim constraint.
  * \param axis The axis index to be checked

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -22,8 +22,6 @@
  * \brief binary broadcast operators.
  */
 
-#include <algorithm>
-
 #include "../op_common.h"
 
 namespace tvm {
@@ -58,7 +56,10 @@ namespace relax {
 template <typename FType>
 StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
                                     FType f_compute_out_dtype) {
-  auto [lhs_sinfo, rhs_sinfo] = GetBinaryInputTensorStructInfo(call, ctx, /*op_name=*/"Binary");
+  Array<TensorStructInfo> input_sinfo =
+      GetInputTensorStructInfo(call, ctx, /*input_names=*/{"lhs", "rhs"}, /*op_name=*/"Binary");
+  TensorStructInfo lhs_sinfo = input_sinfo[0];
+  TensorStructInfo rhs_sinfo = input_sinfo[1];
 
   // DateType
   DataType output_dtype = f_compute_out_dtype(call, ctx, lhs_sinfo, rhs_sinfo);
@@ -73,44 +74,17 @@ StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
 
   auto* lhs_shape = lhs_sinfo->shape.as<ShapeExprNode>();
   auto* rhs_shape = rhs_sinfo->shape.as<ShapeExprNode>();
-  arith::Analyzer* analyzer = ctx->GetAnalyzer();
   // Shapes and ndims
   if (lhs_shape && rhs_shape) {
     // If all inputs have shapes, directly infer shapes
-    std::vector<PrimExpr> output_shape;
-
-    size_t lhs_ndim = lhs_sinfo->ndim;
-    size_t rhs_ndim = rhs_sinfo->ndim;
-    size_t max_ndim = std::max(lhs_ndim, rhs_ndim);
-
-    size_t i = 1;
-    for (; i <= std::min(lhs_ndim, rhs_ndim); ++i) {
-      const PrimExpr& dim0 = lhs_shape->values[lhs_ndim - i];
-      const PrimExpr& dim1 = rhs_shape->values[rhs_ndim - i];
-      const auto* int_dim0 = dim0.as<IntImmNode>();
-      const auto* int_dim1 = dim1.as<IntImmNode>();
-      if (int_dim0 != nullptr && int_dim0->value == 1) {
-        output_shape.push_back(dim1);
-      } else if (int_dim1 != nullptr && int_dim1->value == 1) {
-        output_shape.push_back(dim0);
-      } else if (analyzer->CanProveEqual(dim0, dim1)) {
-        output_shape.push_back(dim0);
-      } else if (int_dim0 && int_dim1 && int_dim0->value != int_dim1->value) {
-        ctx->ReportFatal(Diagnostic::Error(call)
-                         << "The lhs shape at dim " << lhs_ndim - i << " is " << dim0
-                         << " and the rhs shape at dim " << rhs_ndim - i << " is " << dim1
-                         << ", which are not broadcastable.");
-      } else {
-        // Use simple fallback when shape mismatch.
-        return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
-      }
+    Optional<Array<PrimExpr>> output_shape = InferBinaryBroadcastShape(
+        call, ctx, lhs_shape->values, rhs_shape->values, /*op_name=*/"binary op");
+    if (!output_shape.defined()) {
+      return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
+    } else {
+      ICHECK_EQ(static_cast<int>(output_shape.value().size()), output_ndim);
+      return TensorStructInfo(ShapeExpr(output_shape.value()), output_dtype);
     }
-    auto& longer_shape = (lhs_ndim > rhs_ndim) ? lhs_shape : rhs_shape;
-    for (; i <= max_ndim; ++i) {
-      output_shape.push_back(longer_shape->values[max_ndim - i]);
-    }
-    Expr shape = ShapeExpr(Array<PrimExpr>(output_shape.rbegin(), output_shape.rend()));
-    return TensorStructInfo(shape, output_dtype);
   } else {
     return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
   }

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -56,8 +56,7 @@ namespace relax {
 template <typename FType>
 StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
                                     FType f_compute_out_dtype) {
-  Array<TensorStructInfo> input_sinfo =
-      GetInputTensorStructInfo(call, ctx, /*input_names=*/{"lhs", "rhs"}, /*op_name=*/"Binary");
+  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
   TensorStructInfo lhs_sinfo = input_sinfo[0];
   TensorStructInfo rhs_sinfo = input_sinfo[1];
 
@@ -77,8 +76,8 @@ StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
   // Shapes and ndims
   if (lhs_shape && rhs_shape) {
     // If all inputs have shapes, directly infer shapes
-    Optional<Array<PrimExpr>> output_shape = InferBinaryBroadcastShape(
-        call, ctx, lhs_shape->values, rhs_shape->values, /*op_name=*/"binary op");
+    Optional<Array<PrimExpr>> output_shape =
+        InferBinaryBroadcastShape(call, ctx, lhs_shape->values, rhs_shape->values);
     if (!output_shape.defined()) {
       return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
     } else {

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -64,7 +64,7 @@ Expr MakeUnique(Expr data, bool sorted, bool return_inverse, bool return_counts,
 TVM_REGISTER_GLOBAL("relax.op.unique").set_body_typed(MakeUnique);
 
 StructInfo InferStructInfoUnique(const Call& call, const BlockBuilder& ctx) {
-  TensorStructInfo input_sinfo = GetUnaryInputTensorStructInfo(call, ctx, /*op_name=*/"unique");
+  TensorStructInfo input_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
   const auto* unique_attrs = call->attrs.as<UniqueAttrs>();
   // Only default values of these attributes are supported right now.
   if (unique_attrs->return_counts || unique_attrs->return_inverse || unique_attrs->dim != -1) {

--- a/tests/python/relax/test_tvmscript_parser_nn_ops.py
+++ b/tests/python/relax/test_tvmscript_parser_nn_ops.py
@@ -114,5 +114,133 @@ def test_softmax():
     _check(foo, bb.get()["foo"])
 
 
+def test_batch_norm():
+    @R.function
+    def foo(
+        x: R.Tensor((2, 4, 3, 3), dtype="float32"),
+        gamma: R.Tensor((4,), dtype="float32"),
+        beta: R.Tensor((4,), dtype="float32"),
+        moving_mean: R.Tensor((4,), dtype="float32"),
+        moving_var: R.Tensor((4,), dtype="float32"),
+    ) -> R.Tuple(
+        R.Tensor((2, 4, 3, 3), dtype="float32"),
+        R.Tensor((4,), dtype="float32"),
+        R.Tensor((4,), dtype="float32"),
+    ):
+        gv: R.Tuple(
+            R.Tensor((2, 4, 3, 3), dtype="float32"),
+            R.Tensor((4,), dtype="float32"),
+            R.Tensor((4,), dtype="float32"),
+        ) = R.nn.batch_norm(x, gamma, beta, moving_mean, moving_var, axis=1)
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 4, 3, 3), "float32"))
+    gamma = relax.Var("gamma", R.Tensor((4,), "float32"))
+    beta = relax.Var("beta", R.Tensor((4,), "float32"))
+    moving_mean = relax.Var("moving_mean", R.Tensor((4,), "float32"))
+    moving_var = relax.Var("moving_var", R.Tensor((4,), "float32"))
+
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x, gamma, beta, moving_mean, moving_var]):
+        gv = bb.emit(relax.op.nn.batch_norm(x, gamma, beta, moving_mean, moving_var, axis=1))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_layer_norm():
+    @R.function
+    def foo(
+        x: R.Tensor((2, 3, 4, 5), "float32"),
+        gamma: R.Tensor((4, 5), "float32"),
+        beta: R.Tensor((4, 5), "float32"),
+    ) -> R.Tensor((2, 3, 4, 5), "float32"):
+        gv: R.Tensor((2, 3, 4, 5), "float32") = R.nn.layer_norm(x, gamma, beta, axes=[-2, -1])
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 3, 4, 5), "float32"))
+    gamma = relax.Var("gamma", R.Tensor((4, 5), "float32"))
+    beta = relax.Var("beta", R.Tensor((4, 5), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x, gamma, beta]):
+        gv = bb.emit(relax.op.nn.layer_norm(x, gamma, beta, axes=[-2, -1]))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_matmul():
+    @R.function
+    def foo(
+        x: R.Tensor((2, 3, 4, 5), "float32"), y: R.Tensor((6, 2, 3, 5, 7), "float32")
+    ) -> R.Tensor((6, 2, 3, 4, 7), "float32"):
+        gv: R.Tensor((6, 2, 3, 4, 7), "float32") = R.nn.matmul(x, y)
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 3, 4, 5), "float32"))
+    y = relax.Var("y", R.Tensor((6, 2, 3, 5, 7), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x, y]):
+        gv = bb.emit(relax.op.nn.matmul(x, y))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_dropout():
+    @R.function
+    def foo(
+        x: R.Tensor((2, 3), "float32")
+    ) -> R.Tuple(R.Tensor((2, 3), "float32"), R.Tensor((2, 3), "float32")):
+        gv: R.Tuple(R.Tensor((2, 3), "float32"), R.Tensor((2, 3), "float32")) = R.nn.dropout(
+            x, rate=0.5
+        )
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 3), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x]):
+        gv = bb.emit(relax.op.nn.dropout(x))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_cross_entropy():
+    @R.function
+    def foo(
+        predictions: R.Tensor((2, 3), "float32"), targets: R.Tensor((2, 3), "float32")
+    ) -> R.Tensor((), "float32"):
+        gv: R.Tensor((), "float32") = R.nn.cross_entropy(predictions, targets)
+        return gv
+
+    predictions = relax.Var("predictions", R.Tensor((2, 3), "float32"))
+    targets = relax.Var("targets", R.Tensor((2, 3), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [predictions, targets]):
+        gv = bb.emit(relax.op.nn.cross_entropy(predictions, targets))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_softmax_cross_entropy():
+    @R.function
+    def foo(
+        predictions: R.Tensor((2, 3), "float32"), targets: R.Tensor((2, 3), "float32")
+    ) -> R.Tensor((), "float32"):
+        gv: R.Tensor((), "float32") = R.nn.softmax_cross_entropy(predictions, targets)
+        return gv
+
+    predictions = relax.Var("predictions", R.Tensor((2, 3), "float32"))
+    targets = relax.Var("targets", R.Tensor((2, 3), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [predictions, targets]):
+        gv = bb.emit(relax.op.nn.softmax_cross_entropy(predictions, targets))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
 if __name__ == "__foo__":
     tvm.testing.main()


### PR DESCRIPTION
Following #67, this PR introduces the rest part of NN operators we already have to the latest StructInfo codebase. It is part of our operator migration efforts as listed in #62.

* Normalization: BatchNorm, LayerNorm
* Matmul
* Dropout
* Loss function: CrossEntropy, SoftmaxCrossEntropy