### PR TITLE
[Relax][Utils] Add ExtendFunc utils

### DIFF
--- a/include/tvm/relax/utils.h
+++ b/include/tvm/relax/utils.h
@@ -146,6 +146,24 @@ TVM_DLL bool IsLeafExpr(const Expr& expr);
  */
 TVM_DLL Function CopyWithNewParams(Function func);
 
+/*!
+ * \brief Extend a relax function by another given function. It will link orig_func with
+ * ex_func and return a new function.
+ *
+ * In detail, the result function has the arguments list of orig_func and the combination
+ * of their body, which passes the return values of orig_func as the arguments of ex_func. For
+ * those arguments of ex_func which are not mapped to some return values, they will be lifted and
+ * appended to the argument list of result function.
+ *
+ * This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in some
+ * sense.
+ *
+ * \param orig_func The function to be extended.
+ * \param ex_func The function to be linked after the orig_func.
+ * \return The result function after extending.
+ */
+TVM_DLL Function ExtendFunc(Function orig_func, Function ex_func);
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -97,3 +97,54 @@ def copy_with_new_params(func: Function) -> Function:
         The copied function.
     """
     return _ffi_api.CopyWithNewParams(func)  # type: ignore
+
+
+def extend_func(orig_func: Function, ex_func: Function) -> Function:
+    """Extend a relax function by another given function. It will link orig_func with
+    ex_func and return a new function.
+
+    In detail, the result function has the arguments list of orig_func and the combination
+    of their body, which passes the return values of orig_func as the arguments of ex_func. For
+    those arguments of ex_func which are not mapped to some return values, they will be lifted and
+    appended to the argument list of result function.
+
+    This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in some
+    sense.
+
+    Note: the return value of orig_func will be bound to DataflowVar. So it is a bad idea to use this
+    util if the params of ex_func present in its R.output.
+
+    Example:
+
+    .. code-block:: python
+        # Before.
+            @R.function
+            def func1(a, b):
+                return a + b, a * b
+
+            @R.function
+            def func2(c, d, e):
+                return d, c, c + e
+
+        # After. func1_func2 = extend_func(orig_func=func1, ex_func=func2).
+            @R.function
+            def func1_func2(a, b, e):
+                c = a + b
+                d = a * b
+                return d, c, c + e
+
+    Parameters
+    ----------
+    orig_func : Function
+        The function to be extended.
+
+    ex_func : Function
+        The function to be linked after the orig_func.
+
+    Returns
+    -------
+    ret : Function
+        The result function.
+    """
+
+    return _ffi_api.ExtendFunc(orig_func, ex_func)  # type: ignore

--- a/python/tvm/relax/utils.py
+++ b/python/tvm/relax/utils.py
@@ -111,8 +111,8 @@ def extend_func(orig_func: Function, ex_func: Function) -> Function:
     This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in some
     sense.
 
-    Note: the return value of orig_func will be bound to DataflowVar. So it is a bad idea to use this
-    util if the params of ex_func present in its R.output.
+    Note: the return value of orig_func will be bound to DataflowVar. So it is a bad idea to use
+    this util if the params of ex_func present in its R.output.
 
     Example:
 

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -107,5 +107,142 @@ Function CopyWithNewParams(Function func) { return FunctionCopier::Transform(fun
 
 TVM_REGISTER_GLOBAL("relax.CopyWithNewParams").set_body_typed(CopyWithNewParams);
 
+/*! \brief Helper to implement extend function.*/
+class ExtendFuncMutator : public ExprMutator {
+ public:
+  explicit ExtendFuncMutator(const SeqExpr& ex_body) : ex_body_(ex_body) {}
+
+  Expr VisitExpr_(const SeqExprNode* seq_expr) override {
+    // mutate only the last block.
+    Array<BindingBlock> blocks;
+    for (int i = 0; i < static_cast<int>(seq_expr->blocks.size()); ++i) {
+      if (i < static_cast<int>(seq_expr->blocks.size()) - 1) {
+        blocks.push_back(seq_expr->blocks[i]);
+      } else {
+        BindingBlock new_block = this->VisitBindingBlock(seq_expr->blocks[i]);
+        if (!new_block->bindings.empty()) {
+          blocks.push_back(new_block);
+        }
+      }
+    }
+    this->VisitExpr(seq_expr->body);
+    return SeqExpr(blocks, ex_body_->body);
+  }
+
+  BindingBlock VisitBindingBlock_(const DataflowBlockNode* block) override {
+    builder_->BeginDataflowBlock();
+    // emit original bindings.
+    for (const auto& binding : block->bindings) {
+      this->VisitBinding(binding);
+    }
+
+    ICHECK(orig_rets_var_.size() == orig_rets.size());
+    for (int i = 0; i < static_cast<int>(orig_rets_var_.size()); ++i) {
+      if (orig_rets_var_[i].defined()) {
+        builder_->EmitNormalized(VarBinding(orig_rets_var_[i].value(), orig_rets[i]));
+      }
+    }
+
+    // emit blocks for extend part.
+    for (BindingBlock block : ex_body_->blocks) {
+      for (Binding binding : block->bindings) {
+        this->VisitBinding(binding);
+      }
+    }
+
+    return builder_->EndBlock();
+  }
+
+  void VisitBinding_(const VarBindingNode* binding) override {
+    Var new_var = Downcast<Var>(this->VisitExpr(binding->var));
+    Expr new_value = this->VisitExpr(binding->value);
+    builder_->EmitNormalized(VarBinding(new_var, new_value));
+  }
+
+  // remap orignal dataflow var
+  // TODO(chaofan): a better way to check whether new_ret_var should be dataflow
+  void RemapToDataflow(SeqExpr body) {
+    for (BindingBlock block : body->blocks) {
+      for (Binding binding : block->bindings) {
+        const auto* binding_node = binding.as<VarBindingNode>();
+        if (binding_node && !binding_node->var->IsInstance<DataflowVarNode>()) {
+          Var new_binding_var = DataflowVar(
+              binding_node->var->vid, GetStructInfo(binding_node->var), binding_node->var->span);
+          this->var_remap_[binding_node->var->vid] = new_binding_var;
+        }
+      }
+    }
+  }
+
+  Array<Var> RemapExParams(const Array<Var>& ex_func_params, Array<Var> new_params) {
+    for (int i = 0; i < static_cast<int>(ex_func_params.size()); ++i) {
+      Var ex_param = ex_func_params[i];
+      if (i < static_cast<int>(orig_rets.size())) {
+        // map return value to ex param
+        if (const auto* var_node = orig_rets[i].as<VarNode>()) {
+          ICHECK(orig_rets[i].as<DataflowVarNode>());
+          orig_rets_var_.push_back(NullOpt);
+          this->var_remap_[ex_param->vid] = GetRef<Var>(var_node);
+        } else {
+          Var new_ret_var =
+              DataflowVar(/*name_hint=*/"ret_" + std::to_string(i), GetStructInfo(orig_rets[i]));
+          orig_rets_var_.push_back(new_ret_var);
+          this->var_remap_[ex_param->vid] = new_ret_var;
+        }
+      } else {
+        // append to the param list
+        Var new_ex_param = Var(ex_param->vid, GetStructInfo(ex_param), ex_param->span);
+        this->var_remap_[ex_param->vid] = new_ex_param;
+        new_params.push_back(new_ex_param);
+      }
+    }
+    return new_params;
+  }
+
+  Array<Expr> orig_rets;
+
+ private:
+  SeqExpr ex_body_;
+  Array<Optional<Var>> orig_rets_var_;
+};
+
+/*!
+ * \brief Extend a relax function by another given function.
+ * \param orig_func The function to be extended.
+ * \param ex_func The function to be linked after the orig_func.
+ * \return The result function after extending.
+ */
+Function ExtendFunc(Function orig_func, Function ex_func) {
+  CHECK(orig_func->body->IsInstance<SeqExprNode>())
+      << "the body of the original function is not SeqExpr.";
+  CHECK(ex_func->body->IsInstance<SeqExprNode>()) << "the body of the ex function is not SeqExpr.";
+
+  auto param_copied_func = CopyWithNewParams(orig_func);
+  auto seq_expr = Downcast<SeqExpr>(param_copied_func->body);
+
+  ExtendFuncMutator mutator(Downcast<SeqExpr>(ex_func->body));
+  mutator.RemapToDataflow(seq_expr);
+  // Get the orignal rets. If it is a Tuple, unpack it.
+  if (orig_func->ret_struct_info.as<TupleStructInfoNode>()) {
+    const auto* tuple_node = seq_expr->body.as<TupleNode>();
+    ICHECK(tuple_node != nullptr);
+    for (Expr field : tuple_node->fields) {
+      mutator.orig_rets.push_back(mutator.VisitExpr(field));
+    }
+  } else {
+    mutator.orig_rets.push_back(mutator.VisitExpr(seq_expr->body));
+  }
+
+  CHECK(ex_func->params.size() >= mutator.orig_rets.size())
+      << "The number of return values of original functions should be greater than the number of "
+         "parameters of ex function";
+
+  auto new_params = mutator.RemapExParams(ex_func->params, param_copied_func->params);
+  Expr new_body = mutator.VisitExpr(seq_expr);
+  return Function(new_params, new_body, ex_func->ret_struct_info, param_copied_func->attrs);
+}
+
+TVM_REGISTER_GLOBAL("relax.ExtendFunc").set_body_typed(ExtendFunc);
+
 }  // namespace relax
 }  // namespace tvm

--- a/tests/python/relax/test_utils.py
+++ b/tests/python/relax/test_utils.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
+import tvm.testing
 from tvm import relax
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R
@@ -34,5 +34,119 @@ def test_copy_with_new_params():
         assert before_var != after_var
 
 
+def test_extend_func_basic_extend():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.sum(x)
+            gv1 = R.sum(y)
+            R.output(gv0, gv1)
+        return gv0, gv1
+
+    @R.function
+    def ex(arg1: R.Tensor((), dtype="float32"), arg2: R.Tensor((), dtype="float32")):
+        R.func_attr({"global_symbol": "ex"})
+        with R.dataflow():
+            gv0 = R.add(arg1, arg2)
+            R.output(gv0)
+        return gv0
+
+    @R.function
+    def orig_ex(
+        x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=0):
+        # block 0
+        with R.dataflow():
+            gv0: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+            gv1: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+            gv01: R.Tensor((), dtype="float32") = R.add(gv0, gv1)
+            R.output(gv01)
+        return gv01
+
+    after = relax.utils.extend_func(orig, ex)
+    assert_structural_equal(after, orig_ex)
+
+
+def test_extend_func_extra_params():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.sum(x)
+            gv1 = R.add(x, x)
+            R.output(gv0, gv1)
+        return gv0, gv1
+
+    @R.function
+    def ex(
+        arg1: R.Tensor((), dtype="float32"),
+        arg2: R.Tensor((3, 3), dtype="float32"),
+        arg3: R.Tensor((3, 3), dtype="float32"),
+    ):
+        R.func_attr({"global_symbol": "ex"})
+        with R.dataflow():
+            gv0 = R.add(arg2, arg3)
+            R.output(gv0)
+        return gv0
+
+    @R.function
+    def orig_ex(
+        x: R.Tensor((3, 3), dtype="float32"), arg3: R.Tensor((3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=2):
+        # block 0
+        with R.dataflow():
+            gv0: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+            gv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+            gv01: R.Tensor((3, 3), dtype="float32") = R.add(gv1, arg3)
+            R.output(gv01)
+        return gv01
+
+    after = relax.utils.extend_func(orig, ex)
+    assert_structural_equal(after, orig_ex)
+
+
+def test_extend_func_nested_tuple():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.add(x, x)
+            gv1 = R.sum(y)
+            gv2 = R.add(x, y)
+            R.output(gv0, gv1, gv2)
+        return (gv0, gv1), gv2
+
+    @R.function
+    def ex(
+        arg1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32")),
+        arg2: R.Tensor((), dtype="float32"),
+    ):
+        R.func_attr({"global_symbol": "ex"})
+        with R.dataflow():
+            arg10 = arg1[0]
+            gv0 = R.add(arg10, arg2)
+            R.output(gv0)
+        return gv0
+
+    @R.function
+    def orig_ex(
+        x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")
+    ) -> R.Tensor((3, 3), dtype="float32"):
+        # block 0
+        with R.dataflow():
+            gv0: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+            gv1: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+            gv2: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+            ret_0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32")) = (
+                gv0,
+                gv1,
+            )
+            arg10: R.Tensor((3, 3), dtype="float32") = ret_0[0]
+            gv01: R.Tensor((3, 3), dtype="float32") = R.add(arg10, gv2)
+            R.output(gv01)
+        return gv01
+
+    after = relax.utils.extend_func(orig, ex)
+    assert_structural_equal(after, orig_ex)
+
+
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tvm.testing.main()


### PR DESCRIPTION
**Background:** suppose we have a backbone module `mod` which has a function `forward`. Run `forward` we can get the output/predictions of this module. Now to run AD in this module, we need to "extend" the function `forward` with a specified loss function. This can be easily done if we have an Inline pass. We can define a new function
```
def forward_loss(*args, labels):
    out = forward(*args)
    loss = loss_func(out, labels)
    return loss
``` 
and inline it. But implementing an Inline is difficult and it needs call graph analysis (which still lacks in relax). So for now we can use this simple util to replace Inline here temporarily.
This util is similar with "tail call inline". The following is an example:
```
# Before.
@R.function
def func1(a, b):
    return a + b, a * b

@R.function
def func2(c, d, e):
    return d, c, c + e

# After. func1_func2 = extend_func(orig_func=func1, ex_func=func2).
@R.function
def func1_func2(a, b, e):
    c = a + b
    d = a * b
    return d, c, c + e
```
