### PR TITLE
[FIX][AD] Fix nested msg utils introduced in AD Pass

### DIFF
--- a/include/tvm/relax/nested_msg.h
+++ b/include/tvm/relax/nested_msg.h
@@ -347,15 +347,15 @@ NestedMsg<T> MapToNestedMsgBySInfo(Expr expr, FType fmapleaf) {
  * then recursively combines the results as tuple expr.
  *
  * \param msg The input nested message.
- * \param fmapleaf The mapping function for each leaf with signature `Expr fmapleaf(T)`.
+ * \param fmapleaf The mapping function for each leaf with signature `Expr fmapleaf(Optional<T>)`.
  * \tparam T the content type of nested msg.
  * \tparam FType The mapping function type.
  */
 template <typename T, typename FType>
 Expr NestedMsgToExpr(NestedMsg<T> msg, FType fmapleaf) {
-  ICHECK(!msg.IsNull()) << "Cannot map null msg.";
-
-  if (msg.IsLeaf()) {
+  if (msg.IsNull()) {
+    return fmapleaf(NullOpt);
+  } else if (msg.IsLeaf()) {
     return fmapleaf(msg.LeafValue());
   } else {
     ICHECK(msg.IsNested());

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -227,7 +227,12 @@ class BackwardBindingGenerator : private ExprVisitor {
   }
 
   static Expr AdjointMsgToExpr(AdjointMsg msg) {
-    return NestedMsgToExpr<Expr>(msg, [](Expr leaf_expr) { return leaf_expr; });
+    return NestedMsgToExpr<Expr>(msg, [](Optional<Expr> leaf_expr) {
+      if (!leaf_expr.defined()) {
+        LOG(FATAL) << "Null should not exist in AdjointMsg.";
+      }
+      return leaf_expr.value();
+    });
   }
 
   static AdjointMsg ExprToAdjointMsg(Expr expr) {

--- a/tests/cpp/nested_msg_test.cc
+++ b/tests/cpp/nested_msg_test.cc
@@ -219,8 +219,9 @@ TEST(NestedMsg, NestedMsgToExpr) {
   relax::Var x("x", sf0), y("y", sf0), z("z", sf0);
 
   NestedMsg<Integer> msg = {c0, {c0, c1}, {c0, {c1, c2}}};
-  auto expr = NestedMsgToExpr<Integer>(msg, [&](NestedMsg<Integer> leaf_msg) {
-    int value = leaf_msg.LeafValue().IntValue();
+  auto expr = NestedMsgToExpr<Integer>(msg, [&](Optional<Integer> leaf) {
+    ICHECK(leaf.defined());
+    int value = leaf.value().IntValue();
     switch (value) {
       case 0:
         return x;
@@ -237,8 +238,7 @@ TEST(NestedMsg, NestedMsgToExpr) {
   // test simplified
   relax::Var t("t", sf1);
   NestedMsg<Expr> msg1 = {TupleGetItem(t, 0), TupleGetItem(t, 1)};
-  auto expr1 =
-      NestedMsgToExpr<Expr>(msg1, [](NestedMsg<Expr> leaf_msg) { return leaf_msg.LeafValue(); });
+  auto expr1 = NestedMsgToExpr<Expr>(msg1, [](Optional<Expr> leaf) { return leaf.value(); });
   EXPECT_TRUE(StructuralEqual()(expr1, t));
 }
 


### PR DESCRIPTION
This PR is a small fix patch for https://github.com/mlc-ai/relax/pull/103, containing two small modifications:
- In AD PR we introduce `NestedMsgToExpr`, where the signature of `fmapleaf` is `Expr fmapleaf(T)`. And for null nested msg it will directly throws error. Now we change it to `Expr fmapleaf(Optional<T>)` and pass `NullOpt` to `fmapleaf`, which enables user to decide whether to throw an error or return some default value.
- In the test of nested msg we forget to change the signature of `fmapleaf` (originally it is `Expr fmapleaf(NestedMsg<T>)`). It still passed due to the type casting between `NestedMsg<T>` and `T` but it needs to be fixed.