### PR TITLE
[Op][Manip] collapse_sum_like, collapse_sum_to

### DIFF
--- a/python/tvm/relax/op/manipulate.py
+++ b/python/tvm/relax/op/manipulate.py
@@ -165,7 +165,11 @@ def concat(data: Union[Expr, List[Expr]], axis: Optional[int] = 0) -> Expr:
     return _ffi_api.concat(data, axis)  # type: ignore
 
 
-def split(data: Expr, indices_or_sections: Union[int, List[PrimExprLike]], axis: int = 0) -> Expr:
+def split(
+    data: Expr,
+    indices_or_sections: Union[int, List[PrimExprLike]],
+    axis: int = 0,
+) -> Expr:
     """Split input tensor along axis by sections or indices.
 
     If indices_or_sections is an integer, the input will be divided equally

--- a/python/tvm/relax/op/manipulate.py
+++ b/python/tvm/relax/op/manipulate.py
@@ -239,7 +239,7 @@ def collapse_sum_like(data: Expr, collapse_target: Expr) -> Expr:
     result : relax.Expr
         The result tensor after summation.
     """
-    return _ffi_api.collapse_sum_like(data, collapse_target)
+    return _ffi_api.collapse_sum_like(data, collapse_target)  # type: ignore
 
 
 def collapse_sum_to(data: Expr, shape: Union[Tuple[PrimExprLike], Expr]) -> Expr:
@@ -271,4 +271,4 @@ def collapse_sum_to(data: Expr, shape: Union[Tuple[PrimExprLike], Expr]) -> Expr
     """
     if isinstance(shape, (tuple, list)):
         shape = ShapeExpr(shape)
-    return _ffi_api.collapse_sum_to(data, shape)
+    return _ffi_api.collapse_sum_to(data, shape)  # type: ignore

--- a/python/tvm/relax/op/manipulate.py
+++ b/python/tvm/relax/op/manipulate.py
@@ -165,7 +165,7 @@ def concat(data: Union[Expr, List[Expr]], axis: Optional[int] = 0) -> Expr:
     return _ffi_api.concat(data, axis)  # type: ignore
 
 
-def split(data: Expr, indices_or_sections: Union[int, List[PrimExprLike]], axis: int = 0,) -> Expr:
+def split(data: Expr, indices_or_sections: Union[int, List[PrimExprLike]], axis: int = 0) -> Expr:
     """Split input tensor along axis by sections or indices.
 
     If indices_or_sections is an integer, the input will be divided equally
@@ -238,9 +238,7 @@ def collapse_sum_like(data: Expr, collapse_target: Expr) -> Expr:
     return _ffi_api.collapse_sum_like(data, collapse_target)
 
 
-def collapse_sum_to(
-    data: Expr, shape: Union[Tuple[PrimExprLike], Expr]
-) -> Expr:
+def collapse_sum_to(data: Expr, shape: Union[Tuple[PrimExprLike], Expr]) -> Expr:
     """Return a summation of data to the given shape.
 
     collapse_sum_to is intended as the backward operator of tvm.relax.op.broadcast_to and

--- a/python/tvm/relax/op/manipulate.py
+++ b/python/tvm/relax/op/manipulate.py
@@ -22,7 +22,6 @@ from tvm.tir import IntImm
 
 from . import _ffi_api
 from ..expr import Expr, ShapeExpr, Tuple as RxTuple
-from ..expr import Expr, ShapeExpr, Tuple as RxTuple
 
 
 PrimExprLike = Union[int, PrimExpr]
@@ -240,7 +239,7 @@ def collapse_sum_like(data: Expr, collapse_target: Expr) -> Expr:
 
 
 def collapse_sum_to(
-    data: Expr, shape: Union[List[PrimExprLike], Tuple[PrimExprLike], Expr]
+    data: Expr, shape: Union[Tuple[PrimExprLike], Expr]
 ) -> Expr:
     """Return a summation of data to the given shape.
 
