### PR TITLE
[Op][Trans2] Full/FullLike, Zeros/ZerosLike, Ones/OnesLike

### DIFF
--- a/include/tvm/relax/op_attr_types.h
+++ b/include/tvm/relax/op_attr_types.h
@@ -377,6 +377,15 @@ struct SqueezeAttrs : public tvm::AttrsNode<SqueezeAttrs> {
   }
 };  // struct SqueezeAttrs
 
+/*! \brief Attributes used in full, ones, and zeros operators */
+struct InitAttrs : public tvm::AttrsNode<InitAttrs> {
+  DataType dtype;
+
+  TVM_DECLARE_ATTRS(InitAttrs, "relax.attrs.InitAttrs") {
+    TVM_ATTR_FIELD(dtype).describe("The data type of the created tensor.");
+  }
+};  // struct InitAttrs
+
 }  // namespace relax
 }  // namespace tvm
 #endif  // TVM_RELAX_OP_ATTR_TYPES_H_

--- a/python/tvm/relax/op/__init__.py
+++ b/python/tvm/relax/op/__init__.py
@@ -19,6 +19,7 @@
 
 # Operators
 from .base import *
+from .create import *
 from .manipulate import *
 from .op_attrs import *
 from .reduce import *

--- a/python/tvm/relax/op/create.py
+++ b/python/tvm/relax/op/create.py
@@ -27,19 +27,19 @@ PrimExprLike = Union[int, PrimExpr]
 
 
 def full(
-    fill_value: Expr,
     shape: Union[Tuple[PrimExprLike], Expr],
+    fill_value: Expr,
     dtype: Optional[Union[str, DataType]] = None,
 ) -> Expr:
     """Fill array with scalar value.
 
     Parameters
     ----------
-    fill_value : relax.Expr
-        The value to fill. Must be a scalar tensor.
-
     shape : Union[Tuple[PrimExprLike], Expr]
         The shape of the created tensor.
+
+    fill_value : relax.Expr
+        The value to fill. Must be a scalar tensor.
 
     dtype : Optional[Union[str, DataType]]
         The data type of the created tensor.
@@ -50,7 +50,7 @@ def full(
     result : relax.Expr
         The result tensor.
     """
-    return _ffi_api.full(fill_value, shape, dtype)  # type: ignore
+    return _ffi_api.full(shape, fill_value, dtype)  # type: ignore
 
 
 def full_like(data: Expr, fill_value: Expr) -> Expr:

--- a/python/tvm/relax/op/create.py
+++ b/python/tvm/relax/op/create.py
@@ -1,0 +1,147 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Creation operators."""
+from typing import Optional, Tuple, Union
+
+from tvm.ir.expr import PrimExpr
+
+from . import _ffi_api
+from ..expr import Expr, ShapeExpr
+
+PrimExprLike = Union[int, PrimExpr]
+
+
+def full(
+    fill_value: Expr,
+    shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr],
+    dtype: Optional[str] = None,
+) -> Expr:
+    """Fill array with scalar value.
+
+    Parameters
+    ----------
+    fill_value : relax.Expr
+        The value to fill. Must be a scalar tensor.
+
+    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+        The shape of the created tensor.
+
+    dtype : Optional[str]
+        The data type of the created tensor.
+        If dtype is not given, it will by default use the dtype of fill_value.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result tensor.
+    """
+    return _ffi_api.full(fill_value, shape, dtype)  # type: ignore
+
+
+def full_like(data: Expr, fill_value: Expr) -> Expr:
+    """Construct a tensor such that
+    - its shape and dtype is the same as the input data tensor's,
+    - its value is filled with the input scalar fill value.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input tensor, which provides the shape and dtype.
+
+    fill_value : relax.Expr
+        The value to fill. Must be a scalar tensor.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result tensor.
+    """
+    return _ffi_api.full_like(data, fill_value)  # type: ignore
+
+
+def ones(shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr], dtype: str) -> Expr:
+    """Construct a tensor of all ones, with the input shape and dtype.
+
+    Parameters
+    ----------
+    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+        The shape of the created tensor.
+
+    dtype : Optional[str]
+        The data type of the created tensor.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result tensor.
+    """
+    if isinstance(shape, (tuple, list)):
+        shape = ShapeExpr(shape)
+    return _ffi_api.ones(shape, dtype)  # type: ignore
+
+
+def ones_like(data: Expr) -> Expr:
+    """Construct a tensor with all ones, with shape and dtype of the input tensor shape.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input tensor, which provides the shape and dtype.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result tensor.
+    """
+    return _ffi_api.ones_like(data)  # type: ignore
+
+
+def zeros(shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr], dtype: str) -> Expr:
+    """Construct a tensor of all zeros, with the input shape and dtype.
+
+    Parameters
+    ----------
+    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+        The shape of the created tensor.
+
+    dtype : str
+        The data type of the created tensor.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result tensor.
+    """
+    if isinstance(shape, (tuple, list)):
+        shape = ShapeExpr(shape)
+    return _ffi_api.zeros(shape, dtype)  # type: ignore
+
+
+def zeros_like(data: Expr) -> Expr:
+    """Construct a tensor with all ones, with shape and dtype of the input tensor shape.
+
+    Parameters
+    ----------
+    data : relax.Expr
+        The input tensor, which provides the shape and dtype.
+
+    Returns
+    -------
+    result : relax.Expr
+        The result tensor.
+    """
+    return _ffi_api.zeros_like(data)  # type: ignore

--- a/python/tvm/relax/op/create.py
+++ b/python/tvm/relax/op/create.py
@@ -17,6 +17,7 @@
 """Creation operators."""
 from typing import Optional, Tuple, Union
 
+from tvm import DataType
 from tvm.ir.expr import PrimExpr
 
 from . import _ffi_api
@@ -27,8 +28,8 @@ PrimExprLike = Union[int, PrimExpr]
 
 def full(
     fill_value: Expr,
-    shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr],
-    dtype: Optional[str] = None,
+    shape: Union[Tuple[PrimExprLike], Expr],
+    dtype: Optional[Union[str, DataType]] = None,
 ) -> Expr:
     """Fill array with scalar value.
 
@@ -37,10 +38,10 @@ def full(
     fill_value : relax.Expr
         The value to fill. Must be a scalar tensor.
 
-    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+    shape : Union[Tuple[PrimExprLike], Expr]
         The shape of the created tensor.
 
-    dtype : Optional[str]
+    dtype : Optional[Union[str, DataType]]
         The data type of the created tensor.
         If dtype is not given, it will by default use the dtype of fill_value.
 
@@ -73,15 +74,15 @@ def full_like(data: Expr, fill_value: Expr) -> Expr:
     return _ffi_api.full_like(data, fill_value)  # type: ignore
 
 
-def ones(shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr], dtype: str) -> Expr:
+def ones(shape: Union[Tuple[PrimExprLike], Expr], dtype: Union[str, DataType]) -> Expr:
     """Construct a tensor of all ones, with the input shape and dtype.
 
     Parameters
     ----------
-    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+    shape : Union[Tuple[PrimExprLike], Expr]
         The shape of the created tensor.
 
-    dtype : Optional[str]
+    dtype : Union[str, DataType]
         The data type of the created tensor.
 
     Returns
@@ -110,15 +111,15 @@ def ones_like(data: Expr) -> Expr:
     return _ffi_api.ones_like(data)  # type: ignore
 
 
-def zeros(shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr], dtype: str) -> Expr:
+def zeros(shape: Union[Tuple[PrimExprLike], Expr], dtype: Union[str, DataType]) -> Expr:
     """Construct a tensor of all zeros, with the input shape and dtype.
 
     Parameters
     ----------
-    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+    shape : Union[Tuple[PrimExprLike], Expr]
         The shape of the created tensor.
 
-    dtype : str
+    dtype : Union[str, DataType]
         The data type of the created tensor.
 
     Returns

--- a/python/tvm/relax/op/image/image.py
+++ b/python/tvm/relax/op/image/image.py
@@ -17,6 +17,7 @@
 """Image operators."""
 from typing import Optional, Tuple, Union
 
