### PR TITLE
[Op] Test and fixes for shape variables

### DIFF
--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -282,6 +282,10 @@ def gelu(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.gelu(data)  # type: ignore
 
@@ -301,6 +305,10 @@ def silu(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.silu(data)  # type: ignore
 
@@ -324,6 +332,10 @@ def softmax(data: Expr, axis: int = -1) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.softmax(data, axis)  # type: ignore
 

--- a/python/tvm/relax/op/tensor.py
+++ b/python/tvm/relax/op/tensor.py
@@ -150,6 +150,10 @@ def sin(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.sin(data)  # type: ignore
 
@@ -166,6 +170,10 @@ def cos(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.cos(data)  # type: ignore
 
@@ -182,6 +190,10 @@ def tanh(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.tanh(data)  # type: ignore
 
@@ -198,6 +210,10 @@ def sqrt(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.sqrt(data)  # type: ignore
 
@@ -213,7 +229,11 @@ def log(data: Expr) -> Expr:
     Returns
     -------
     result : relax.Expr
-        The computed result
+        The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.log(data)  # type: ignore
 
@@ -230,6 +250,10 @@ def sigmoid(data: Expr) -> Expr:
     -------
     result : relax.Expr
         The computed result.
+
+    Note
+    ----
+    The input tensor is required to have float dtype
     """
     return _ffi_api.sigmoid(data)  # type: ignore
 

--- a/src/relax/op/nn/pooling.cc
+++ b/src/relax/op/nn/pooling.cc
@@ -146,7 +146,12 @@ StructInfo InferStructInfoAdaptiveAvgPool2D(const Call& call, const BlockBuilder
   Optional<ShapeExpr> data_shape =
       CheckNdimPerLayoutAndGetShape(call, ctx, data_sinfo, data_layout);
   if (!data_shape.defined()) {
-    return TensorStructInfo(data_sinfo->dtype, out_layout.ndim());
+    if (data_sinfo->shape.defined() && attrs->out_layout == attrs->layout &&
+        !attrs->output_size.defined()) {
+      return data_sinfo;
+    } else {
+      return TensorStructInfo(data_sinfo->dtype, out_layout.ndim());
+    }
   }
 
   Array<PrimExpr> data_NCHW_shape = data2NCHW.ForwardShape(data_shape.value()->values);

--- a/src/relax/op/op_common.cc
+++ b/src/relax/op/op_common.cc
@@ -28,7 +28,8 @@ Array<TensorStructInfo> GetInputTensorStructInfo(const Call& call, const BlockBu
   Op op = Downcast<Op>(call->op);
   int n_input = op->arguments.size();
   if (static_cast<int>(call->args.size()) != n_input) {
-    ctx->ReportFatal(Diagnostic::Error(call) << op << " op should have 2 arguments");
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << op << " op should have " << n_input << " arguments");
   }
   Array<TensorStructInfo> input_tensor_sinfo;
   input_tensor_sinfo.reserve(n_input);

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -192,7 +192,10 @@ inline Optional<ShapeExpr> CheckNdimPerLayoutAndGetShape(const Call& call, const
                      << layout.ndim() << "-dim tensor. However, the given input has ndim "
                      << sinfo->ndim);
   }
-  return Downcast<Optional<ShapeExpr>>(sinfo->shape);
+  if (const auto* shape_expr = sinfo->shape.as<ShapeExprNode>()) {
+    return GetRef<ShapeExpr>(shape_expr);
+  }
+  return NullOpt;
 }
 
 /*!

--- a/src/relax/op/op_common.h
+++ b/src/relax/op/op_common.h
@@ -71,8 +71,9 @@ inline TensorStructInfo GetUnaryInputTensorStructInfo(const Call& call, const Bl
  * \param OpName The name of operator to register. The name passed in will
  *  1. be prepended with a prefix "relax.op." as the FFI key string for the make function,
  *  2. be prepended with a prefix "relax." as the key string in the operator registry.
+ * \param RequireFloatDtype A boolean indicating if the input is required to have float dtype.
  */
-#define RELAX_REGISTER_UNARY_OP(OpName)                               \
+#define RELAX_REGISTER_UNARY_OP(OpName, RequireFloatDtype)            \
   TVM_REGISTER_GLOBAL("relax.op." OpName).set_body_typed([](Expr e) { \
     static const Op& op = Op::Get("relax." OpName);                   \
     return Call(op, {e}, Attrs(), {});                                \
@@ -80,10 +81,19 @@ inline TensorStructInfo GetUnaryInputTensorStructInfo(const Call& call, const Bl
   TVM_REGISTER_OP("relax." OpName)                                    \
       .set_num_inputs(1)                                              \
       .add_argument("e", "Tensor", "The input tensor.")               \
-      .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoUnary)
+      .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoUnary<RequireFloatDtype>)
 
+template <bool require_float_dtype>
 inline StructInfo InferStructInfoUnary(const Call& call, const BlockBuilder& ctx) {
-  return GetUnaryInputTensorStructInfo(call, ctx);
+  TensorStructInfo input_sinfo = GetUnaryInputTensorStructInfo(call, ctx);
+  if (require_float_dtype && !input_sinfo->IsUnknownDtype() && !input_sinfo->dtype.is_float()) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << call->op
+        << " requires the input tensor to have float dtype. However, the given input dtype is "
+        << input_sinfo->dtype);
+  }
+  return input_sinfo;
 }
 
 /************ Utilities ************/

--- a/src/relax/op/tensor/binary.cc
+++ b/src/relax/op/tensor/binary.cc
@@ -84,6 +84,8 @@ StructInfo InferStructInfoBroadcast(const Call& call, const BlockBuilder& ctx,
       ICHECK_EQ(static_cast<int>(output_shape.value().size()), output_ndim);
       return TensorStructInfo(ShapeExpr(output_shape.value()), output_dtype);
     }
+  } else if (lhs_sinfo->shape.defined() && lhs_sinfo->shape.same_as(rhs_sinfo->shape)) {
+    return TensorStructInfo(lhs_sinfo->shape.value(), output_dtype);
   } else {
     return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
   }

--- a/src/relax/op/tensor/unary.cc
+++ b/src/relax/op/tensor/unary.cc
@@ -28,25 +28,25 @@ namespace tvm {
 namespace relax {
 
 /* relax.negative */
-RELAX_REGISTER_UNARY_OP("negative");
+RELAX_REGISTER_UNARY_OP("negative", /*require_float_dtype=*/false);
 
 /* relax.sin */
-RELAX_REGISTER_UNARY_OP("sin");
+RELAX_REGISTER_UNARY_OP("sin", /*require_float_dtype=*/true);
 
 /* relax.cos */
-RELAX_REGISTER_UNARY_OP("cos");
+RELAX_REGISTER_UNARY_OP("cos", /*require_float_dtype=*/true);
 
 /* relax.tanh */
-RELAX_REGISTER_UNARY_OP("tanh");
+RELAX_REGISTER_UNARY_OP("tanh", /*require_float_dtype=*/true);
 
 /* relax.sqrt */
-RELAX_REGISTER_UNARY_OP("sqrt");
+RELAX_REGISTER_UNARY_OP("sqrt", /*require_float_dtype=*/true);
 
 /* relax.log */
-RELAX_REGISTER_UNARY_OP("log");
+RELAX_REGISTER_UNARY_OP("log", /*require_float_dtype=*/true);
 
 /* relax.sigmoid */
-RELAX_REGISTER_UNARY_OP("sigmoid");
+RELAX_REGISTER_UNARY_OP("sigmoid", /*require_float_dtype=*/true);
 
 /* relax.unique */
 TVM_REGISTER_NODE_TYPE(UniqueAttrs);

--- a/tests/python/relax/test_op_binary.py
+++ b/tests/python/relax/test_op_binary.py
@@ -75,7 +75,7 @@ def test_binary_cmp_infer_struct_info():
     _check_inference(bb, relax.op.less(x, y1), relax.TensorStructInfo((2, 3), "bool"))
 
 
-def test_binary_infer_struct_info_symbolic():
+def test_binary_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")
@@ -103,6 +103,27 @@ def test_binary_infer_struct_info_symbolic():
     _check_inference(bb, relax.op.add(x4, y2), relax.TensorStructInfo(dtype="float32", ndim=4))
     _check_inference(bb, relax.op.add(x4, y3), relax.TensorStructInfo(dtype="float32", ndim=2))
     _check_inference(bb, relax.op.add(x4, y4), relax.TensorStructInfo(dtype="float32", ndim=-1))
+
+
+def test_binary_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s0", relax.ShapeStructInfo(ndim=2))
+    s1 = relax.Var("s1", relax.ShapeStructInfo(ndim=2))
+    s2 = relax.Var("s2", relax.ShapeStructInfo(ndim=4))
+    s3 = relax.Var("s3", relax.ShapeStructInfo(ndim=1))
+    s4 = relax.Var("s4", relax.ShapeStructInfo())
+    x = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    y0 = relax.Var("y", relax.TensorStructInfo(s0, "float32"))
+    y1 = relax.Var("y", relax.TensorStructInfo(s1, "float32"))
+    y2 = relax.Var("y", relax.TensorStructInfo(s2, "float32"))
+    y3 = relax.Var("y", relax.TensorStructInfo(s3, "float32"))
+    y4 = relax.Var("y", relax.TensorStructInfo(s4, "float32"))
+
+    _check_inference(bb, relax.op.subtract(x, y0), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(bb, relax.op.subtract(x, y1), relax.TensorStructInfo(dtype="float32", ndim=2))
+    _check_inference(bb, relax.op.subtract(x, y2), relax.TensorStructInfo(dtype="float32", ndim=4))
+    _check_inference(bb, relax.op.subtract(x, y3), relax.TensorStructInfo(dtype="float32", ndim=2))
+    _check_inference(bb, relax.op.subtract(x, y4), relax.TensorStructInfo(dtype="float32"))
 
 
 def test_binary_arith_infer_struct_info_more_input_dtype():

--- a/tests/python/relax/test_op_image.py
+++ b/tests/python/relax/test_op_image.py
@@ -96,7 +96,7 @@ def test_resize2d_infer_struct_info():
     )
 
 
-def test_resize2d_infer_struct_info_symbolic():
+def test_resize2d_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     n = tir.Var("n", "int64")
     c = tir.Var("c", "int64")
@@ -119,6 +119,30 @@ def test_resize2d_infer_struct_info_symbolic():
         bb,
         relax.op.image.resize2d(x1, size=(oh, ow), layout="NCHW16c"),
         relax.TensorStructInfo((n, c, oh, ow, 16), "float32"),
+    )
+
+
+def test_resize2d_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(ndim=4))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=5))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+
+    _check_inference(
+        bb, relax.op.image.resize2d(x0, size=32), relax.TensorStructInfo(dtype="float32", ndim=4)
+    )
+    _check_inference(
+        bb,
+        relax.op.image.resize2d(x1, size=32, layout="NCHW16c"),
+        relax.TensorStructInfo(dtype="float32", ndim=5),
+    )
+    _check_inference(
+        bb,
+        relax.op.image.resize2d(x2, size=32, layout="NCHW16c"),
+        relax.TensorStructInfo(dtype="float32", ndim=5),
     )
 
 

--- a/tests/python/relax/test_op_nn.py
+++ b/tests/python/relax/test_op_nn.py
@@ -896,6 +896,30 @@ def test_matmul_infer_struct_info_more_input_dtype():
     _check_inference(bb, relax.op.nn.matmul(x2, y2), relax.TensorStructInfo((3, 5), "int64"))
 
 
+def test_matmul_infer_struct_info_mixed_precision():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((3, 4), "float16"))
+    y0 = relax.Var("y", R.Tensor((4, 5), "float16"))
+    x1 = relax.Var("x", R.Tensor((3, 4), "int8"))
+    y1 = relax.Var("y", R.Tensor((4, 5), "int8"))
+    x2 = relax.Var("x", R.Tensor((3, 4)))
+    y2 = relax.Var("y", R.Tensor((4, 5)))
+
+    _check_inference(
+        bb,
+        relax.op.nn.matmul(x0, y0, out_dtype="float32"),
+        relax.TensorStructInfo((3, 5), "float32"),
+    )
+    _check_inference(
+        bb, relax.op.nn.matmul(x1, y1, out_dtype="int32"), relax.TensorStructInfo((3, 5), "int32")
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.matmul(x2, y2, out_dtype="float32"),
+        relax.TensorStructInfo((3, 5), "float32"),
+    )
+
+
 def test_matmul_infer_struct_info_zero_rank_input():
     bb = relax.BlockBuilder()
     x0 = relax.Var("x", R.Tensor((3, 4), "float32"))

--- a/tests/python/relax/test_op_nn_convolution.py
+++ b/tests/python/relax/test_op_nn_convolution.py
@@ -241,6 +241,32 @@ def test_conv2d_infer_struct_info_more_input_dtype():
     )
 
 
+def test_conv2d_infer_struct_info_mixed_precision():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3, 28, 28), "float16"))
+    w0 = relax.Var("w", R.Tensor((4, 3, 3, 3), "float16"))
+    x1 = relax.Var("x", R.Tensor((2, 3, 28, 28), "int8"))
+    w1 = relax.Var("w", R.Tensor((4, 3, 3, 3), "int8"))
+    x2 = relax.Var("x", R.Tensor((2, 3, 28, 28)))
+    w2 = relax.Var("w", R.Tensor((4, 3, 3, 3)))
+
+    _check_inference(
+        bb,
+        relax.op.nn.conv2d(x0, w0, out_dtype="float32"),
+        relax.TensorStructInfo((2, 4, 26, 26), "float32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.conv2d(x1, w1, out_dtype="int32"),
+        relax.TensorStructInfo((2, 4, 26, 26), "int32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.conv2d(x2, w2, out_dtype="float32"),
+        relax.TensorStructInfo((2, 4, 26, 26), "float32"),
+    )
+
+
 def test_conv2d_unequal_input_channel():
     bb = relax.BlockBuilder()
     ic = tir.Var("ic", "int64")

--- a/tests/python/relax/test_op_nn_pooling.py
+++ b/tests/python/relax/test_op_nn_pooling.py
@@ -100,7 +100,7 @@ def test_max_pool2d_infer_struct_info():
     _check_inference(bb, relax.op.nn.max_pool2d(x5), relax.TensorStructInfo(dtype="", ndim=4))
 
 
-def test_max_pool2d_infer_struct_info_symbolic():
+def test_max_pool2d_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     n = tir.Var("n", "int64")
     c = tir.Var("c", "int64")
@@ -143,6 +143,30 @@ def test_max_pool2d_infer_struct_info_symbolic():
         bb,
         relax.op.nn.max_pool2d(x1, layout="NCHW16c", out_layout="NHWC"),
         relax.TensorStructInfo((n, ih, iw, c * 16), "float32"),
+    )
+
+
+def test_max_pool2d_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(ndim=4))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=5))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+
+    _check_inference(
+        bb, relax.op.nn.max_pool2d(x0), relax.TensorStructInfo(dtype="float32", ndim=4)
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.max_pool2d(x1, layout="NCHW16c"),
+        relax.TensorStructInfo(dtype="float32", ndim=5),
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.max_pool2d(x2),
+        relax.TensorStructInfo(dtype="float32", ndim=4),
     )
 
 
@@ -252,7 +276,7 @@ def test_adaptive_avg_pool2d_infer_struct_info():
     )
 
 
-def test_adaptive_avg_pool2d_infer_struct_info_symbolic():
+def test_adaptive_avg_pool2d_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     n = tir.Var("n", "int64")
     c = tir.Var("c", "int64")
@@ -281,6 +305,38 @@ def test_adaptive_avg_pool2d_infer_struct_info_symbolic():
         bb,
         relax.op.nn.adaptive_avg_pool2d(x1, layout="NCHW16c", out_layout="NHWC"),
         relax.TensorStructInfo((n, ih, iw, c * 16), "float32"),
+    )
+
+
+def test_adaptive_avg_pool2d_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(ndim=4))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=5))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+
+    _check_inference(bb, relax.op.nn.adaptive_avg_pool2d(x0), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(
+        bb,
+        relax.op.nn.adaptive_avg_pool2d(x0, output_size=32),
+        relax.TensorStructInfo(dtype="float32", ndim=4),
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.adaptive_avg_pool2d(x1, layout="NCHW16c"),
+        relax.TensorStructInfo(s1, "float32"),
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.adaptive_avg_pool2d(x0, out_layout="NCHW16c"),
+        relax.TensorStructInfo(dtype="float32", ndim=5),
+    )
+    _check_inference(
+        bb,
+        relax.op.nn.adaptive_avg_pool2d(x2, out_layout="NCHW16c"),
+        relax.TensorStructInfo(dtype="float32", ndim=5),
     )
 
 

--- a/tests/python/relax/test_op_reduce.py
+++ b/tests/python/relax/test_op_reduce.py
@@ -100,7 +100,7 @@ def test_reduction_infer_struct_info():
     _check_inference(bb, relax.op.sum(x0, axis=[]), relax.TensorStructInfo((2, 3, 4, 5), "float32"))
 
 
-def test_reduction_infer_struct_info_symbolic():
+def test_reduction_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     a = tir.Var("a", "int64")
     b = tir.Var("b", "int64")
@@ -119,6 +119,33 @@ def test_reduction_infer_struct_info_symbolic():
         bb,
         relax.op.min(x, axis=None, keepdims=True),
         relax.TensorStructInfo((1, 1, 1, 1), "float32"),
+    )
+
+
+def test_reduction_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(ndim=4))
+    s1 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+
+    _check_inference(bb, relax.op.max(x0), relax.TensorStructInfo((), dtype="float32"))
+    _check_inference(
+        bb, relax.op.max(x0, keepdims=True), relax.TensorStructInfo((1, 1, 1, 1), dtype="float32")
+    )
+    _check_inference(
+        bb, relax.op.max(x0, axis=[2, 3]), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+    _check_inference(
+        bb,
+        relax.op.max(x0, axis=[2, 3], keepdims=True),
+        relax.TensorStructInfo(dtype="float32", ndim=4),
+    )
+    _check_inference(bb, relax.op.max(x1), relax.TensorStructInfo((), dtype="float32"))
+    _check_inference(bb, relax.op.max(x1, keepdims=True), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, relax.op.max(x1, axis=[2, 3]), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(
+        bb, relax.op.max(x1, axis=[2, 3], keepdims=True), relax.TensorStructInfo(dtype="float32")
     )
 
 

--- a/tests/python/relax/test_op_ternary.py
+++ b/tests/python/relax/test_op_ternary.py
@@ -54,7 +54,7 @@ def test_ewise_fma_infer_struct_info():
     _check_inference(bb, relax.op.ewise_fma(x1, y0, z0), relax.TensorStructInfo((2, 3), dtype=""))
 
 
-def test_ewise_fma_infer_struct_info_symbolic():
+def test_ewise_fma_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")
@@ -66,6 +66,26 @@ def test_ewise_fma_infer_struct_info_symbolic():
     _check_inference(bb, relax.op.ewise_fma(x0, y0, z0), relax.TensorStructInfo((m, n), "float32"))
     _check_inference(
         bb, relax.op.ewise_fma(x0, y1, z0), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+
+
+def test_ewise_fma_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+    y = relax.Var("y", relax.TensorStructInfo(s0, "float32"))
+    z = relax.Var("z", relax.TensorStructInfo(s0, "float32"))
+
+    _check_inference(bb, relax.op.ewise_fma(x0, y, z), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(
+        bb, relax.op.ewise_fma(x1, y, z), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+    _check_inference(
+        bb, relax.op.ewise_fma(x2, y, z), relax.TensorStructInfo(dtype="float32", ndim=2)
     )
 
 

--- a/tests/python/relax/test_op_unary.py
+++ b/tests/python/relax/test_op_unary.py
@@ -55,7 +55,7 @@ def test_unary_arith_infer_struct_info():
     _check_inference(bb, relax.op.tanh(x4), relax.TensorStructInfo(dtype=""))
 
 
-def test_unary_arith_infer_struct_info_symbolic():
+def test_unary_arith_infer_struct_info_shape_symbolic():
     bb = relax.BlockBuilder()
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")
@@ -64,6 +64,17 @@ def test_unary_arith_infer_struct_info_symbolic():
 
     _check_inference(bb, relax.op.sqrt(x0), relax.TensorStructInfo((m, n), "float32"))
     _check_inference(bb, relax.op.sigmoid(x1), relax.TensorStructInfo((4, n), "int32"))
+
+
+def test_unary_arith_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s1 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+
+    _check_inference(bb, relax.op.log(x0), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(bb, relax.op.tanh(x1), relax.TensorStructInfo(s1, "float32"))
 
 
 def test_unary_arith_infer_struct_info_more_input_dtype():

--- a/tests/python/relax/test_op_unary.py
+++ b/tests/python/relax/test_op_unary.py
@@ -60,10 +60,10 @@ def test_unary_arith_infer_struct_info_shape_symbolic():
     m = tir.Var("m", "int64")
     n = tir.Var("n", "int64")
     x0 = relax.Var("x", R.Tensor((m, n), "float32"))
-    x1 = relax.Var("x", R.Tensor((4, n), "int32"))
+    x1 = relax.Var("x", R.Tensor((4, n), "float32"))
 
     _check_inference(bb, relax.op.sqrt(x0), relax.TensorStructInfo((m, n), "float32"))
-    _check_inference(bb, relax.op.sigmoid(x1), relax.TensorStructInfo((4, n), "int32"))
+    _check_inference(bb, relax.op.sigmoid(x1), relax.TensorStructInfo((4, n), "float32"))
 
 
 def test_unary_arith_infer_struct_info_shape_var():
@@ -84,8 +84,19 @@ def test_unary_arith_infer_struct_info_more_input_dtype():
     x2 = relax.Var("x", R.Tensor((2, 3), "int64"))
 
     _check_inference(bb, relax.op.negative(x0), relax.TensorStructInfo((2, 3), "float64"))
-    _check_inference(bb, relax.op.sin(x1), relax.TensorStructInfo((2, 3), "int8"))
-    _check_inference(bb, relax.op.log(x2), relax.TensorStructInfo((2, 3), "int64"))
+    _check_inference(bb, relax.op.negative(x1), relax.TensorStructInfo((2, 3), "int8"))
+    _check_inference(bb, relax.op.negative(x2), relax.TensorStructInfo((2, 3), "int64"))
+
+
+def test_unary_arith_infer_struct_info_invalid_input_dtype():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3), "int8"))
+    x1 = relax.Var("x", R.Tensor((2, 3), "int64"))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.sin(x0))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.log(x1))
 
 
 def test_unary_arith_wrong_input_number():


### PR DESCRIPTION
This PR brings unit tests for cases like “the shape of a tensor is a shape variable”, which are not covered by previous PRs listed #62.

By adding such tests, a few bugs of previous structure info deduction got revealed. The reason of those bugs is mainly the under consideration of shape variables. And this PR fixes them accordingly.