@@ -248,21 +247,19 @@ def collapse_sum_to(
     other broadcast operators in the automatic differentiation process.
 
     We expect that data is the result of broadcasting some tensor of the given shape in some
-    broadcast operation. Thus the given shape and data.shape must follow broadcast rules.
+    broadcast operation. Thus the given `shape` and `data.shape` must follow broadcast rules.
 
-    During computation, the axes of data.shape and shape are checked from right to left. For every
-    axis, if it either:
-    - exist in data but not in collapse_target, or
-    - is larger than 1 in data and equals to 1 in collapse_target,
-
-    data will be summed over this axis.
+    During computation, all axes of `data.shape` and `shape` are checked from right to left.
+    For an axis, if it follows these rules, `data` will be summed over this axis:
+    - the axis exists in `data.shape` but not in `shape`, or
+    - the axis exists in `data.shape` and equals to 1 in `shape`.
 
     Parameters
     ----------
     data : relax.Expr
         The input tensor.
 
-    shape : Union[List[PrimExprLike], Tuple[PrimExprLike], relax.Expr]
+    shape : Union[Tuple[PrimExprLike], relax.Expr]
         The shape to collapse to.
 
     Returns

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -94,7 +94,9 @@ from . import _ffi_api, frame
 
 
 def tensor(
-    shape: Optional[List[Union[PrimExpr, str]]] = None, dtype: Optional[str] = None, ndim: int = -1
+    shape: Optional[List[Union[PrimExpr, str]]] = None,
+    dtype: Optional[str] = None,
+    ndim: int = -1,
 ) -> TensorStructInfo:
     """Helper function for `R.Tensor` in parser
     Parameters
@@ -399,7 +401,8 @@ def Else() -> frame.ElseFrame:  # pylint: disable=invalid-name
 
 
 def RewriteSymbolicShape(
-    struct_info: StructInfo, var_table: Dict[str, tvm.tir.Var]
+    struct_info: StructInfo,
+    var_table: Dict[str, tvm.tir.Var],
 ) -> Tuple[StructInfo, List[tvm.tir.Var]]:
     """Helper function to rewrite symbolic shape
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -94,7 +94,7 @@ from . import _ffi_api, frame
 
 
 def tensor(
-    shape: Optional[List[Union[PrimExpr, str]]] = None, dtype: Optional[str] = None, ndim: int = -1,
+    shape: Optional[List[Union[PrimExpr, str]]] = None, dtype: Optional[str] = None, ndim: int = -1
 ) -> TensorStructInfo:
     """Helper function for `R.Tensor` in parser
     Parameters
@@ -399,7 +399,7 @@ def Else() -> frame.ElseFrame:  # pylint: disable=invalid-name
 
 
 def RewriteSymbolicShape(
-    struct_info: StructInfo, var_table: Dict[str, tvm.tir.Var],
+    struct_info: StructInfo, var_table: Dict[str, tvm.tir.Var]
 ) -> Tuple[StructInfo, List[tvm.tir.Var]]:
     """Helper function to rewrite symbolic shape
 

--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -34,6 +34,8 @@ from tvm.relax.op import (
     broadcast_to,
     builtin,
     call_tir,
+    collapse_sum_like,
+    collapse_sum_to,
     concat,
     cos,
     divide,
@@ -92,9 +94,7 @@ from . import _ffi_api, frame
 
 
 def tensor(
-    shape: Optional[List[Union[PrimExpr, str]]] = None,
-    dtype: Optional[str] = None,
-    ndim: int = -1,
+    shape: Optional[List[Union[PrimExpr, str]]] = None, dtype: Optional[str] = None, ndim: int = -1,
 ) -> TensorStructInfo:
     """Helper function for `R.Tensor` in parser
     Parameters
@@ -399,8 +399,7 @@ def Else() -> frame.ElseFrame:  # pylint: disable=invalid-name
 
 
 def RewriteSymbolicShape(
-    struct_info: StructInfo,
-    var_table: Dict[str, tvm.tir.Var],
+    struct_info: StructInfo, var_table: Dict[str, tvm.tir.Var],
 ) -> Tuple[StructInfo, List[tvm.tir.Var]]:
     """Helper function to rewrite symbolic shape
 
@@ -444,6 +443,8 @@ __all__ = [
     "builtin",
     "call_packed",
     "call_tir",
+    "collapse_sum_like",
+    "collapse_sum_to",
     "concat",
     "const",
     "cos",

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -798,5 +798,125 @@ TVM_REGISTER_OP("relax.broadcast_to")
     .add_argument("shape", "Shape", "The target shape.")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoBroadcastTo);
 
+void CheckCollapseShape(const Call& call, const BlockBuilder& ctx,
+                        const Array<PrimExpr>& data_shape, const Array<PrimExpr>& target_shape) {
+  arith::Analyzer* analyzer = ctx->GetAnalyzer();
+
+  int data_ndim = data_shape.size();
+  int target_ndim = target_shape.size();
+
+  int data_ax = data_ndim - 1, target_ax = target_ndim - 1;
+  for (; data_ax >= 0; --data_ax) {
+    if (target_ax < 0) {
+      continue;
+    }
+    const PrimExpr& dim0 = data_shape[data_ax];
+    const PrimExpr& dim1 = target_shape[target_ax];
+    const auto* int_dim0 = dim0.as<IntImmNode>();
+    const auto* int_dim1 = dim1.as<IntImmNode>();
+
+    if (analyzer->CanProveEqual(dim0, dim1) || (int_dim1 != nullptr && int_dim1->value == 1)) {
+      --target_ax;
+    } else if (int_dim0 && int_dim1 && int_dim0->value != int_dim1->value) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << "In " << call->op << ", the data shape at dim " << data_ax << " is "
+                       << dim0 << " and the target shape at dim " << target_ax << " is " << dim1
+                       << ", which do not match the rule of collapse sum.");
+    } else {
+      // We are providing best effort check. In this case where we are
+      // not sure about it, just continue and check next.
+      --target_ax;
+    }
+  }
+}
+
+/* relax.collapse_sum_like */
+Expr collapse_sum_like(Expr data, Expr collapse_target) {
+  static const Op& op = Op::Get("relax.collapse_sum_like");
+  return Call(op, {std::move(data), std::move(collapse_target)}, Attrs(), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.collapse_sum_like").set_body_typed(collapse_sum_like);
+
+StructInfo InferStructInfoCollapseSumLike(const Call& call, const BlockBuilder& ctx) {
+  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
+  TensorStructInfo data_sinfo = input_sinfo[0];
+  TensorStructInfo collapse_target_sinfo = input_sinfo[1];
+
+  DataType output_dtype = data_sinfo->dtype;
+
+  auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
+  auto* collapse_target_shape = collapse_target_sinfo->shape.as<ShapeExprNode>();
+
+  if (data_shape && collapse_target_shape) {
+    CheckCollapseShape(call, ctx, data_shape->values, collapse_target_shape->values);
+  }
+
+  if (collapse_target_sinfo->shape.defined()) {
+    return TensorStructInfo(collapse_target_sinfo->shape.value(), output_dtype);
+  } else {
+    int output_ndim;
+    if (collapse_target_sinfo->IsUnknownNdim()) {
+      output_ndim = kUnknownNDim;
+    } else {
+      output_ndim = collapse_target_sinfo->ndim;
+    }
+    return TensorStructInfo(output_dtype, /*ndim=*/output_ndim);
+  }
+}
+
+TVM_REGISTER_OP("relax.collapse_sum_like")
+    .set_num_inputs(2)
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_argument("collapse_target", "Tensor",
+                  "The tensor whose shape is the shape to collapse to.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCollapseSumLike);
+
+/* relax.collapse_sum_to */
+Expr collapse_sum_to(Expr data, Expr shape) {
+  static const Op& op = Op::Get("relax.collapse_sum_to");
+  return Call(op, {std::move(data), std::move(shape)}, Attrs(), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.collapse_sum_to").set_body_typed(collapse_sum_to);
+
+StructInfo InferStructInfoCollapseSumTo(const Call& call, const BlockBuilder& ctx) {
+  if (call->args.size() != 2) {
+    ctx->ReportFatal(Diagnostic::Error(call) << "CollapseSumTo should have 2 arguments");
+  }
+
+  const auto* data_sinfo = GetStructInfoAs<TensorStructInfoNode>(call->args[0]);
+  const auto* shape_sinfo = GetStructInfoAs<ShapeStructInfoNode>(call->args[1]);
+
+  if (data_sinfo == nullptr) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << "CollapseSumTo requires the input data to be a Tensor. However, the given one is "
+        << call->args[0]->struct_info_->GetTypeKey());
+  }
+  if (shape_sinfo == nullptr) {
+    ctx->ReportFatal(
+        Diagnostic::Error(call)
+        << "CollapseSumTo requires the input shape to be a Shape. However, the given one is "
+        << call->args[0]->struct_info_->GetTypeKey());
+  }
+
+  DataType output_dtype = data_sinfo->dtype;
+
+  auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
+
+  if (data_shape && shape_sinfo->values.defined()) {
+    CheckCollapseShape(call, ctx, data_shape->values, shape_sinfo->values.value());
+  }
+
+  return TensorStructInfo(/*shape=*/call->args[1], output_dtype);
+}
+
+TVM_REGISTER_OP("relax.collapse_sum_to")
+    .set_num_inputs(2)
+    .add_argument("data", "Tensor", "The input tensor.")
+    .add_argument("shape", "Shape", "The shape to collapse to.")
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCollapseSumTo);
+
 }  // namespace relax
 }  // namespace tvm

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -851,11 +851,18 @@ StructInfo InferStructInfoCollapseSumLike(const Call& call, const BlockBuilder& 
 
   DataType output_dtype = data_sinfo->dtype;
 
-  auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
-  auto* collapse_target_shape = collapse_target_sinfo->shape.as<ShapeExprNode>();
+  Optional<Array<PrimExpr>> data_shape_value;
+  if (data_sinfo->shape.defined()) {
+    data_shape_value = GetStructInfoAs<ShapeStructInfoNode>(data_sinfo->shape.value())->values;
+  }
+  Optional<Array<PrimExpr>> collapse_target_shape_value;
+  if (collapse_target_sinfo->shape.defined()) {
+    collapse_target_shape_value =
+        GetStructInfoAs<ShapeStructInfoNode>(collapse_target_sinfo->shape.value())->values;
+  }
 
-  if (data_shape && collapse_target_shape) {
-    CheckCollapseShape(call, ctx, data_shape->values, collapse_target_shape->values);
+  if (data_shape_value.defined() && collapse_target_shape_value.defined()) {
+    CheckCollapseShape(call, ctx, data_shape_value.value(), collapse_target_shape_value.value());
   }
 
   if (collapse_target_sinfo->shape.defined()) {
@@ -903,10 +910,13 @@ StructInfo InferStructInfoCollapseSumTo(const Call& call, const BlockBuilder& ct
 
   DataType output_dtype = data_sinfo->dtype;
 
-  auto* data_shape = data_sinfo->shape.as<ShapeExprNode>();
+  Optional<Array<PrimExpr>> data_shape_value;
+  if (data_sinfo->shape.defined()) {
+    data_shape_value = GetStructInfoAs<ShapeStructInfoNode>(data_sinfo->shape.value())->values;
+  }
 
-  if (data_shape && shape_sinfo->values.defined()) {
-    CheckCollapseShape(call, ctx, data_shape->values, shape_sinfo->values.value());
+  if (data_shape_value.defined() && shape_sinfo->values.defined()) {
+    CheckCollapseShape(call, ctx, data_shape_value.value(), shape_sinfo->values.value());
   }
 
   return TensorStructInfo(/*shape=*/call->args[1], output_dtype);

--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -829,8 +829,8 @@ void CheckCollapseShape(const Call& call, const BlockBuilder& ctx,
       ctx->ReportFatal(Diagnostic::Error(call)
                        << call->op
                        << " fails to match the axes because of unknown dim or symbolic"
-                          "shape. In this position the dim of data shape is "
-                       << dim0 << "while the dim of target shape is " << dim1
+                          " shape. In this position the dim of data shape is "
+                       << dim0 << " while the dim of target shape is " << dim1
                        << ". If it is symbolic, consider use MatchCast first.");
     }
   }

--- a/src/relax/op/tensor/manipulate.h
+++ b/src/relax/op/tensor/manipulate.h
@@ -103,7 +103,7 @@ Expr broadcast_to(Expr data, Expr shape);
 
 /*!
  * \brief Return a summation of data to the shape of collapse_target.
- * For details, please see collapse_sum_to.
+ * For details, please see the operator `relax.collapse_sum_to`.
  * \param data The input tensor.
  * \param collapse_target The tensor whose shape is the shape to collapse to.
  * \return The result tensor after summation.

--- a/src/relax/op/tensor/manipulate.h
+++ b/src/relax/op/tensor/manipulate.h
@@ -101,6 +101,27 @@ Expr split(Expr data, ObjectRef indices_or_sections, int axis);
 /*! \brief Broadcasts a tensor to a specified shape. */
 Expr broadcast_to(Expr data, Expr shape);
 
+/*!
+ * \brief Return a summation of data to the shape of collapse_target.
+ * For details, please see collapse_sum_to.
+ * \param data The input tensor.
+ * \param collapse_target The tensor whose shape is the shape to collapse to.
+ * \return The result tensor after summation.
+ */
+Expr collapse_sum_like(Expr data, Expr collapse_target);
+
+/*!
+ * \brief Return a summation of data to the given shape.
+ * collapse_sum_to is intended as the backward operator of broadcast_to and
+ * other broadcast operators in the automatic differentiation process.
+ * We expect that data is the result of broadcasting some tensor of the given shape in some
+ * broadcast operation. Thus the given shape and data.shape must follow broadcast rules.
+ * \param data The input tensor.
+ * \param shape The shape to collapse to.
+ * \return The result tensor of the given shape after summation.
+ */
+Expr collapse_sum_to(Expr data, Expr shape);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2267,15 +2267,9 @@ def test_collapse_sum_like_infer_struct_info_shape_var():
     y1 = relax.Var("y", relax.TensorStructInfo(s4, "float32"))
     y2 = relax.Var("y", relax.TensorStructInfo(s5, "float32"))
 
-    _check_inference(
-        bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo(s3, "float32")
-    )
-    _check_inference(
-        bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo(s4, "float32")
-    )
-    _check_inference(
-        bb, relax.op.collapse_sum_like(x2, y2), relax.TensorStructInfo(s5, "float32")
-    )
+    _check_inference(bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo(s4, "float32"))
+    _check_inference(bb, relax.op.collapse_sum_like(x2, y2), relax.TensorStructInfo(s5, "float32"))
 
 
 def test_collapse_sum_like_infer_struct_info_more_input_dtype():
@@ -2288,9 +2282,7 @@ def test_collapse_sum_like_infer_struct_info_more_input_dtype():
     _check_inference(
         bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo((3, 4), "float16")
     )
-    _check_inference(
-        bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo((3, 4), "int8")
-    )
+    _check_inference(bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo((3, 4), "int8"))
 
 
 def test_collapse_sum_like_wrong_input_type():
@@ -2419,6 +2411,75 @@ def test_collapse_sum_to_check_shape_failure():
 
     with pytest.raises(TVMError):
         bb.normalize(relax.op.collapse_sum_to(y, (4,)))
+
+
+def test_collapse_sum_to_struct_info_tgt_shape_var():
+    bb = relax.BlockBuilder()
+    a = tir.Var("a", "int64")
+    b = tir.Var("b", "int64")
+    c = tir.Var("c", "int64")
+    d = tir.Var("d", "int64")
+    s0 = relax.Var("s", relax.ShapeStructInfo((3, a, b)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=3))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", R.Tensor((3, a, b), "float32"))
+    x1 = relax.Var("x", R.Tensor("float32", ndim=3))
+    x2 = relax.Var("x", R.Tensor(""))
+    x3 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x4 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x5 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+    stgt0 = relax.Var("stgt", relax.ShapeStructInfo((a, b)))
+    stgt1 = relax.Var("stgt", relax.ShapeStructInfo(ndim=2))
+    stgt2 = relax.Var("stgt", relax.ShapeStructInfo())
+
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x0, stgt0), relax.TensorStructInfo(stgt0, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, stgt0), relax.TensorStructInfo(stgt0, "float32")
+    )
+    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt0), relax.TensorStructInfo(stgt0, ""))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x3, stgt0), relax.TensorStructInfo(stgt0, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x4, stgt0), relax.TensorStructInfo(stgt0, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x5, stgt0), relax.TensorStructInfo(stgt0, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x0, stgt1), relax.TensorStructInfo(stgt1, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, stgt1), relax.TensorStructInfo(stgt1, "float32")
+    )
+    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt1), relax.TensorStructInfo(stgt1, ""))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x3, stgt1), relax.TensorStructInfo(stgt1, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x4, stgt1), relax.TensorStructInfo(stgt1, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x5, stgt1), relax.TensorStructInfo(stgt1, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x0, stgt2), relax.TensorStructInfo(stgt2, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, stgt2), relax.TensorStructInfo(stgt2, "float32")
+    )
+    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt2), relax.TensorStructInfo(stgt2, ""))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x3, stgt2), relax.TensorStructInfo(stgt2, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x4, stgt2), relax.TensorStructInfo(stgt2, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x5, stgt2), relax.TensorStructInfo(stgt2, "float32")
+    )
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -40,7 +40,7 @@ def _check_inference(bb: relax.BlockBuilder, call: relax.Call, expected_sinfo: r
     tvm.ir.assert_structural_equal(ret.struct_info, expected_sinfo)
 
 
-def test_reshape_infer_struct_into():
+def test_reshape_infer_struct_info():
     bb = relax.BlockBuilder()
     x0 = relax.Var("x", R.Tensor((2, 3, 4, 5), "float32"))
     x1 = relax.Var("x", R.Tensor("float32", ndim=4))
@@ -175,7 +175,7 @@ def test_reshape_infer_struct_info_shape_var():
     _check_inference(bb, relax.op.reshape(x2, ns1), relax.TensorStructInfo(ns1, "float32"))
 
 
-def test_reshape_infer_struct_into_more_input_dtype():
+def test_reshape_infer_struct_info_more_input_dtype():
     bb = relax.BlockBuilder()
     x0 = relax.Var("x", R.Tensor((2, 3, 4, 5), "float16"))
     x1 = relax.Var("x", R.Tensor((2, 3, 4, 5), "int8"))
@@ -2330,20 +2330,19 @@ def test_collapse_sum_to_infer_struct_info():
     x3 = relax.Var("x", R.Tensor((2, 3, 4)))
     x4 = relax.Var("x", R.Tensor(ndim=3))
     x5 = relax.Var("x", R.Tensor())
-    s0 = (3, 4)
 
     _check_inference(
-        bb, relax.op.collapse_sum_to(x0, s0), relax.TensorStructInfo((3, 4), "float32")
+        bb, relax.op.collapse_sum_to(x0, (3, 4)), relax.TensorStructInfo((3, 4), "float32")
     )
     _check_inference(
-        bb, relax.op.collapse_sum_to(x1, s0), relax.TensorStructInfo((3, 4), "float32")
+        bb, relax.op.collapse_sum_to(x1, (3, 4)), relax.TensorStructInfo((3, 4), "float32")
     )
     _check_inference(
-        bb, relax.op.collapse_sum_to(x2, s0), relax.TensorStructInfo((3, 4), "float32")
+        bb, relax.op.collapse_sum_to(x2, (3, 4)), relax.TensorStructInfo((3, 4), "float32")
     )
-    _check_inference(bb, relax.op.collapse_sum_to(x3, s0), relax.TensorStructInfo((3, 4), ""))
-    _check_inference(bb, relax.op.collapse_sum_to(x4, s0), relax.TensorStructInfo((3, 4), ""))
-    _check_inference(bb, relax.op.collapse_sum_to(x5, s0), relax.TensorStructInfo((3, 4), ""))
+    _check_inference(bb, relax.op.collapse_sum_to(x3, (3, 4)), relax.TensorStructInfo((3, 4), ""))
+    _check_inference(bb, relax.op.collapse_sum_to(x4, (3, 4)), relax.TensorStructInfo((3, 4), ""))
+    _check_inference(bb, relax.op.collapse_sum_to(x5, (3, 4)), relax.TensorStructInfo((3, 4), ""))
 
 
 def test_collapse_sum_to_infer_struct_info_shape_symbolic():
@@ -2351,15 +2350,13 @@ def test_collapse_sum_to_infer_struct_info_shape_symbolic():
     a = tir.Var("a", "int64")
     b = tir.Var("b", "int64")
     x0 = relax.Var("x", R.Tensor((3, 4, a), "float32"))
-    s0 = (4, a)
     x1 = relax.Var("x", R.Tensor((3, 4, b + a), "float32"))
-    s1 = (1, a + b)
 
     _check_inference(
-        bb, relax.op.collapse_sum_to(x0, s0), relax.TensorStructInfo((4, a), "float32")
+        bb, relax.op.collapse_sum_to(x0, (4, a)), relax.TensorStructInfo((4, a), "float32")
     )
     _check_inference(
-        bb, relax.op.collapse_sum_to(x1, s1), relax.TensorStructInfo((1, a + b), "float32")
+        bb, relax.op.collapse_sum_to(x1, (1, a + b)), relax.TensorStructInfo((1, a + b), "float32")
     )
 
 

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -131,7 +131,9 @@ def test_reshape_infer_struct_info_shape_symbolic():
         relax.TensorStructInfo((c, tir.floordiv(a * b * c * d, c * d * b), d, b), "float32"),
     )
     _check_inference(
-        bb, relax.op.reshape(x, (c, a * d, b)), relax.TensorStructInfo((c, a * d, b), "float32"),
+        bb,
+        relax.op.reshape(x, (c, a * d, b)),
+        relax.TensorStructInfo((c, a * d, b), "float32"),
     )
     _check_inference(
         bb,
@@ -2438,7 +2440,9 @@ def test_collapse_sum_to_struct_info_tgt_shape_var():
     _check_inference(
         bb, relax.op.collapse_sum_to(x1, stgt0), relax.TensorStructInfo(stgt0, "float32")
     )
-    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt0), relax.TensorStructInfo(stgt0, ""))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x2, stgt0), relax.TensorStructInfo(stgt0, "")
+    )
     _check_inference(
         bb, relax.op.collapse_sum_to(x3, stgt0), relax.TensorStructInfo(stgt0, "float32")
     )
