### PR TITLE
[TOPI] Expose the interface of `topi.collapse_sum`

### DIFF
--- a/include/tvm/topi/reduction.h
+++ b/include/tvm/topi/reduction.h
@@ -329,9 +329,7 @@ inline Tensor sum(const Tensor& data, const Array<Integer>& axis, bool keepdims 
 }
 
 inline Tensor collapse_sum(const Tensor& data, Array<PrimExpr> target_shape) {
-  ICHECK_GE(data->shape.size(), target_shape.size())
-      << "Shapes of collapse_sum do not match: data.shape = " << data->shape
-      << ", target_shape = " << target_shape;
+  ICHECK_GE(data->shape.size(), target_shape.size());
   auto ishape = detail::GetConstIntValues(data->shape, "ishape");
   auto oshape = detail::GetConstIntValues(target_shape, "oshape");
 
@@ -347,9 +345,6 @@ inline Tensor collapse_sum(const Tensor& data, Array<PrimExpr> target_shape) {
       squeeze_axes.push_back(i_ax);
     } else if (oshape[o_ax] == 1) {
       --o_ax;
-    } else {
-      LOG(FATAL) << "Shapes of collapse_sum do not match: data.shape = " << data->shape
-                 << ", target_shape = " << target_shape;
     }
   }
 

--- a/include/tvm/topi/reduction.h
+++ b/include/tvm/topi/reduction.h
@@ -329,7 +329,9 @@ inline Tensor sum(const Tensor& data, const Array<Integer>& axis, bool keepdims 
 }
 
 inline Tensor collapse_sum(const Tensor& data, Array<PrimExpr> target_shape) {
-  ICHECK_GE(data->shape.size(), target_shape.size());
+  ICHECK_GE(data->shape.size(), target_shape.size())
+      << "Shapes of collapse_sum do not match: data.shape = " << data->shape
+      << ", target_shape = " << target_shape;
   auto ishape = detail::GetConstIntValues(data->shape, "ishape");
   auto oshape = detail::GetConstIntValues(target_shape, "oshape");
 
@@ -345,6 +347,9 @@ inline Tensor collapse_sum(const Tensor& data, Array<PrimExpr> target_shape) {
       squeeze_axes.push_back(i_ax);
     } else if (oshape[o_ax] == 1) {
       --o_ax;
+    } else {
+      LOG(FATAL) << "Shapes of collapse_sum do not match: data.shape = " << data->shape
+                 << ", target_shape = " << target_shape;
     }
   }
 