+from tvm import DataType
 from tvm.ir.expr import PrimExpr
 
 from . import _ffi_api
@@ -37,7 +38,7 @@ def resize2d(
     cubic_alpha: float = -0.5,
     cubic_exclude: int = 0,
     extrapolation_value: float = 0.0,
-    out_dtype: Optional[str] = None,
+    out_dtype: Optional[Union[str, DataType]] = None,
 ) -> Expr:
     """Image resize2d operator.
 
@@ -89,7 +90,7 @@ def resize2d(
     extrapolation_value: float
         Fill value to use when roi is outside of the image
 
-    out_dtype : Optional[str]
+    out_dtype : Optional[Union[str, DataType]]
         The dtype of the output tensor.
         It it is not specified, the output will have the same dtype as input if not specified.
 

--- a/python/tvm/relax/op/manipulate.py
+++ b/python/tvm/relax/op/manipulate.py
@@ -26,7 +26,7 @@ from ..expr import Expr
 PrimExprLike = Union[int, PrimExpr]
 
 
-def reshape(data: Expr, shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr]) -> Expr:
+def reshape(data: Expr, shape: Union[Tuple[PrimExprLike], Expr]) -> Expr:
     """Reshape the input array.
 
     ``-1`` infers the dimension of the output shape by using the remainder of
@@ -44,7 +44,7 @@ def reshape(data: Expr, shape: Union[PrimExprLike, Tuple[PrimExprLike], Expr]) -
     data : relax.Expr
         The input data to the operator.
 
-    shape : Union[PrimExprLike, Tuple[PrimExprLike], Expr]
+    shape : Union[Tuple[PrimExprLike], Expr]
         The new shape. Should be compatible with the original shape.
 
     Returns

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -17,6 +17,7 @@
 """Relax Neural Network (NN) operators"""
 from typing import List, Optional, Tuple, Union
 
+from tvm import DataType
 from tvm.ir.expr import PrimExpr
 
 from . import _ffi_api
@@ -34,7 +35,7 @@ def conv2d(
     data_layout: str = "NCHW",
     kernel_layout: str = "OIHW",
     out_layout: Optional[str] = None,
-    out_dtype: Optional[str] = None,
+    out_dtype: Optional[Union[str, DataType]] = None,
 ) -> Expr:
     r"""2D convolution.
 
@@ -90,7 +91,7 @@ def conv2d(
     out_layout : Optional[str]
         Layout of the output. If not specified, it is the same as data_layout
 
-    out_dtype : Optional[str]
+    out_dtype : Optional[Union[str, DataType]]
         Specifies the output data type for mixed precision conv2d.
 
     Returns
@@ -491,7 +492,7 @@ def layer_norm(
     return _ffi_api.layer_norm(data, gamma, beta, axes, epsilon, center, scale)  # type: ignore
 
 
-def matmul(a: Expr, b: Expr, out_dtype: Optional[str] = None) -> Expr:
+def matmul(a: Expr, b: Expr, out_dtype: Optional[Union[str, DataType]] = None) -> Expr:
     """General matrix multiplication of two tensors.
 
     (The below is copied from torch.matmul)
@@ -520,7 +521,7 @@ def matmul(a: Expr, b: Expr, out_dtype: Optional[str] = None) -> Expr:
     b : relax.Expr
         The right operand of the matmul.
 
-    out_dtype: Optional[str]
+    out_dtype: Optional[Union[str, DataType]]
         The data type of the matmul result.
         When it is not specified, the output dtype will be the the same as input dtype.
 

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -132,3 +132,8 @@ class ExpandDimsAttrs(Attrs):
 @tvm._ffi.register_object("relax.attrs.SqueezeAttrs")
 class SqueezeAttrs(Attrs):
     """Attributes for squeeze operator"""
+
+
+@tvm._ffi.register_object("relax.attrs.InitAttrs")
+class InitAttrs(Attrs):
+    """Attributes used in full operator"""

--- a/python/tvm/relax/op/transform.py
+++ b/python/tvm/relax/op/transform.py
@@ -17,13 +17,13 @@
 """Transform operators."""
 from typing import Union
 
-import tvm
+from tvm import DataType
 
 from . import _ffi_api
 from ..expr import Constant, Expr
 
 
-def cast(data: Expr, dtype: Union[str, tvm.DataType]) -> Expr:
+def cast(data: Expr, dtype: Union[str, DataType]) -> Expr:
     """Cast input tensor to data type.
 
     Parameters
@@ -31,7 +31,7 @@ def cast(data: Expr, dtype: Union[str, tvm.DataType]) -> Expr:
     data : relax.Expr
         The input data to the operator.
 
-    dtype: Union[str, tvm.DataType]
+    dtype: Union[str, DataType]
         The target data type
 
     Returns
@@ -39,12 +39,10 @@ def cast(data: Expr, dtype: Union[str, tvm.DataType]) -> Expr:
     result : relax.Expr
         The casted result.
     """
-    if isinstance(dtype, str):
-        dtype = tvm.DataType(dtype)
     return _ffi_api.cast(data, dtype)  # type: ignore
 
 