@@ -2454,7 +2458,9 @@ def test_collapse_sum_to_struct_info_tgt_shape_var():
     _check_inference(
         bb, relax.op.collapse_sum_to(x1, stgt1), relax.TensorStructInfo(stgt1, "float32")
     )
-    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt1), relax.TensorStructInfo(stgt1, ""))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x2, stgt1), relax.TensorStructInfo(stgt1, "")
+    )
     _check_inference(
         bb, relax.op.collapse_sum_to(x3, stgt1), relax.TensorStructInfo(stgt1, "float32")
     )
@@ -2470,7 +2476,9 @@ def test_collapse_sum_to_struct_info_tgt_shape_var():
     _check_inference(
         bb, relax.op.collapse_sum_to(x1, stgt2), relax.TensorStructInfo(stgt2, "float32")
     )
-    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt2), relax.TensorStructInfo(stgt2, ""))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x2, stgt2), relax.TensorStructInfo(stgt2, "")
+    )
     _check_inference(
         bb, relax.op.collapse_sum_to(x3, stgt2), relax.TensorStructInfo(stgt2, "float32")
     )

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2440,9 +2440,7 @@ def test_collapse_sum_to_struct_info_tgt_shape_var():
     _check_inference(
         bb, relax.op.collapse_sum_to(x1, stgt0), relax.TensorStructInfo(stgt0, "float32")
     )