--- a/python/tvm/relax/transform/legalize_ops.py
+++ b/python/tvm/relax/transform/legalize_ops.py
@@ -619,11 +619,11 @@ DEFAULT_OP_LEGALIZE_MAP: Dict[str, LegalizeFunc] = {
     "relax.reshape": _reshape(topi.reshape, "reshape"),
     "relax.split": _split,
     "relax.squeeze": _squeeze,
-    # Todo(relax-team): Introduce TOPI collapse_sum for gradient
-    # "relax.collapse_sum_like": _reshape(topi.collapse_sum, "collapse_sum"),
-    # "relax.collapse_sum_to": _reshape(
-    #     topi.collapse_sum, "collapse_sum", is_collapse_sum_like=True
-    # ),
+    # TODO(relax-team): collapse_sum support symbolic shape
+    "relax.collapse_sum_like": _reshape(
+        topi.collapse_sum, "collapse_sum", is_collapse_sum_like=True
+    ),
+    "relax.collapse_sum_to": _reshape(topi.collapse_sum, "collapse_sum"),
     # Search
     "relax.where": _where,
     # Statistical

--- a/python/tvm/topi/reduction.py
+++ b/python/tvm/topi/reduction.py
@@ -248,3 +248,28 @@ def prod(data, axis=None, keepdims=False):
     ret : tvm.te.Tensor
     """
     return cpp.prod(data, axis, keepdims)
+
+
+def collapse_sum(data, target_shape):
+    """Return a summation of data to the given shape.
+    collapse_sum is intended as the backward operator of topi broadcast operators in the automatic
+    differentiation process.
+    We expect that data is the result of broadcasting some tensor of target_shape in some
+    broadcast operation. Thus target_shape and data.shape must follow broadcast rules.
+    During computation, the axes of data.shape and target_shape are checked from right to left.
+    For every axis, if it either:
+    - exist in data but not in target_shape, or
+    - is larger than 1 in data and equals to 1 in target_shape,
+    data will be summed over this axis.
+    Parameters
+    ----------
+    data : tvm.te.Tensor
+        The input tensor.
+    shape : Tuple[int]
+        The shape to collapse to.
+    Returns
+    -------
+    ret : tvm.te.Tensor
+        The result tensor after summation.
+    """
+    return cpp.collapse_sum(data, target_shape)

--- a/src/topi/reduction.cc
+++ b/src/topi/reduction.cc
@@ -64,5 +64,9 @@ TVM_REGISTER_GLOBAL("topi.any").set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = topi::any(args[0], ArrayOrInt(args[1]), args[2]);
 });
 
+TVM_REGISTER_GLOBAL("topi.collapse_sum").set_body([](TVMArgs args, TVMRetValue* rv) {
+  *rv = topi::collapse_sum(args[0], args[1]);
+});
+
 }  // namespace topi
 }  // namespace tvm

--- a/tests/python/topi/python/test_topi_reduce.py
+++ b/tests/python/topi/python/test_topi_reduce.py
@@ -24,6 +24,7 @@ import pytest
 import tvm
 import tvm.testing
 import tvm.topi.testing
+from tvm.topi.utils import get_const_tuple
 
 from tvm import te, topi
 
@@ -181,6 +182,44 @@ def test_complex_reduce(target, dev):
     out_tvm = tvm.nd.empty(shape=out_npy.shape, device=dev, dtype=dtype)
     foo(data_tvm, out_tvm)
     tvm.testing.assert_allclose(out_tvm.numpy(), out_npy, 1e-3, 1e-3)
+
+
+data_shape, target_shape = tvm.testing.parameters(
+    ((2, 3), (3,)),
+    ((2, 3, 4), (2, 1, 4)),
+    ((2, 3, 4, 5), (3, 1, 5)),
+)
+
+
+def _my_npy_collapse_sum(data, target_shape):
+    reduce_axes = []
+    i = data.ndim - 1
+    j = len(target_shape) - 1
+    while i >= 0:
+        if j < 0:
+            reduce_axes.append(i)
+        elif target_shape[j] == 1 and data.shape[i] > 1:
+            reduce_axes.append(i)
+        i -= 1
+        j -= 1
+    return np.sum(data, tuple(reduce_axes)).reshape(target_shape)
+
+
+def test_collapse_sum(data_shape, target_shape):
+    A = te.placeholder(data_shape, name="A")
+    B = topi.collapse_sum(A, target_shape)
+    s = te.create_schedule([B.op])
+
+    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
+    b_np = _my_npy_collapse_sum(a_np, target_shape)
+    dev = tvm.cpu(0)
+    a = tvm.nd.array(a_np, dev)
+    b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), dev)
+    # Building with the CSE pass disabled
+    with tvm.transform.PassContext(opt_level=3, disabled_pass=["tir.CommonSubexprElimTIR"]):
+        foo = tvm.build(s, [A, B], "llvm", name="collapse_sum")
+    foo(a, b)
+    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TOPI has an implementation of `collapse_sum` internally (`tvm/topi/reduction.h`) but it is not exposed to FFI and can not be called in Python side. This patch exposes it and adds some related tests.
Besides, now legalizer can legalize `collapse_sum_like/to`! But due to the TOPI implementation, it can't handle the symbolic case. 