-def wrap_param(data: Expr, dtype: Union[str, tvm.DataType] = "float32") -> Expr:
+def wrap_param(data: Expr, dtype: Union[str, DataType] = "float32") -> Expr:
     """Cast input tensor which is model param to data type if the dtype of the input data is not
     the same as the given dtype.
 
@@ -53,7 +51,7 @@ def wrap_param(data: Expr, dtype: Union[str, tvm.DataType] = "float32") -> Expr:
     data : relax.Expr
         The input data to the operator.
 
-    dtype: Union[str, tvm.DataType]
+    dtype: Union[str, DataType]
         The target data type
 
     Returns

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -39,6 +39,8 @@ from tvm.relax.op import (
     expand_dims,
     flatten,
     floor_divide,
+    full,
+    full_like,
     image,
     invoke_closure,
     less,
@@ -51,6 +53,8 @@ from tvm.relax.op import (
     multiply,
     negative,
     nn,
+    ones,
+    ones_like,
     permute_dims,
     print,
     reshape,
@@ -65,6 +69,8 @@ from tvm.relax.op import (
     unique,
     variance,
     wrap_param,
+    zeros,
+    zeros_like,
 )
 from tvm.relax.utils import convert_to_expr
 from tvm.runtime import Object as tvm_Object
@@ -438,6 +444,8 @@ __all__ = [
     "expand_dims",
     "flatten",
     "floor_divide",
+    "full",
+    "full_like",
     "func_attr",
     "func_name",
     "func_ret_struct_info",
@@ -455,6 +463,8 @@ __all__ = [
     "multiply",
     "negative",
     "nn",
+    "ones",
+    "ones_like",
     "output",
     "permute_dims",
     "print",
@@ -471,4 +481,6 @@ __all__ = [
     "unique",
     "variance",
     "wrap_param",
+    "zeros",
+    "zeros_like",
 ]

--- a/src/relax/op/tensor/create.cc
+++ b/src/relax/op/tensor/create.cc
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file create.cc
+ * \brief Creation operators.
+ */
+
+#include "../op_common.h"
+
+namespace tvm {
+namespace relax {
+
+/* Initialization operators */
+TVM_REGISTER_NODE_TYPE(InitAttrs);
+
+/* relax.full */
+Expr MakeFull(Expr fill_value, ObjectRef shape, DataType dtype) {
+  Expr shape_in_expr{nullptr};
+  if (const auto* expr = shape.as<ExprNode>()) {
+    shape_in_expr = GetRef<Expr>(expr);
+  } else if (const auto* _array = shape.as<ArrayNode>()) {
+    shape_in_expr = ShapeExpr(GetRef<Array<PrimExpr>>(_array));
+  } else {
+    LOG(FATAL) << "Full only expects the input shape to be either an Expr or an Array of PrimExpr. "
+                  "However, the given one is "
+               << shape->GetTypeKey();
+  }
+
+  ObjectPtr<InitAttrs> attrs = make_object<InitAttrs>();
+  attrs->dtype = dtype;
+
+  static const Op& op = Op::Get("relax.full");
+  return Call(op, {std::move(fill_value), std::move(shape_in_expr)}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.full").set_body_typed(MakeFull);
+
+StructInfo InferStructInfoFull(const Call& call, const BlockBuilder& ctx) {
+  if (call->args.size() != 2) {
+    ctx->ReportFatal(Diagnostic::Error(call) << "Full op should have 2 arguments");
+  }
+  const auto* fill_value_sinfo = GetStructInfoAs<TensorStructInfoNode>(call->args[0]);
+  const auto* shape_sinfo = GetStructInfoAs<ShapeStructInfoNode>(call->args[1]);
+  if (fill_value_sinfo == nullptr || fill_value_sinfo->ndim != 0) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << "Full requires the input fill value to be zero rank Tensor. However, the given one is "
+        << call->args[0]->struct_info_);
+  }
+  if (shape_sinfo == nullptr) {
+    ctx->ReportFatal(Diagnostic::Error(call)
+                     << "Full requires the input shape to be a Shape. However, the given one is "
+                     << call->args[1]->struct_info_->GetTypeKey());
+  }
+
+  const auto* attrs = call->attrs.as<InitAttrs>();
+  DataType out_dtype = attrs->dtype.is_void() ? fill_value_sinfo->dtype : attrs->dtype;
+  return TensorStructInfo(/*shape=*/call->args[1], out_dtype);
+}
+
+TVM_REGISTER_OP("relax.full")
+    .set_attrs_type<InitAttrs>()
+    .set_num_inputs(2)
+    .add_argument("fill_value", "Tensor", "The scalar tensor, denoting the value to fill.")
+    .add_argument("shape", "Shape", "The shape of the created tensor.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoFull);
+
+/* relax.full_like */
+Expr MakeFullLike(Expr data, Expr fill_value) {
+  static const Op& op = Op::Get("relax.full_like");
+  return Call(op, {std::move(data), std::move(fill_value)}, Attrs(), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.full_like").set_body_typed(MakeFullLike);
+
+StructInfo InferStructInfoFullLike(const Call& call, const BlockBuilder& ctx) {
+  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
+  TensorStructInfo data_sinfo = input_sinfo[0];
+  TensorStructInfo fill_value_sinfo = input_sinfo[1];
+  if (fill_value_sinfo->ndim != 0) {
+    ctx->ReportFatal(Diagnostic::Error(call) << "FullLike requires the input fill value to be zero "
+                                                "rank Tensor. However, the given one has ndim"
+                                             << fill_value_sinfo->ndim);
+  }
+
+  return data_sinfo;
+}
+
+TVM_REGISTER_OP("relax.full_like")
+    .set_num_inputs(2)
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_argument("fill_value", "Tensor", "The scalar value to fill.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoFullLike);
+
+// Structure info inference for Ones and Zeros
+StructInfo InferStructInfoOnesZeros(const Call& call, const BlockBuilder& ctx) {
+  if (call->args.size() != 1) {
+    ctx->ReportFatal(Diagnostic::Error(call) << "Ones/Zeros should have 1 argument");
+  }
+
+  const auto* shape_sinfo = GetStructInfoAs<ShapeStructInfoNode>(call->args[0]);
+  if (shape_sinfo == nullptr) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << "Ones/Zeros requires the input shape to be a Shape. However, the given one is "
+        << call->args[0]->struct_info_->GetTypeKey());
+  }
+  const auto* attrs = call->attrs.as<InitAttrs>();
+  return TensorStructInfo(/*shape=*/call->args[0], attrs->dtype);
+}
+
+/* relax.ones & relax.ones_like */
+Expr MakeOnes(Expr shape, DataType dtype) {
+  CHECK(!dtype.is_void()) << "Ones op expects the input dtype not to be void";
+  ObjectPtr<InitAttrs> attrs = make_object<InitAttrs>();
+  attrs->dtype = dtype;
+
+  static const Op& op = Op::Get("relax.ones");
+  return Call(op, {std::move(shape)}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.ones").set_body_typed(MakeOnes);
+
+TVM_REGISTER_OP("relax.ones")
+    .set_attrs_type<InitAttrs>()
+    .set_num_inputs(1)
+    .add_argument("shape", "ShapeExpr", "The shape of the created tensor.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOnesZeros);
+
+RELAX_REGISTER_UNARY_OP("ones_like", /*require_float_dtype=*/false);
+
+/* relax.zeros & relax.zeros_like */
+Expr MakeZeros(Expr shape, DataType dtype) {
+  CHECK(!dtype.is_void()) << "Zeros op expects the input dtype not to be void";
+  ObjectPtr<InitAttrs> attrs = make_object<InitAttrs>();
+  attrs->dtype = dtype;
+
+  static const Op& op = Op::Get("relax.zeros");
+  return Call(op, {std::move(shape)}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.zeros").set_body_typed(MakeZeros);
+
+TVM_REGISTER_OP("relax.zeros")
+    .set_attrs_type<InitAttrs>()
+    .set_num_inputs(1)
+    .add_argument("shape", "ShapeExpr", "The shape of the created tensor.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoOnesZeros);
+
+RELAX_REGISTER_UNARY_OP("zeros_like", /*require_float_dtype=*/false);
+
+}  // namespace relax
+}  // namespace tvm

--- a/tests/python/relax/test_op_create.py
+++ b/tests/python/relax/test_op_create.py
@@ -1,0 +1,485 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax, tir
+from tvm import TVMError
+from tvm.ir import Op
+from tvm.script import relax as R
+
+
+def test_op_correctness():
+    x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
+    fill_value = relax.Var("fill_value", R.Tensor((), "float32"))
+    assert relax.op.full(fill_value, (2, 3)).op == Op.get("relax.full")
+    assert relax.op.full_like(x, fill_value).op == Op.get("relax.full_like")
+    assert relax.op.ones((2, 3), "float32").op == Op.get("relax.ones")
+    assert relax.op.ones_like(x).op == Op.get("relax.ones_like")
+    assert relax.op.zeros((2, 3), "float32").op == Op.get("relax.zeros")
+    assert relax.op.zeros_like(x).op == Op.get("relax.zeros_like")
+
+
+def _check_inference(bb: relax.BlockBuilder, call: relax.Call, expected_sinfo: relax.StructInfo):
+    ret = bb.normalize(call)
+    tvm.ir.assert_structural_equal(ret.struct_info, expected_sinfo)
+
+
+def test_full_infer_struct_info():
+    bb = relax.BlockBuilder()
+    v0 = relax.Var("v", R.Tensor((), "float32"))
+    v1 = relax.Var("v", R.Tensor("float32", ndim=0))
+    v2 = relax.Var("v", R.Tensor(()))
+    v3 = relax.Var("v", R.Tensor(ndim=0))
+    s0 = relax.ShapeExpr((2, 3))
+    s1 = relax.Var("s", relax.ShapeStructInfo((2, 3)))
+    s2 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s3 = relax.Var("s", relax.ShapeStructInfo())
+
+    _check_inference(
+        bb, relax.op.full(v0, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v0, (2, 3)), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(
+        bb, relax.op.full(v0, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v0, s0), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full(v0, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(v0, s1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full(v0, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(v0, s2), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full(v0, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(v0, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(
+        bb, relax.op.full(v1, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v1, (2, 3)), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(
+        bb, relax.op.full(v1, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v1, s0), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full(v1, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(v1, s1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full(v1, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(v1, s2), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full(v1, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(v1, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(
+        bb, relax.op.full(v2, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v2, (2, 3)), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(
+        bb, relax.op.full(v2, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v2, s0), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full(v2, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(v2, s1), relax.TensorStructInfo(s1, dtype=""))
+    _check_inference(bb, relax.op.full(v2, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(v2, s2), relax.TensorStructInfo(s2, dtype=""))
+    _check_inference(bb, relax.op.full(v2, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(v2, s3), relax.TensorStructInfo(s3, dtype=""))
+    _check_inference(
+        bb, relax.op.full(v3, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v3, (2, 3)), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(
+        bb, relax.op.full(v3, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v3, s0), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full(v3, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(v3, s1), relax.TensorStructInfo(s1, dtype=""))
+    _check_inference(bb, relax.op.full(v3, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(v3, s2), relax.TensorStructInfo(s2, dtype=""))
+    _check_inference(bb, relax.op.full(v3, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(v3, s3), relax.TensorStructInfo(s3, dtype=""))
+
+
+def test_full_infer_struct_info_shape_symbolic():
+    bb = relax.BlockBuilder()
+    a = tir.Var("a", "int64")
+    v = relax.Var("v", R.Tensor((), "float32"))
+    s0 = relax.ShapeExpr((a, 3))
+    s1 = relax.Var("s", relax.ShapeStructInfo((a, 3)))
+
+    _check_inference(
+        bb, relax.op.full(v, (a, 3), "float16"), relax.TensorStructInfo((a, 3), "float16")
+    )
+    _check_inference(bb, relax.op.full(v, (a, 3)), relax.TensorStructInfo((a, 3), "float32"))
+    _check_inference(bb, relax.op.full(v, s0, "float16"), relax.TensorStructInfo((a, 3), "float16"))
+    _check_inference(bb, relax.op.full(v, s0), relax.TensorStructInfo((a, 3), "float32"))
+    _check_inference(bb, relax.op.full(v, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(v, s1), relax.TensorStructInfo(s1, "float32"))
+
+
+def test_full_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo(()))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=0))
+    v0 = relax.Var("v", relax.TensorStructInfo(s0, "float32"))
+    v1 = relax.Var("v", relax.TensorStructInfo(s1, "float32"))
+
+    _check_inference(
+        bb, relax.op.full(v0, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+    _check_inference(
+        bb, relax.op.full(v1, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+    )
+
+
+def test_full_infer_struct_info_more_input_dtype():
+    bb = relax.BlockBuilder()
+    v0 = relax.Var("v", R.Tensor((), "float16"))
+    v1 = relax.Var("v", R.Tensor((), "int8"))
+    v2 = relax.Var("v", R.Tensor((), "int32"))
+
+    _check_inference(
+        bb, relax.op.full(v0, (2, 3), "float32"), relax.TensorStructInfo((2, 3), "float32")
+    )
+    _check_inference(bb, relax.op.full(v0, (2, 3)), relax.TensorStructInfo((2, 3), "float16"))
+    _check_inference(
+        bb, relax.op.full(v1, (2, 3), "int32"), relax.TensorStructInfo((2, 3), "int32")
+    )
+    _check_inference(bb, relax.op.full(v1, (2, 3)), relax.TensorStructInfo((2, 3), "int8"))
+    _check_inference(bb, relax.op.full(v2, (2, 3), "int8"), relax.TensorStructInfo((2, 3), "int8"))
+    _check_inference(bb, relax.op.full(v2, (2, 3)), relax.TensorStructInfo((2, 3), "int32"))
+
+
+def test_full_infer_struct_info_fill_value_not_scalar_tensor():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo((1,)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=1))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    v0 = relax.Var("v", R.Tensor((1,), "float32"))
+    v1 = relax.Var("v", R.Tensor("float32", ndim=1))
+    v2 = relax.Var("v", R.Tensor("float32"))
+    v3 = relax.Var("v", relax.TensorStructInfo(s0, "float32"))
+    v4 = relax.Var("v", relax.TensorStructInfo(s1, "float32"))
+    v5 = relax.Var("v", relax.TensorStructInfo(s2, "float32"))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v0, (2, 3)))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v1, (2, 3)))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v2, (2, 3)))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v3, (2, 3)))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v4, (2, 3)))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v5, (2, 3)))
+
+
+def test_full_infer_struct_info_wrong_input_type():
+    bb = relax.BlockBuilder()
+    v0 = relax.Var("v", R.Tensor((), "float32"))
+    v1 = relax.Var("v", relax.ShapeStructInfo(()))
+    v2 = relax.Var("v", relax.FuncStructInfo([], R.Tensor((), "float32")))
+    s = relax.Var("s", R.Tensor((2, 3)))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v0, s))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v1, (2, 3)))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full(v2, (2, 3)))
+
+
+def test_full_like_infer_struct_info():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3), "float32"))
+    x1 = relax.Var("x", R.Tensor("float32", ndim=2))
+    x2 = relax.Var("x", R.Tensor("float32"))
+    x3 = relax.Var("x", R.Tensor((2, 3)))
+    x4 = relax.Var("x", R.Tensor(ndim=2))
+    x5 = relax.Var("x", R.Tensor())
+    v0 = relax.Var("v", R.Tensor((), "float16"))
+    v1 = relax.Var("v", R.Tensor("float16", ndim=0))
+    v2 = relax.Var("v", R.Tensor(()))
+    v3 = relax.Var("v", R.Tensor(ndim=0))
+
+    _check_inference(bb, relax.op.full_like(x0, v0), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full_like(x0, v1), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full_like(x0, v2), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full_like(x0, v3), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(
+        bb, relax.op.full_like(x1, v0), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+    _check_inference(
+        bb, relax.op.full_like(x1, v1), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+    _check_inference(
+        bb, relax.op.full_like(x1, v2), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+    _check_inference(
+        bb, relax.op.full_like(x1, v3), relax.TensorStructInfo(dtype="float32", ndim=2)
+    )
+    _check_inference(bb, relax.op.full_like(x2, v0), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, relax.op.full_like(x2, v1), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, relax.op.full_like(x2, v2), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, relax.op.full_like(x2, v3), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, relax.op.full_like(x3, v0), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full_like(x3, v1), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full_like(x3, v2), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full_like(x3, v3), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full_like(x4, v0), relax.TensorStructInfo(dtype="", ndim=2))
+    _check_inference(bb, relax.op.full_like(x4, v1), relax.TensorStructInfo(dtype="", ndim=2))
+    _check_inference(bb, relax.op.full_like(x4, v2), relax.TensorStructInfo(dtype="", ndim=2))
+    _check_inference(bb, relax.op.full_like(x4, v3), relax.TensorStructInfo(dtype="", ndim=2))
+    _check_inference(bb, relax.op.full_like(x5, v0), relax.TensorStructInfo(dtype=""))
+    _check_inference(bb, relax.op.full_like(x5, v1), relax.TensorStructInfo(dtype=""))
+    _check_inference(bb, relax.op.full_like(x5, v2), relax.TensorStructInfo(dtype=""))
+    _check_inference(bb, relax.op.full_like(x5, v3), relax.TensorStructInfo(dtype=""))
+
+
+def test_full_like_infer_struct_info_shape_symbolic():
+    bb = relax.BlockBuilder()
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
+    x0 = relax.Var("x", R.Tensor((m, n), "float32"))
+    x1 = relax.Var("x", R.Tensor((m, n)))
+    v = relax.Var("v", R.Tensor((), "float16"))
+
+    _check_inference(bb, relax.op.full_like(x0, v), relax.TensorStructInfo((m, n), "float32"))
+    _check_inference(bb, relax.op.full_like(x1, v), relax.TensorStructInfo((m, n), dtype=""))
+
+
+def test_full_like_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo((2, 3)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+    x3 = relax.Var("x", R.Tensor((2, 3), "float32"))
+    sv0 = relax.Var("sv", relax.ShapeStructInfo(()))
+    sv1 = relax.Var("sv", relax.ShapeStructInfo(ndim=0))
+    v0 = relax.Var("v", relax.TensorStructInfo(sv0, "float16"))
+    v1 = relax.Var("v", relax.TensorStructInfo(sv1, "float16"))
+    v2 = relax.Var("v", R.Tensor((), "float16"))
+
+    _check_inference(bb, relax.op.full_like(x0, v0), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(bb, relax.op.full_like(x0, v1), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(bb, relax.op.full_like(x0, v2), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(bb, relax.op.full_like(x1, v0), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full_like(x1, v1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full_like(x1, v2), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full_like(x2, v0), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full_like(x2, v1), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full_like(x2, v2), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full_like(x3, v0), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full_like(x3, v1), relax.TensorStructInfo((2, 3), "float32"))
+
+
+def test_full_like_infer_struct_info_more_input_dtype():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3), "float16"))
+    x1 = relax.Var("x", R.Tensor((2, 3), "int8"))
+    v0 = relax.Var("v", R.Tensor((), "int32"))
+    v1 = relax.Var("v", R.Tensor((), "float64"))
+
+    _check_inference(bb, relax.op.full_like(x0, v0), relax.TensorStructInfo((2, 3), "float16"))
+    _check_inference(bb, relax.op.full_like(x0, v1), relax.TensorStructInfo((2, 3), "float16"))
+    _check_inference(bb, relax.op.full_like(x1, v0), relax.TensorStructInfo((2, 3), "int8"))
+    _check_inference(bb, relax.op.full_like(x1, v1), relax.TensorStructInfo((2, 3), "int8"))
+
+
+def test_full_like_infer_struct_info_fill_value_not_scalar_tensor():
+    bb = relax.BlockBuilder()
+    x = relax.Var("x", R.Tensor((2, 3), "float32"))
+    s0 = relax.Var("s", relax.ShapeStructInfo((1,)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=1))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    v0 = relax.Var("v", R.Tensor((1,), "float32"))
+    v1 = relax.Var("v", R.Tensor("float32", ndim=1))
+    v2 = relax.Var("v", R.Tensor("float32"))
+    v3 = relax.Var("v", relax.TensorStructInfo(s0, "float32"))
+    v4 = relax.Var("v", relax.TensorStructInfo(s1, "float32"))
+    v5 = relax.Var("v", relax.TensorStructInfo(s2, "float32"))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x, v0))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x, v1))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x, v2))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x, v3))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x, v4))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x, v5))
+
+
+def test_full_like_infer_struct_info_wrong_input_type():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", relax.ShapeStructInfo((2, 3)))
+    x1 = relax.Var("x", relax.FuncStructInfo([], R.Tensor((), "float32")))
+    x2 = relax.Var("x", R.Tensor((2, 3)))
+    v0 = relax.Var("v", R.Tensor(()))
+    v1 = relax.Var("v", relax.ShapeStructInfo(()))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x0, v0))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x1, v0))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.full_like(x2, v1))
+
+
+def test_ones_zeros_infer_struct_info():
+    bb = relax.BlockBuilder()
+    s0 = relax.ShapeExpr((2, 3))
+    s1 = relax.Var("s", relax.ShapeStructInfo((2, 3)))
+    s2 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s3 = relax.Var("s", relax.ShapeStructInfo())
+
+    _check_inference(
+        bb, relax.op.ones((2, 3), "float32"), relax.TensorStructInfo((2, 3), "float32")
+    )
+    _check_inference(bb, relax.op.ones(s0, "float32"), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.ones(s1, "float32"), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.ones(s2, "float32"), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.ones(s3, "float32"), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(
+        bb, relax.op.zeros((2, 3), "float32"), relax.TensorStructInfo((2, 3), "float32")
+    )
+    _check_inference(bb, relax.op.zeros(s0, "float32"), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.zeros(s1, "float32"), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.zeros(s2, "float32"), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.zeros(s3, "float32"), relax.TensorStructInfo(s3, "float32"))
+
+
+def test_ones_zeros_infer_struct_info_shape_symbolic():
+    bb = relax.BlockBuilder()
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
+    s0 = relax.ShapeExpr((m, n))
+    s1 = relax.Var("s", relax.ShapeStructInfo((m, n)))
+
+    _check_inference(
+        bb, relax.op.ones((m, n), "float32"), relax.TensorStructInfo((m, n), "float32")
+    )
+    _check_inference(bb, relax.op.ones(s0, "float32"), relax.TensorStructInfo((m, n), "float32"))
+    _check_inference(bb, relax.op.ones(s1, "float32"), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(
+        bb, relax.op.zeros((m, n), "float32"), relax.TensorStructInfo((m, n), "float32")
+    )
+    _check_inference(bb, relax.op.zeros(s0, "float32"), relax.TensorStructInfo((m, n), "float32"))
+    _check_inference(bb, relax.op.zeros(s1, "float32"), relax.TensorStructInfo(s1, "float32"))
+
+
+def test_ones_zeros_infer_struct_info_more_input_dtype():
+    bb = relax.BlockBuilder()
+    s0 = relax.ShapeExpr((2, 3))
+    s1 = relax.Var("s", relax.ShapeStructInfo((2, 3)))
+    s2 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s3 = relax.Var("s", relax.ShapeStructInfo())
+
+    _check_inference(bb, relax.op.ones(s0, "float16"), relax.TensorStructInfo((2, 3), "float16"))
+    _check_inference(bb, relax.op.ones(s1, "int8"), relax.TensorStructInfo(s1, "int8"))
+    _check_inference(bb, relax.op.zeros(s2, "int32"), relax.TensorStructInfo(s2, "int32"))
+    _check_inference(bb, relax.op.zeros(s3, "float64"), relax.TensorStructInfo(s3, "float64"))
+
+
+def test_ones_zeros_wrong_dtype():
+    with pytest.raises(TypeError):
+        relax.op.ones((2, 3))
+    with pytest.raises(TVMError):
+        relax.op.ones((2, 3), "")
+    with pytest.raises(TypeError):
+        relax.op.zeros((2, 3))
+    with pytest.raises(TVMError):
+        relax.op.zeros((2, 3), "")
+
+
+def test_ones_zeros_infer_struct_info_wrong_input_type():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", R.Tensor((2, 3)))
+    s1 = relax.Var("s", relax.FuncStructInfo([], R.Tensor((2, 3))))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.ones(s0, "float32"))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.zeros(s1, "float32"))
+
+
+def test_ones_like_zeros_like_infer_struct_info():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3), "float32"))
+    x1 = relax.Var("x", R.Tensor("float32", ndim=2))
+    x2 = relax.Var("x", R.Tensor("float32"))
+    x3 = relax.Var("x", R.Tensor((2, 3)))
+    x4 = relax.Var("x", R.Tensor(ndim=2))
+    x5 = relax.Var("x", R.Tensor())
+
+    _check_inference(bb, relax.op.ones_like(x0), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.ones_like(x1), relax.TensorStructInfo(dtype="float32", ndim=2))
+    _check_inference(bb, relax.op.ones_like(x2), relax.TensorStructInfo(dtype="float32"))
+    _check_inference(bb, relax.op.ones_like(x3), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.ones_like(x4), relax.TensorStructInfo(dtype="", ndim=2))
+    _check_inference(bb, relax.op.ones_like(x5), relax.TensorStructInfo(dtype=""))
+
+
+def test_ones_like_zeros_like_infer_struct_info_shape_symbolic():
+    bb = relax.BlockBuilder()
+    m = tir.Var("m", "int64")
+    n = tir.Var("n", "int64")
+    x0 = relax.Var("x", R.Tensor((m, n), "float32"))
+    x1 = relax.Var("x", R.Tensor((m, n)))
+
+    _check_inference(bb, relax.op.ones_like(x0), relax.TensorStructInfo((m, n), "float32"))
+    _check_inference(bb, relax.op.zeros_like(x1), relax.TensorStructInfo((m, n), dtype=""))
+
+
+def test_ones_like_zeros_like_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo((2, 3)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+
+    _check_inference(bb, relax.op.ones_like(x0), relax.TensorStructInfo(s0, "float32"))
+    _check_inference(bb, relax.op.zeros_like(x1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.zeros_like(x2), relax.TensorStructInfo(s2, "float32"))
+
+
+def test_ones_like_zeros_like_infer_struct_info_more_input_dtype():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3), "float64"))
+    x1 = relax.Var("x", R.Tensor((2, 3), "int8"))
+
+    _check_inference(bb, relax.op.ones_like(x0), relax.TensorStructInfo((2, 3), "float64"))
+    _check_inference(bb, relax.op.zeros_like(x1), relax.TensorStructInfo((2, 3), "int8"))
+
+
+def test_ones_like_zeros_like_infer_struct_info_wrong_input_type():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", relax.ShapeStructInfo((2, 3)))
+    x1 = relax.Var("x", relax.FuncStructInfo([], R.Tensor((2, 3), "float32")))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.ones_like(x0))
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.zeros_like(x1))
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_op_create.py
+++ b/tests/python/relax/test_op_create.py
@@ -26,7 +26,7 @@ from tvm.script import relax as R
 def test_op_correctness():
     x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
     fill_value = relax.Var("fill_value", R.Tensor((), "float32"))
-    assert relax.op.full(fill_value, (2, 3)).op == Op.get("relax.full")
+    assert relax.op.full((2, 3), fill_value).op == Op.get("relax.full")
     assert relax.op.full_like(x, fill_value).op == Op.get("relax.full_like")
     assert relax.op.ones((2, 3), "float32").op == Op.get("relax.ones")
     assert relax.op.ones_like(x).op == Op.get("relax.ones_like")
@@ -51,61 +51,75 @@ def test_full_infer_struct_info():
     s3 = relax.Var("s", relax.ShapeStructInfo())
 
     _check_inference(
-        bb, relax.op.full(v0, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full((2, 3), v0, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v0, (2, 3)), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full((2, 3), v0), relax.TensorStructInfo((2, 3), "float32"))
     _check_inference(
-        bb, relax.op.full(v0, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full(s0, v0, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v0, s0), relax.TensorStructInfo((2, 3), "float32"))
-    _check_inference(bb, relax.op.full(v0, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
-    _check_inference(bb, relax.op.full(v0, s1), relax.TensorStructInfo(s1, "float32"))
-    _check_inference(bb, relax.op.full(v0, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
-    _check_inference(bb, relax.op.full(v0, s2), relax.TensorStructInfo(s2, "float32"))
-    _check_inference(bb, relax.op.full(v0, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
-    _check_inference(bb, relax.op.full(v0, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(bb, relax.op.full(s0, v0), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full(s1, v0, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(s1, v0), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full(s2, v0, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(s2, v0), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full(s3, v0, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(s3, v0), relax.TensorStructInfo(s3, "float32"))
     _check_inference(
-        bb, relax.op.full(v1, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full((2, 3), v1, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v1, (2, 3)), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full((2, 3), v1), relax.TensorStructInfo((2, 3), "float32"))
     _check_inference(
-        bb, relax.op.full(v1, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full(s0, v1, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v1, s0), relax.TensorStructInfo((2, 3), "float32"))
-    _check_inference(bb, relax.op.full(v1, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
-    _check_inference(bb, relax.op.full(v1, s1), relax.TensorStructInfo(s1, "float32"))
-    _check_inference(bb, relax.op.full(v1, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
-    _check_inference(bb, relax.op.full(v1, s2), relax.TensorStructInfo(s2, "float32"))
-    _check_inference(bb, relax.op.full(v1, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
-    _check_inference(bb, relax.op.full(v1, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(bb, relax.op.full(s0, v1), relax.TensorStructInfo((2, 3), "float32"))
+    _check_inference(bb, relax.op.full(s1, v1, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(s1, v1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full(s2, v1, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(s2, v1), relax.TensorStructInfo(s2, "float32"))
+    _check_inference(bb, relax.op.full(s3, v1, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(s3, v1), relax.TensorStructInfo(s3, "float32"))
     _check_inference(
-        bb, relax.op.full(v2, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full((2, 3), v2, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v2, (2, 3)), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full((2, 3), v2), relax.TensorStructInfo((2, 3), dtype=""))
     _check_inference(
-        bb, relax.op.full(v2, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full(s0, v2, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v2, s0), relax.TensorStructInfo((2, 3), dtype=""))
-    _check_inference(bb, relax.op.full(v2, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
-    _check_inference(bb, relax.op.full(v2, s1), relax.TensorStructInfo(s1, dtype=""))
-    _check_inference(bb, relax.op.full(v2, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
-    _check_inference(bb, relax.op.full(v2, s2), relax.TensorStructInfo(s2, dtype=""))
-    _check_inference(bb, relax.op.full(v2, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
-    _check_inference(bb, relax.op.full(v2, s3), relax.TensorStructInfo(s3, dtype=""))
+    _check_inference(bb, relax.op.full(s0, v2), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full(s1, v2, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(s1, v2), relax.TensorStructInfo(s1, dtype=""))
+    _check_inference(bb, relax.op.full(s2, v2, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(bb, relax.op.full(s2, v2), relax.TensorStructInfo(s2, dtype=""))
+    _check_inference(bb, relax.op.full(s3, v2, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(s3, v2), relax.TensorStructInfo(s3, dtype=""))
     _check_inference(
-        bb, relax.op.full(v3, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full((2, 3), v3, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v3, (2, 3)), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full((2, 3), v3), relax.TensorStructInfo((2, 3), dtype=""))
     _check_inference(
-        bb, relax.op.full(v3, s0, "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full(s0, v3, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v3, s0), relax.TensorStructInfo((2, 3), dtype=""))
-    _check_inference(bb, relax.op.full(v3, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
-    _check_inference(bb, relax.op.full(v3, s1), relax.TensorStructInfo(s1, dtype=""))
-    _check_inference(bb, relax.op.full(v3, s2, "float16"), relax.TensorStructInfo(s2, "float16"))
-    _check_inference(bb, relax.op.full(v3, s2), relax.TensorStructInfo(s2, dtype=""))
-    _check_inference(bb, relax.op.full(v3, s3, "float16"), relax.TensorStructInfo(s3, "float16"))
-    _check_inference(bb, relax.op.full(v3, s3), relax.TensorStructInfo(s3, dtype=""))
+    _check_inference(bb, relax.op.full(s0, v3), relax.TensorStructInfo((2, 3), dtype=""))
+    _check_inference(bb, relax.op.full(s1, v3, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(
+        bb,
+        relax.op.full(
+            s1,
+            v3,
+        ),
+        relax.TensorStructInfo(s1, dtype=""),
+    )
+    _check_inference(bb, relax.op.full(s2, v3, "float16"), relax.TensorStructInfo(s2, "float16"))
+    _check_inference(
+        bb,
+        relax.op.full(
+            s2,
+            v3,
+        ),
+        relax.TensorStructInfo(s2, dtype=""),
+    )
+    _check_inference(bb, relax.op.full(s3, v3, "float16"), relax.TensorStructInfo(s3, "float16"))
+    _check_inference(bb, relax.op.full(s3, v3), relax.TensorStructInfo(s3, dtype=""))
 
 
 def test_full_infer_struct_info_shape_symbolic():
@@ -116,13 +130,13 @@ def test_full_infer_struct_info_shape_symbolic():
     s1 = relax.Var("s", relax.ShapeStructInfo((a, 3)))
 
     _check_inference(
-        bb, relax.op.full(v, (a, 3), "float16"), relax.TensorStructInfo((a, 3), "float16")
+        bb, relax.op.full((a, 3), v, "float16"), relax.TensorStructInfo((a, 3), "float16")
     )
-    _check_inference(bb, relax.op.full(v, (a, 3)), relax.TensorStructInfo((a, 3), "float32"))
-    _check_inference(bb, relax.op.full(v, s0, "float16"), relax.TensorStructInfo((a, 3), "float16"))
-    _check_inference(bb, relax.op.full(v, s0), relax.TensorStructInfo((a, 3), "float32"))
-    _check_inference(bb, relax.op.full(v, s1, "float16"), relax.TensorStructInfo(s1, "float16"))
-    _check_inference(bb, relax.op.full(v, s1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.full((a, 3), v), relax.TensorStructInfo((a, 3), "float32"))
+    _check_inference(bb, relax.op.full(s0, v, "float16"), relax.TensorStructInfo((a, 3), "float16"))
+    _check_inference(bb, relax.op.full(s0, v), relax.TensorStructInfo((a, 3), "float32"))
+    _check_inference(bb, relax.op.full(s1, v, "float16"), relax.TensorStructInfo(s1, "float16"))
+    _check_inference(bb, relax.op.full(s1, v), relax.TensorStructInfo(s1, "float32"))
 
 
 def test_full_infer_struct_info_shape_var():
@@ -133,10 +147,10 @@ def test_full_infer_struct_info_shape_var():
     v1 = relax.Var("v", relax.TensorStructInfo(s1, "float32"))
 
     _check_inference(
-        bb, relax.op.full(v0, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full((2, 3), v0, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
     _check_inference(
-        bb, relax.op.full(v1, (2, 3), "float16"), relax.TensorStructInfo((2, 3), "float16")
+        bb, relax.op.full((2, 3), v1, "float16"), relax.TensorStructInfo((2, 3), "float16")
     )
 
 
@@ -147,15 +161,15 @@ def test_full_infer_struct_info_more_input_dtype():
     v2 = relax.Var("v", R.Tensor((), "int32"))
 
     _check_inference(
-        bb, relax.op.full(v0, (2, 3), "float32"), relax.TensorStructInfo((2, 3), "float32")
+        bb, relax.op.full((2, 3), v0, "float32"), relax.TensorStructInfo((2, 3), "float32")
     )
-    _check_inference(bb, relax.op.full(v0, (2, 3)), relax.TensorStructInfo((2, 3), "float16"))
+    _check_inference(bb, relax.op.full((2, 3), v0), relax.TensorStructInfo((2, 3), "float16"))
     _check_inference(
-        bb, relax.op.full(v1, (2, 3), "int32"), relax.TensorStructInfo((2, 3), "int32")
+        bb, relax.op.full((2, 3), v1, "int32"), relax.TensorStructInfo((2, 3), "int32")
     )
-    _check_inference(bb, relax.op.full(v1, (2, 3)), relax.TensorStructInfo((2, 3), "int8"))
-    _check_inference(bb, relax.op.full(v2, (2, 3), "int8"), relax.TensorStructInfo((2, 3), "int8"))
-    _check_inference(bb, relax.op.full(v2, (2, 3)), relax.TensorStructInfo((2, 3), "int32"))
+    _check_inference(bb, relax.op.full((2, 3), v1), relax.TensorStructInfo((2, 3), "int8"))
+    _check_inference(bb, relax.op.full((2, 3), v2, "int8"), relax.TensorStructInfo((2, 3), "int8"))
+    _check_inference(bb, relax.op.full((2, 3), v2), relax.TensorStructInfo((2, 3), "int32"))
 
 
 def test_full_infer_struct_info_fill_value_not_scalar_tensor():
@@ -171,17 +185,17 @@ def test_full_infer_struct_info_fill_value_not_scalar_tensor():
     v5 = relax.Var("v", relax.TensorStructInfo(s2, "float32"))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v0, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v0))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v1, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v1))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v2, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v2))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v3, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v3))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v4, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v4))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v5, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v5))
 
 
 def test_full_shape_not_tuple():
@@ -189,9 +203,9 @@ def test_full_shape_not_tuple():
     v = relax.Var("v", R.Tensor((), "float32"))
 
     with pytest.raises(TVMError):
-        relax.op.full(v, 4)
+        relax.op.full(4, v)
     with pytest.raises(TVMError):
-        relax.op.full(v, m)
+        relax.op.full(m, v)
 
 
 def test_full_infer_struct_info_wrong_input_type():
@@ -202,11 +216,11 @@ def test_full_infer_struct_info_wrong_input_type():
     s = relax.Var("s", R.Tensor((2, 3)))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v0, s))
+        bb.normalize(relax.op.full(s, v0))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v1, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v1))
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.full(v2, (2, 3)))
+        bb.normalize(relax.op.full((2, 3), v2))
 
 
 def test_full_like_infer_struct_info():

--- a/tests/python/relax/test_op_create.py
+++ b/tests/python/relax/test_op_create.py
@@ -184,6 +184,16 @@ def test_full_infer_struct_info_fill_value_not_scalar_tensor():
         bb.normalize(relax.op.full(v5, (2, 3)))
 
 
+def test_full_shape_not_tuple():
+    m = tir.Var("m", "int64")
+    v = relax.Var("v", R.Tensor((), "float32"))
+
+    with pytest.raises(TVMError):
+        relax.op.full(v, 4)
+    with pytest.raises(TVMError):
+        relax.op.full(v, m)
+
+
 def test_full_infer_struct_info_wrong_input_type():
     bb = relax.BlockBuilder()
     v0 = relax.Var("v", R.Tensor((), "float32"))
@@ -395,6 +405,15 @@ def test_ones_zeros_infer_struct_info_more_input_dtype():
     _check_inference(bb, relax.op.ones(s1, "int8"), relax.TensorStructInfo(s1, "int8"))
     _check_inference(bb, relax.op.zeros(s2, "int32"), relax.TensorStructInfo(s2, "int32"))
     _check_inference(bb, relax.op.zeros(s3, "float64"), relax.TensorStructInfo(s3, "float64"))
+
+
+def test_ones_zeros_shape_not_tuple():
+    m = tir.Var("m", "int64")
+
+    with pytest.raises(TVMError):
+        relax.op.ones(10, "float32")
+    with pytest.raises(TVMError):
+        relax.op.zeros(m, "float32")
 
 
 def test_ones_zeros_wrong_dtype():

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -22,15 +22,8 @@ from tvm import TVMError
 from tvm.ir import Op
 from tvm.script import relax as R
 
-import numpy as np
-
 
 def test_op_correctness():
-    x = relax.Var("x", R.Tensor((2, 3), "float32"))
-    c = relax.Constant(tvm.nd.array(np.array([1, 2, 3], dtype="float16")))
-    assert relax.op.cast(x, "float16").op == Op.get("relax.cast")
-    assert relax.op.wrap_param(c, "float32").op == Op.get("relax.wrap_param")
-
     x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
     assert relax.op.reshape(x, (4, 5, 3)).op == Op.get("relax.reshape")
     assert relax.op.permute_dims(x).op == Op.get("relax.permute_dims")
@@ -42,82 +35,6 @@ def test_op_correctness():
 def _check_inference(bb: relax.BlockBuilder, call: relax.Call, expected_sinfo: relax.StructInfo):
     ret = bb.normalize(call)
     tvm.ir.assert_structural_equal(ret.struct_info, expected_sinfo)
-
-
-def test_cast_infer_struct_info():
-    bb = relax.BlockBuilder()
-    x0 = relax.Var("x", R.Tensor((2, 3), "float32"))
-    x1 = relax.Var("x", R.Tensor("float32", ndim=2))
-    x2 = relax.Var("x", R.Tensor("float32"))
-    x3 = relax.Var("x", R.Tensor((2, 3)))
-    x4 = relax.Var("x", R.Tensor(ndim=2))
-    x5 = relax.Var("x", R.Tensor())
-
-    _check_inference(bb, relax.op.cast(x0, "float16"), relax.TensorStructInfo((2, 3), "float16"))
-    _check_inference(
-        bb, relax.op.cast(x1, "float16"), relax.TensorStructInfo(dtype="float16", ndim=2)
-    )
-    _check_inference(bb, relax.op.cast(x2, "float16"), relax.TensorStructInfo(dtype="float16"))
-    _check_inference(bb, relax.op.cast(x3, "float16"), relax.TensorStructInfo((2, 3), "float16"))
-    _check_inference(
-        bb, relax.op.cast(x4, "float16"), relax.TensorStructInfo(dtype="float16", ndim=2)
-    )
-    _check_inference(bb, relax.op.cast(x5, "float16"), relax.TensorStructInfo(dtype="float16"))
-
-
-def test_cast_infer_struct_info_shape_symbolic():
-    bb = relax.BlockBuilder()
-    m = tir.Var("m", "int64")
-    n = tir.Var("n", "int64")
-    x0 = relax.Var("x", R.Tensor((m, n), "float32"))
-    x1 = relax.Var("x", R.Tensor((m, n)))
-
-    _check_inference(bb, relax.op.cast(x0, "float16"), relax.TensorStructInfo((m, n), "float16"))
-    _check_inference(bb, relax.op.cast(x1, "float16"), relax.TensorStructInfo((m, n), "float16"))
-
-
-def test_cast_infer_struct_info_shape_var():
-    bb = relax.BlockBuilder()
-    s0 = relax.Var("s", relax.ShapeStructInfo((2, 3)))
-    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
-    s2 = relax.Var("s", relax.ShapeStructInfo())
-    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
-    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
-    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
-
-    _check_inference(bb, relax.op.cast(x0, "float16"), relax.TensorStructInfo(s0, "float16"))
-    _check_inference(bb, relax.op.cast(x1, "float16"), relax.TensorStructInfo(s1, "float16"))
-    _check_inference(bb, relax.op.cast(x2, "float16"), relax.TensorStructInfo(s2, "float16"))
-
-
-def test_cast_infer_struct_info_more_input_dtype():
-    bb = relax.BlockBuilder()
-    x0 = relax.Var("x", R.Tensor((2, 3), "float16"))
-    x1 = relax.Var("x", R.Tensor((2, 3), "int8"))
-    x2 = relax.Var("x", R.Tensor((2, 3), "int32"))
-
-    _check_inference(bb, relax.op.cast(x0, "float32"), relax.TensorStructInfo((2, 3), "float32"))
-    _check_inference(bb, relax.op.cast(x1, "int32"), relax.TensorStructInfo((2, 3), "int32"))
-    _check_inference(bb, relax.op.cast(x2, "int8"), relax.TensorStructInfo((2, 3), "int8"))
-
-
-def test_cast_infer_struct_info_wrong_input_type():
-    bb = relax.BlockBuilder()
-    x0 = relax.Var("x", relax.ShapeStructInfo((2, 3)))
-    x1 = relax.Var("x", relax.FuncStructInfo([], R.Tensor((2, 3), "float32")))
-
-    with pytest.raises(TVMError):
-        bb.normalize(relax.op.cast(x0, "float16"))
-    with pytest.raises(TVMError):
-        bb.normalize(relax.op.cast(x1, "float16"))
-
-
-def test_wrap_param_infer_struct_info():
-    bb = relax.BlockBuilder()
-    x0 = relax.Constant(tvm.nd.array(np.zeros([1, 2, 3], dtype="float16")))
-    x1 = relax.Constant(tvm.nd.array(np.zeros([1, 2, 3], dtype="int8")))
-    _check_inference(bb, relax.op.cast(x0, "float32"), relax.TensorStructInfo((1, 2, 3), "float32"))
-    _check_inference(bb, relax.op.cast(x1, "int32"), relax.TensorStructInfo((1, 2, 3), "int32"))
 
 
 def test_reshape_infer_struct_into():

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -223,6 +223,16 @@ def test_reshape_infer_struct_info_inference_not_deducible():
         bb.normalize(relax.op.reshape(x3, (2, 3, -1)))
 
 
+def test_reshape_new_shape_not_tuple():
+    m = tir.Var("m", "int64")
+    x = relax.Var("x", R.Tensor((2, 3, 4, 5), "float32"))
+
+    with pytest.raises(TVMError):
+        relax.op.reshape(x, 120)
+    with pytest.raises(TVMError):
+        relax.op.reshape(x, m)
+
+
 def test_reshape_infer_struct_info_new_shape_not_integer():
     bb = relax.BlockBuilder()
     x = relax.Var("x", R.Tensor((2, 3, 4, 5), "float32"))

--- a/tests/python/relax/test_op_nn.py
+++ b/tests/python/relax/test_op_nn.py
@@ -104,7 +104,7 @@ def test_linear_unit_infer_struct_info_more_input_dtype():
     _check_inference(bb, relax.op.nn.relu(x2), relax.TensorStructInfo((2, 3), "int64"))
 
 
-def test_unary_arith_infer_struct_info_invalid_input_dtype():
+def test_linear_unit_infer_struct_info_invalid_input_dtype():
     bb = relax.BlockBuilder()
     x0 = relax.Var("x", R.Tensor((2, 3), "int8"))
     x1 = relax.Var("x", R.Tensor((2, 3), "int64"))

--- a/tests/python/relax/test_tvmscript_parser_create_ops.py
+++ b/tests/python/relax/test_tvmscript_parser_create_ops.py
@@ -37,13 +37,13 @@ def _check(
 def test_full():
     @R.function
     def foo(v: R.Tensor((), "int32")) -> R.Tensor((2, 3), "float32"):
-        gv: R.Tensor((2, 3), "float32") = R.full(v, (2, 3), dtype="float32")
+        gv: R.Tensor((2, 3), "float32") = R.full((2, 3), v, dtype="float32")
         return gv
 
     bb = relax.BlockBuilder()
     v = relax.Var("v", R.Tensor((), "int32"))
     with bb.function("foo", [v]):
-        gv = bb.emit(relax.op.full(v, (2, 3), "float32"))
+        gv = bb.emit(relax.op.full((2, 3), v, "float32"))
         bb.emit_func_output(gv)
 
     _check(foo, bb.get()["foo"])

--- a/tests/python/relax/test_tvmscript_parser_create_ops.py
+++ b/tests/python/relax/test_tvmscript_parser_create_ops.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Optional, Union
+
+import tvm
+import tvm.testing
+from tvm import IRModule, relax
+from tvm.script.parser import relax as R
+
+
+def _check(
+    parsed: Union[relax.Function, IRModule],
+    expect: Optional[Union[relax.Function, IRModule]],
+):
+    test = parsed.script(show_meta=True)
+    roundtrip_mod = tvm.script.parse(test)
+    tvm.ir.assert_structural_equal(parsed, roundtrip_mod)
+    if expect:
+        tvm.ir.assert_structural_equal(parsed, expect)
+
+
+def test_full():
+    @R.function
+    def foo(v: R.Tensor((), "int32")) -> R.Tensor((2, 3), "float32"):
+        gv: R.Tensor((2, 3), "float32") = R.full(v, (2, 3), dtype="float32")
+        return gv
+
+    bb = relax.BlockBuilder()
+    v = relax.Var("v", R.Tensor((), "int32"))
+    with bb.function("foo", [v]):
+        gv = bb.emit(relax.op.full(v, (2, 3), "float32"))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_full_like():
+    @R.function
+    def foo(
+        x: R.Tensor((2, 3), "float16"), v: R.Tensor((), "float32")
+    ) -> R.Tensor((2, 3), "float16"):
+        gv: R.Tensor((2, 3), "float16") = R.full_like(x, v)
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 3), "float16"))
+    v = relax.Var("y", R.Tensor((), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x, v]):
+        gv = bb.emit(relax.op.full_like(x, v))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_ones():
+    @R.function
+    def foo(dumb_param: R.Tensor()) -> R.Tensor((2, 3), "float32"):
+        gv: R.Tensor((2, 3), "float32") = R.ones((2, 3), "float32")
+        return gv
+
+    bb = relax.BlockBuilder()
+    dumb_param = relax.Var("dumb_param", R.Tensor())
+    with bb.function("foo", [dumb_param]):
+        gv = bb.emit(relax.op.ones((2, 3), "float32"))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_ones_like():
+    @R.function
+    def foo(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
+        gv: R.Tensor((2, 3), "float32") = R.ones_like(x)
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 3), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x]):
+        gv = bb.emit(relax.op.ones_like(x))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_zeros():
+    @R.function
+    def foo(dumb_param: R.Tensor()) -> R.Tensor((2, 3), "float32"):
+        gv: R.Tensor((2, 3), "float32") = R.zeros((2, 3), "float32")
+        return gv
+
+    bb = relax.BlockBuilder()
+    dumb_param = relax.Var("dumb_param", R.Tensor())
+    with bb.function("foo", [dumb_param]):
+        gv = bb.emit(relax.op.zeros((2, 3), "float32"))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+def test_zeros_like():
+    @R.function
+    def foo(x: R.Tensor((2, 3), "float32")) -> R.Tensor((2, 3), "float32"):
+        gv: R.Tensor((2, 3), "float32") = R.zeros_like(x)
+        return gv
+
+    x = relax.Var("x", R.Tensor((2, 3), "float32"))
+    bb = relax.BlockBuilder()
+    with bb.function("foo", [x]):
+        gv = bb.emit(relax.op.zeros_like(x))
+        bb.emit_func_output(gv)
+
+    _check(foo, bb.get()["foo"])
+
+
+if __name__ == "__foo__":
+    tvm.testing.main()


### PR DESCRIPTION
Following #78, this PR is the second part of transformation operator migration, as listed in #62.

It contains operators
* Cast
* Full / FullLike 
* Zeros / ZerosLike
* Ones / OnesLike

Migrate these op first to unblock some parallelism on, like, auto differentiation.