-    _check_inference(
-        bb, relax.op.collapse_sum_to(x2, stgt0), relax.TensorStructInfo(stgt0, "")
-    )
+    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt0), relax.TensorStructInfo(stgt0, ""))
     _check_inference(
         bb, relax.op.collapse_sum_to(x3, stgt0), relax.TensorStructInfo(stgt0, "float32")
     )
@@ -2458,9 +2456,7 @@ def test_collapse_sum_to_struct_info_tgt_shape_var():
     _check_inference(
         bb, relax.op.collapse_sum_to(x1, stgt1), relax.TensorStructInfo(stgt1, "float32")
     )
-    _check_inference(
-        bb, relax.op.collapse_sum_to(x2, stgt1), relax.TensorStructInfo(stgt1, "")
-    )
+    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt1), relax.TensorStructInfo(stgt1, ""))
     _check_inference(
         bb, relax.op.collapse_sum_to(x3, stgt1), relax.TensorStructInfo(stgt1, "float32")
     )
@@ -2476,9 +2472,7 @@ def test_collapse_sum_to_struct_info_tgt_shape_var():
     _check_inference(
         bb, relax.op.collapse_sum_to(x1, stgt2), relax.TensorStructInfo(stgt2, "float32")
     )
-    _check_inference(
-        bb, relax.op.collapse_sum_to(x2, stgt2), relax.TensorStructInfo(stgt2, "")
-    )
+    _check_inference(bb, relax.op.collapse_sum_to(x2, stgt2), relax.TensorStructInfo(stgt2, ""))
     _check_inference(
         bb, relax.op.collapse_sum_to(x3, stgt2), relax.TensorStructInfo(stgt2, "float32")
     )

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2196,12 +2196,12 @@ def test_collapse_sum_like_infer_struct_info():
     x3 = relax.Var("x", R.Tensor((2, 3, 4)))
     x4 = relax.Var("x", R.Tensor(ndim=3))
     x5 = relax.Var("x", R.Tensor())
