### PR TITLE
[Op][Manip] Todo items for stopping error and trusting input with check

### DIFF
--- a/src/relax/op/tensor/manipulate.cc
+++ b/src/relax/op/tensor/manipulate.cc
@@ -186,6 +186,8 @@ StructInfo InferStructInfoPermuteDims(const Call& call, const BlockBuilder& ctx)
   const auto* attrs = call->attrs.as<PermuteDimsAttrs>();
   if (data_sinfo->IsUnknownNdim()) {
     if (attrs->axes.defined()) {
+      // Todo(relax-team): At this moment, enforcing MatchCast is fine. But we may need to revisit
+      // this requirement to reduce the workload of importers and better support dynamic shapes.
       ctx->ReportFatal(Diagnostic::Error(call)
                        << "PermuteDims cannot be performed when the input tensor " << data_sinfo
                        << " ndim is unknown while the given number of axes " << attrs->axes.value()
@@ -337,6 +339,8 @@ StructInfo InferStructInfoSqueeze(const Call& call, const BlockBuilder& ctx) {
       if (int_len == nullptr || int_len->value != 1) {
         // We would like to ensure safety, and therefore placed a stronger requirement for user to
         // use MatchCast.
+        // Todo(relax-team): At this moment, enforcing MatchCast is fine. But we may need to revisit
+        // this requirement to reduce the workload of importers and better support dynamic shapes.
         ctx->ReportFatal(Diagnostic::Error(call)
                          << "Squeeze expects the input tensor shape values at the given axis "
                             "positions to be all 1. However, the tensor shape at axis "
@@ -535,6 +539,8 @@ StructInfo InferStructInfoConcat(const Call& call, const BlockBuilder& ctx) {
     if (!attrs->axis.defined() && sinfo->ndim != 1) {
       // To ensure safety, we require all tensors to explicitly have ndim 1 when the concat axis
       // is not specified.
+      // Todo(relax-team): At this moment, enforcing MatchCast is fine. But we may need to revisit
+      // this requirement to reduce the workload of importers and better support dynamic shapes.
       ctx->ReportFatal(
           Diagnostic::Error(call)
           << "Concat expects all input tensors to be flattened 1-dimensional tensor when the axis "
@@ -770,6 +776,8 @@ StructInfo InferStructInfoBroadcastTo(const Call& call, const BlockBuilder& ctx)
     } else if (!analyzer->CanProveEqual(old_len, tgt_len)) {
       // We would like to ensure safety, and therefore placed a stronger requirement for user to
       // use MatchCast.
+      // Todo(relax-team): At this moment, enforcing MatchCast is fine. But we may need to revisit
+      // this requirement to reduce the workload of importers and better support dynamic shapes.
       ctx->ReportFatal(
           Diagnostic::Error(call)
           << "broadcast_to expects the input tensor shape is broadcastable to the target shape. "


### PR DESCRIPTION
This PR adds a few TODO items for some manipulation operators.

For example, in `broadcast_to`, at the shape dimension where the input tensor’s length is symbolic while the target shape is another value (e.g., broadcast a tensor with shape `(a,)` to `(a1,)`), we are not able to prove the broadcastability at compile-time. At this moment, our choice is to throw an error, requiring the users to use MatchCast to explicitly casting the input tensor StructInfo to a valid one (like casting `(a,)` to `(1,)` in the case above).

This enforcement increases the workload of importer, because it requires the importer to insert MatchCasts properly. At this moment the importer only handles static shape, so this is not an issue. But we would always like to make the importer robust and thus in the future we need to stop throwing the error and instead insert runtime checks in front of the op call.

For this reason, this PR leaves some TODO items to the manipulation ops that requires MatchCast now.