-    y0 = relax.Var("x", R.Tensor((3, 4), "float32"))
-    y1 = relax.Var("x", R.Tensor("float32", ndim=2))
-    y2 = relax.Var("x", R.Tensor("float32"))
-    y3 = relax.Var("x", R.Tensor((3, 4)))
-    y4 = relax.Var("x", R.Tensor(ndim=2))
-    y5 = relax.Var("x", R.Tensor((1, 4)))
+    y0 = relax.Var("y", R.Tensor((3, 4), "float32"))
+    y1 = relax.Var("y", R.Tensor("float32", ndim=2))
+    y2 = relax.Var("y", R.Tensor("float32"))
+    y3 = relax.Var("y", R.Tensor((3, 4)))
+    y4 = relax.Var("y", R.Tensor(ndim=2))
+    y5 = relax.Var("y", R.Tensor((1, 4)))
 
     _check_inference(
         bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo((3, 4), "float32")
@@ -2235,6 +2235,64 @@ def test_collapse_sum_like_infer_struct_info():
     )
 
 
+def test_collapse_sum_like_infer_struct_info_shape_symbolic():
+    bb = relax.BlockBuilder()
+    a = tir.Var("a", "int64")
+    b = tir.Var("b", "int64")
+    x0 = relax.Var("x", R.Tensor((3, 4, a), "float32"))
+    y0 = relax.Var("y", R.Tensor((4, a), "float32"))
+    x1 = relax.Var("x", R.Tensor((3, 4, b + a), "float32"))
+    y1 = relax.Var("x", R.Tensor((1, a + b), "float32"))
+
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo((4, a), "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo((1, a + b), "float32")
+    )
+
+
+def test_collapse_sum_like_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo((2, 3, 4)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=3))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    s3 = relax.Var("s", relax.ShapeStructInfo((3, 4)))
+    s4 = relax.Var("s", relax.ShapeStructInfo(ndim=2))
+    s5 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+    y0 = relax.Var("y", relax.TensorStructInfo(s3, "float32"))
+    y1 = relax.Var("y", relax.TensorStructInfo(s4, "float32"))
+    y2 = relax.Var("y", relax.TensorStructInfo(s5, "float32"))
+
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo(s3, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo(s4, "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x2, y2), relax.TensorStructInfo(s5, "float32")
+    )
+
+
+def test_collapse_sum_like_infer_struct_info_more_input_dtype():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3, 4), "float16"))
+    x1 = relax.Var("x", R.Tensor((2, 3, 4), "int8"))
+    y0 = relax.Var("y", R.Tensor((3, 4), "float16"))
+    y1 = relax.Var("y", R.Tensor((3, 4), "int8"))
+
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x0, y0), relax.TensorStructInfo((3, 4), "float16")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_like(x1, y1), relax.TensorStructInfo((3, 4), "int8")
+    )
+
+
 def test_collapse_sum_like_wrong_input_type():
     bb = relax.BlockBuilder()
     x0 = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
@@ -2242,19 +2300,26 @@ def test_collapse_sum_like_wrong_input_type():
     x2 = relax.Var("x", relax.FuncStructInfo([], R.Tensor((2, 3, 4), "float32")))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.collapse_sum_to(x0, x1))
+        bb.normalize(relax.op.collapse_sum_like(x0, x1))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.collapse_sum_to(x2, x0))
+        bb.normalize(relax.op.collapse_sum_like(x2, x0))
 
 
-def test_collapse_sum_like_wrong_shape():
+def test_collapse_sum_like_check_shape_failure():
     bb = relax.BlockBuilder()
     x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
     y = relax.Var("y", R.Tensor((3, 6, 5), "float32"))
+    a = tir.Var("a", "int64")
+    b = tir.Var("b", "int64")
+    z = relax.Var("z", R.Tensor([a], "float32"))
+    w = relax.Var("w", R.Tensor([b], "float32"))
 
     with pytest.raises(TVMError):
         bb.normalize(relax.op.collapse_sum_like(x, y))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.collapse_sum_like(z, w))
 
 
 def test_collapse_sum_to_infer_struct_info():
@@ -2265,20 +2330,69 @@ def test_collapse_sum_to_infer_struct_info():
     x3 = relax.Var("x", R.Tensor((2, 3, 4)))
     x4 = relax.Var("x", R.Tensor(ndim=3))
     x5 = relax.Var("x", R.Tensor())
-    y0 = (3, 4)
+    s0 = (3, 4)
 
     _check_inference(
-        bb, relax.op.collapse_sum_to(x0, y0), relax.TensorStructInfo((3, 4), "float32")
+        bb, relax.op.collapse_sum_to(x0, s0), relax.TensorStructInfo((3, 4), "float32")
     )
     _check_inference(
-        bb, relax.op.collapse_sum_to(x1, y0), relax.TensorStructInfo((3, 4), "float32")
+        bb, relax.op.collapse_sum_to(x1, s0), relax.TensorStructInfo((3, 4), "float32")
     )
     _check_inference(
-        bb, relax.op.collapse_sum_to(x2, y0), relax.TensorStructInfo((3, 4), "float32")
+        bb, relax.op.collapse_sum_to(x2, s0), relax.TensorStructInfo((3, 4), "float32")
     )
-    _check_inference(bb, relax.op.collapse_sum_to(x3, y0), relax.TensorStructInfo((3, 4), ""))
-    _check_inference(bb, relax.op.collapse_sum_to(x4, y0), relax.TensorStructInfo((3, 4), ""))
-    _check_inference(bb, relax.op.collapse_sum_to(x5, y0), relax.TensorStructInfo((3, 4), ""))
+    _check_inference(bb, relax.op.collapse_sum_to(x3, s0), relax.TensorStructInfo((3, 4), ""))
+    _check_inference(bb, relax.op.collapse_sum_to(x4, s0), relax.TensorStructInfo((3, 4), ""))
+    _check_inference(bb, relax.op.collapse_sum_to(x5, s0), relax.TensorStructInfo((3, 4), ""))
+
+
+def test_collapse_sum_to_infer_struct_info_shape_symbolic():
+    bb = relax.BlockBuilder()
+    a = tir.Var("a", "int64")
+    b = tir.Var("b", "int64")
+    x0 = relax.Var("x", R.Tensor((3, 4, a), "float32"))
+    s0 = (4, a)
+    x1 = relax.Var("x", R.Tensor((3, 4, b + a), "float32"))
+    s1 = (1, a + b)
+
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x0, s0), relax.TensorStructInfo((4, a), "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, s1), relax.TensorStructInfo((1, a + b), "float32")
+    )
+
+
+def test_collapse_sum_to_infer_struct_info_shape_var():
+    bb = relax.BlockBuilder()
+    s0 = relax.Var("s", relax.ShapeStructInfo((2, 3, 4)))
+    s1 = relax.Var("s", relax.ShapeStructInfo(ndim=3))
+    s2 = relax.Var("s", relax.ShapeStructInfo())
+    x0 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    x1 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
+    x2 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x0, (3, 4)), relax.TensorStructInfo((3, 4), "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, (3, 4)), relax.TensorStructInfo((3, 4), "float32")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, (3, 4)), relax.TensorStructInfo((3, 4), "float32")
+    )
+
+
+def test_collapse_sum_to_infer_struct_info_more_input_dtype():
+    bb = relax.BlockBuilder()
+    x0 = relax.Var("x", R.Tensor((2, 3, 4), "float16"))
+    x1 = relax.Var("x", R.Tensor((2, 3, 4), "int8"))
+
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x0, (3, 4)), relax.TensorStructInfo((3, 4), "float16")
+    )
+    _check_inference(
+        bb, relax.op.collapse_sum_to(x1, (3, 4)), relax.TensorStructInfo((3, 4), "int8")
+    )
 
 
 def test_collapse_sum_to_wrong_input_type():
@@ -2297,12 +2411,17 @@ def test_collapse_sum_to_wrong_input_type():
         bb.normalize(relax.op.collapse_sum_to(x1, x1))
 
 
-def test_collapse_sum_to_wrong_shape():
+def test_collapse_sum_to_check_shape_failure():
     bb = relax.BlockBuilder()
     x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
+    a = tir.Var("a", "int64")
+    y = relax.Var("y", R.Tensor([a], "float32"))
 
     with pytest.raises(TVMError):
         bb.normalize(relax.op.collapse_sum_to(x, (4, 4, 5)))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.collapse_sum_to(y, (4,)))
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2302,18 +2302,34 @@ def test_collapse_sum_like_wrong_input_type():
 
 def test_collapse_sum_like_check_shape_failure():
     bb = relax.BlockBuilder()
-    x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
-    y = relax.Var("y", R.Tensor((3, 6, 5), "float32"))
+    x0 = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
+    y0 = relax.Var("y", R.Tensor((3, 6, 5), "float32"))
     a = tir.Var("a", "int64")
     b = tir.Var("b", "int64")
-    z = relax.Var("z", R.Tensor([a], "float32"))
-    w = relax.Var("w", R.Tensor([b], "float32"))
+    x1 = relax.Var("z", R.Tensor((3, a, 5), "float32"))
+    y1 = relax.Var("w", R.Tensor((3, b, 5), "float32"))
+
+    s0 = relax.Var("s", relax.ShapeStructInfo((3, 4, 5)))
+    s1 = relax.Var("s", relax.ShapeStructInfo((3, 6, 5)))
+    x2 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+    y2 = relax.Var("y", relax.TensorStructInfo(s1, "float32"))
+
+    s2 = relax.Var("s", relax.ShapeStructInfo((3, a, 5)))
+    s3 = relax.Var("s", relax.ShapeStructInfo((3, b, 5)))
+    x3 = relax.Var("x", relax.TensorStructInfo(s2, "float32"))
+    y3 = relax.Var("y", relax.TensorStructInfo(s3, "float32"))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.collapse_sum_like(x, y))
+        bb.normalize(relax.op.collapse_sum_like(x0, y0))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.collapse_sum_like(z, w))
+        bb.normalize(relax.op.collapse_sum_like(x1, y1))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.collapse_sum_like(x2, y2))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.collapse_sum_like(x3, y3))
 
 
 def test_collapse_sum_to_infer_struct_info():
@@ -2404,15 +2420,28 @@ def test_collapse_sum_to_wrong_input_type():
 
 def test_collapse_sum_to_check_shape_failure():
     bb = relax.BlockBuilder()
-    x = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
+    x0 = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
     a = tir.Var("a", "int64")
-    y = relax.Var("y", R.Tensor([a], "float32"))
+    b = tir.Var("b", "int64")
+    x1 = relax.Var("x", R.Tensor((3, a, 5), "float32"))
+
+    s0 = relax.Var("s", relax.ShapeStructInfo((3, 4, 5)))
+    x2 = relax.Var("x", relax.TensorStructInfo(s0, "float32"))
+
+    s1 = relax.Var("s", relax.ShapeStructInfo((3, a, 5)))
+    x3 = relax.Var("x", relax.TensorStructInfo(s1, "float32"))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.collapse_sum_to(x, (4, 4, 5)))
+        bb.normalize(relax.op.collapse_sum_to(x0, (4, 4, 5)))
 
     with pytest.raises(TVMError):
-        bb.normalize(relax.op.collapse_sum_to(y, (4,)))
+        bb.normalize(relax.op.collapse_sum_to(x1, (3, b, 5)))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.collapse_sum_to(x2, (4, 4, 5)))
+
+    with pytest.raises(TVMError):
+        bb.normalize(relax.op.collapse_sum_to(x3, (3, b, 5)))
 
 
 def test_collapse_sum_to_struct_info_tgt_shape_var():

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -2235,7 +2235,7 @@ def test_collapse_sum_like_infer_struct_info():
     )
 
 
-def test_collapse_sum_to_wrong_input_type():
+def test_collapse_sum_like_wrong_input_type():
     bb = relax.BlockBuilder()
     x0 = relax.Var("x", R.Tensor((3, 4, 5), "float32"))
     x1 = relax.Var("x", relax.ShapeStructInfo((4, 5)))

--- a/tests/python/relax/test_tvmscript_parser_manipulate_ops.py
+++ b/tests/python/relax/test_tvmscript_parser_manipulate_ops.py
@@ -24,7 +24,8 @@ from tvm.script.parser import relax as R
 
 
 def _check(
-    parsed: Union[relax.Function, IRModule], expect: Optional[Union[relax.Function, IRModule]],
+    parsed: Union[relax.Function, IRModule],
+    expect: Optional[Union[relax.Function, IRModule]],
 ):
     test = parsed.script(show_meta=True)
     roundtrip_mod = tvm.script.parse(test)


### PR DESCRIPTION
This PR introduces two operators `collapse_sum_like` and `collapse_sum_to` which are mainly used in automatic differentiation.

The shape inference rule of `collapse_sum` can be described as below:
- We have a `data_shape` and `target_shape`. `collapse_sum` collapses `data_shape` to `target_shape`.
- Scan their shapes from right to left. There are only three cases which are permitted:
- Case 1: axes in `target_shape` but not in `data_shape`. E.g. `data_shape=(2, 3, 4, 5)`, `target_shape=(4, 5)`. Here `2, 3` are these axes.
- Case 2: Axes are equal. E.g. `4, 5` in the above case.
- Case 3: Axes are not equal but the axis in `target_shape` is `1`. E.g. `data_shape=(2, 4, 5)`, `target_shape=(2, 1, 5)` is legal.

In fact just the reversed rule of broadcasting.