### PR TITLE
[Relax][Training] Trainer API

### DIFF
--- a/python/tvm/relax/training/__init__.py
+++ b/python/tvm/relax/training/__init__.py
@@ -17,5 +17,6 @@
 """The Relax training APIs."""
 
 from . import optimizer
+from . import trainer
 from . import utils
 from . import loss

--- a/python/tvm/relax/training/__init__.py
+++ b/python/tvm/relax/training/__init__.py
@@ -20,3 +20,5 @@ from . import optimizer
 from . import trainer
 from . import utils
 from . import loss
+
+from .setup_trainer import SetupTrainer

--- a/python/tvm/relax/training/loss.py
+++ b/python/tvm/relax/training/loss.py
@@ -113,7 +113,7 @@ class L1Loss(Loss):
             The ground truth in the calculation of loss.
 
         Returns
-        ----------
+        -------
         The relax function of L1Loss with the loss name as its global symbol.
         """
         bb = BlockBuilder()
@@ -162,7 +162,7 @@ class MSELoss(Loss):
             The ground truth in the calculation of loss.
 
         Returns
-        ----------
+        -------
         The relax function of MSELoss with the loss name as its global symbol.
         """
         bb = BlockBuilder()
@@ -227,7 +227,7 @@ class CrossEntropyLoss(Loss):
             a manual rescaling weight given to each class. It has to be a Tensor of size C.
 
         Returns
-        ----------
+        -------
         The relax function of CrossEntropyLoss with the loss name as its global symbol.
         """
         bb = BlockBuilder()

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -33,8 +33,7 @@ from ..analysis import well_formed
 class SetupTrainer:
     """Transform a NN backbone module to a complete, legalized trainer module.
 
-    This pass should be used after setting the loss and the optimizer. The transformed module
-    will contains the following functions:
+    The transformed module will contains the following functions:
     - `predict`: Predicts the result. It is provided in the input module.
     - `loss`: Calculates the specified loss between the prediction results and the ground truth.
     - `loss_adjoint`: Calculates the loss and the adjoints of parameters.
@@ -95,7 +94,7 @@ class SetupTrainer:
         """Setup the trainer in 3 steps.
         1. Prepare Loss.
         2. Gradient pass.
-        3. Build Optimizer.
+        3. Add Optimizer function.
         4. Legalize operators.
         """
 

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -29,7 +29,7 @@ from ..struct_info import TensorStructInfo
 from ..analysis import well_formed
 
 
-@tvm.transform.module_pass(opt_level=3, name="SetupTrainer")
+@tvm.transform.module_pass(opt_level=0, name="SetupTrainer")
 class SetupTrainer:
     """Transform a NN backbone module to a complete, legalized trainer module.
 

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -1,0 +1,171 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=not-callable,unused-argument
+"""Setup Trainer Pass."""
+from typing import Type, Optional, Any, Dict
+
+import tvm
+from tvm import TVMError
+from tvm.ir.module import IRModule
+
+from ..transform import LegalizeOps, Gradient
+from .loss import Loss
+from .utils import append_loss
+from .optimizer import Optimizer
+from ..struct_info import TensorStructInfo
+from ..analysis import well_formed
+
+
+@tvm.transform.module_pass(opt_level=3, name="SetupTrainer")
+class SetupTrainer:
+    """Transform a NN backbone module to a complete, legalized trainer module.
+
+    This pass should be used after setting the loss and the optimizer. The transformed module
+    will contains the following functions:
+    - `predict`: Predicts the result. It is provided in the input module.
+    - `loss`: Calculates the specified loss between the prediction results and the ground truth.
+    - `loss_adjoint`: Calculates the loss and the adjoints of parameters.
+    - `update_params`: Takes the parameters, the adjoints of parameters and the optimizer state as
+    the inputs and returns updated parameters and new optimizer state. It contains a func attr named
+    `optim_state` which is the initial state of the specified optimizer.
+
+    Notes
+    -----
+    This transform requires the input module to have the following properties:
+    - The module should contain a function named `predict`.
+    - This prediction function should only return a single Tensor which is the prediction
+    result of the backbone.
+    - This prediction function should have a func attr `params_num`, which indicates that
+    the first `params_num` inputs are the parameters (which will be gradiented and trained)
+    of the NN module.
+    """
+
+    PREDICT_FUNC_NAME: str = "predict"
+    LOSS_FUNC_NAME: str = "loss"
+    ADJOINT_FUNC_NAME: str = "loss_adjoint"
+    UPDATE_PARAMS_FUNC_NAME: str = "update_params"
+
+    PARAMS_NUM_ATTR_KEY: str = "params_num"
+    OPTIM_STATE_ATTR_KEY: str = "optim_state"
+
+    def __init__(self):
+        self._loss_config: Optional[Dict[str, Any]] = None
+        self._optim_config: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def _check_backbone_validity(cls, mod: IRModule):
+        if not well_formed(mod):
+            raise ValueError("Backbone Invalid: The backbone is not well formed.")
+        ret_sinfo = mod[cls.PREDICT_FUNC_NAME].body.body.struct_info
+        if not isinstance(ret_sinfo, TensorStructInfo):
+            raise ValueError(
+                "Backbone Invalid: The predict function is expected to have a single Tensor "
+                "return value, which serves as the prediction result of the module. But got ",
+                ret_sinfo,
+            )
+
+    def set_loss(self, loss: Loss, *call_args: TensorStructInfo) -> "SetupTrainer":
+        """Specify the loss function.
+
+        Parameters
+        ----------
+        loss : Loss
+            The loss function. It will be appended to the backbone function using
+            relax.training.utils.append_loss.
+
+        *call_args : TensorStructInfo
+            The struct info a.k.a. the arguments to call the loss function.
+
+        Returns
+        -------
+        self : SetupTrainer
+            Return itself to support fluent interface style.
+        """
+        self._loss_config = {"loss": loss, "call_args": call_args}
+        return self
+
+    def set_optimizer(
+        self, optim_type: Type[Optimizer], *init_args: Any, **init_kwargs: Any
+    ) -> "SetupTrainer":
+        """Specify the optimizer for training.
+
+        Parameters
+        ----------
+        optim_type : Type[Optimizer]
+            The specified optimizer class.
+
+        *init_args : Any
+            Positional arguments passed to the optimize constructor.
+
+        **init_kwargs : Any
+            Keyword arguments passed to the optimize constructor.
+
+        Returns
+        -------
+        self : SetupTrainer
+            Return itself to support fluent interface style.
+
+        Notes
+        -----
+        SetupTrainer will set `param_list` of the optimzer automatically. So you only need
+        to pass the rest initial arguments to it.
+        """
+        self._optim_config = {
+            "optim_type": optim_type,
+            "init_args": init_args,
+            "init_kwargs": init_kwargs,
+        }
+        return self
+
+    def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
+        """Setup the trainer in 3 steps.
+        1. Prepare Loss.
+        2. Gradient pass.
+        3. Build Optimizer.
+        4. Legalize operators.
+        """
+
+        self._check_backbone_validity(mod)
+        # Step 1: Prepare Loss.
+        if self._loss_config is None:
+            raise TVMError("Setup Error: Please call 'set_loss' first before you transform.")
+
+        predict_with_loss = append_loss(
+            mod[self.PREDICT_FUNC_NAME],
+            self._loss_config["loss"](*self._loss_config["call_args"]),
+        )
+        mod[self.LOSS_FUNC_NAME] = predict_with_loss
+
+        # Step 2: Gradient pass.
+        params_num = int(mod[self.PREDICT_FUNC_NAME].attrs[self.PARAMS_NUM_ATTR_KEY])
+        require_grads = mod[self.LOSS_FUNC_NAME].params[:params_num]
+        mod = Gradient(mod.get_global_var(self.LOSS_FUNC_NAME), require_grads=require_grads)(mod)
+
+        # Step 3: Build Optimizer.
+        if self._optim_config is None:
+            raise TVMError("Setup Error: Please call `set_optimizer` first before you setup.")
+        optimizer = self._optim_config["optim_type"](
+            param_list=list(mod[self.ADJOINT_FUNC_NAME].params)[:params_num],
+            *self._optim_config["init_args"],
+            **self._optim_config["init_kwargs"],
+        )
+        mod[self.UPDATE_PARAMS_FUNC_NAME] = optimizer.get_function().with_attr(
+            self.OPTIM_STATE_ATTR_KEY, optimizer.state
+        )
+
+        # Step 4: Legalize operators.
+        return LegalizeOps()(mod)  # type: ignore

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=not-callable,unused-argument
+# pylint: disable=not-callable, unused-argument
 """Setup Trainer Pass."""
 from typing import Type, Optional, Any, Dict
 

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -70,7 +70,7 @@ class SetupTrainer:
     def _check_backbone_validity(cls, mod: IRModule):
         if not well_formed(mod):
             raise ValueError("Backbone Invalid: The backbone is not well formed.")
-        ret_sinfo = mod[cls.PREDICT_FUNC_NAME].body.body.struct_info
+        ret_sinfo = mod[cls.PREDICT_FUNC_NAME].struct_info.ret
         if not isinstance(ret_sinfo, TensorStructInfo):
             raise ValueError(
                 "Backbone Invalid: The predict function is expected to have a single Tensor "

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -109,7 +109,7 @@ class SetupTrainer:
         # Step 2: Gradient pass.
         params_num = int(mod[self.PREDICT_FUNC_NAME].attrs[self.PARAMS_NUM_ATTR_KEY])
         require_grads = mod[self.LOSS_FUNC_NAME].params[:params_num]
-        mod = Gradient(mod.get_global_var(self.LOSS_FUNC_NAME), require_grads=require_grads)(mod)
+        mod = Gradient(self.LOSS_FUNC_NAME, require_grads=require_grads)(mod)
 
         # Step 3: Build Optimizer.
         self._optimizer.init(list(mod[self.ADJOINT_FUNC_NAME].params)[:params_num])

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -1,0 +1,331 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Union, List, Type
+import tvm
+from tvm import relax
+from tvm.ir.module import IRModule
+from tvm.ir.op import Op
+from tvm.runtime.container import tuple_object
+
+
+import numpy as np
+import math
+
+from ..transform import LegalizeOps, Gradient
+from .loss import _Loss
+from .utils import append_loss
+from .optimizer import Optimizer
+from ..struct_info import TensorStructInfo
+from ..vm import VirtualMachine, build
+
+
+class Trainer:
+    """Simple wrapper for relax training.
+
+    Examples
+    --------
+    Initialize it first, do some settings and then train.
+
+    .. code-block:: python
+        trainer = Trainer(backbone=MLP, func_name="main", parameters_indices=range(1, 5))
+        trainer.prepare("relax.nn.softmax_cross_entropy", SGD(None, 0.01))
+        trainer.set_vm_config(target="llvm", device=tvm.cpu())
+        trainer.setup()
+        trainer.rand_init_params()
+        trainer.train(epoch=10, loader=loader, data_hook=_hook, show_detail=True)
+    """
+
+    def __init__(
+        self,
+        backbone: IRModule,
+        func_name: str,
+        parameters_indices: Union[int, List[int]],
+        dtype: str = "float32",
+    ) -> None:
+        """Default initializer for relax.training.Trainer.
+
+        Parameters
+        ----------
+        backbone: IRModule
+            Backbone of the training module. It should be a relax module with a function
+            whose name is `func_name`.
+
+        func_name: str
+            The name of the target function. The function should return the output of the module.
+
+        parameters_indices:
+            The indices of parameters in the input list of the target function.
+
+        dtype: str
+            The dtype of all data here. For simplicity, we suppose all data uses the same dtype. It should be
+            a string which can be used to initialize both numpy dtype and relax DynTensorType.
+            By default it is float32.
+        """
+
+        # should be config after
+        if isinstance(parameters_indices, int):
+            parameters_indices = [parameters_indices]
+        self._parameters_indices = list(parameters_indices)
+
+        self._loss_config = None
+        self._optim_config = None
+        self._vm_config = None
+
+        self._backbone = backbone
+        self._func_name = func_name
+        self._dtype = dtype
+
+        self._parameters_buffer = []
+        self._parameters_name_to_pos = {}
+
+        self._train_func_name = ""
+        self._optimizer = None
+        self._vm = None
+        self._mod = None
+
+    def set_loss(
+        self, loss: _Loss, loss_inputs: Union[TensorStructInfo, List[TensorStructInfo]]
+    ) -> Trainer:
+        """Specify the loss function.
+
+        Parameters
+        ----------
+        loss : _Loss
+            The loss function. It will be extended to the backbone using
+            relax.training.utils.append_loss automatically.
+
+        loss_inputs: Union[TensorStructInfo, List[TensorStructInfo]]
+            The struct info of all arguments of loss function.
+
+        Returns
+        ----------
+        self : Trainer
+            Return itself to support fluent interface style.
+        """
+        self._loss_config = {"loss": loss, "loss_inputs": loss_inputs}
+        return self
+
+    def set_optimizer(self, optim_type: Type[Optimizer], *args, **kwargs) -> Trainer:
+        """Specify the optimizer for training.
+
+        Parameters
+        ----------
+        optim_type: Type[Optimizer]
+            The specified optimizer class.
+
+        args, kwargs:
+            Arguments passed to the optimize constructor.
+
+        Note
+        ----------
+        The Trainer will set param_list and dtype of the optimzer automatically. So you only need
+        to pass the rest arguments to it.
+
+
+        Returns
+        ----------
+        self : Trainer
+            Return itself to support fluent interface style.
+        """
+        self._optim_config = {"optim_type": optim_type, "args": args, "kwargs": kwargs}
+        return self
+
+    def set_vm_config(
+        self,
+        target: Union[str, tvm.target.Target],
+        device: Union[tvm.runtime.Device, List[tvm.runtime.Device]] = tvm.cpu(),
+        memory_cfg: Optional[str] = None,
+    ) -> Trainer:
+        """Specify the following vm config: target, device, memory_cfg.
+
+        Parameters
+        ----------
+        target : Union[str, tvm.target.Target]
+            The target to run all modules on.
+
+        device: Union[Device, List[Device]]
+            The device, or devices on which to execute the VM code.
+
+        memory_cfg: Optional[str]
+            The allocator behavior to use for the VM.
+
+        Returns
+        ----------
+        self : Trainer
+            Return itself to support fluent interface style.
+        """
+        self._vm_config = {"target": target, "device": device, "memory_cfg": memory_cfg}
+        return self
+
+    def setup(self) -> None:
+        """Setup the trainer in 4 steps.
+        1. Prepare Loss.
+        2. Gradient pass and Legalize.
+        3. Allocate buffers for parameters.
+        4. Build Optimizer and VM.
+        """
+
+        # Step 1: Prepare Loss.
+        loss = relax.Var("loss", TensorStructInfo((), self._dtype))
+
+        if self._loss_config is None:
+            raise TVMError("Trainer Error: Please call 'set_loss' first before you setup")
+
+        forward_with_loss = append_loss(
+            self._backbone[self._func_name],
+            self._loss_config["loss"](*self._loss_config["loss_inputs"]),
+        )
+        forward_with_loss_name = self._func_name + "_loss"
+        self._backbone[forward_with_loss_name] = forward_with_loss
+
+        # Step 2: Gradient pass and Legalize.
+        require_grads = [
+            self._backbone[forward_with_loss_name].params[index]
+            for index in self._parameters_indices
+        ]
+        self._mod = Gradient(
+            func=self._backbone.get_global_var(forward_with_loss_name),
+            require_grads=require_grads,
+        )(self._backbone)
+        self._train_func_name = forward_with_loss_name + "_adjoint"
+
+        lowered_mod = LegalizeOps()(self._mod)
+
+        # Step 3: Allocate Buffer for Parameters.
+        def _convert_from_tvm_shape(tvm_shape):
+            return [int(dim) for dim in tvm_shape]
+
+        param_list = []
+        self._parameters_buffer = []
+        for i in range(len(self._mod[self._train_func_name].params)):
+            if i in self._parameters_indices:
+                param = self._mod[self._train_func_name].params[i]
+                param_list.append(param)
+                self._parameters_buffer.append(
+                    tvm.nd.array(
+                        np.zeros(
+                            shape=_convert_from_tvm_shape(param.shape),
+                            dtype=np.dtype(self._dtype),
+                        )
+                    )
+                )
+                self._parameters_name_to_pos[param.name_hint] = len(self._parameters_buffer) - 1
+
+        # Step 4: Build Optimizer and VM
+        if self._optim_config is None:
+            raise TVMError("Trainer Error: Please call 'set_optimizer' first before you setup")
+        self._optimizer = self._optim_config["optim_type"](
+            param_list=param_list,
+            dtype=self._dtype,
+            *self._optim_config["args"],
+            **self._optim_config["kwargs"],
+        )
+
+        if self._vm_config is None:
+            raise TVMError("Trainer Error: Please set vm_config first before you setup")
+        ex = build(lowered_mod, target=self._vm_config["target"])
+        self._vm = VirtualMachine(
+            ex, device=self._vm_config["device"], memory_cfg=self._vm_config["memory_cfg"]
+        )
+
+    def _check_setup(self):
+        if self._vm is None:
+            raise TVMError("Trainer Error: Please setup first.")
+
+    def _prepare_inputs(self, func_name, inputs):
+        ptr_inputs = 0
+        ptr_params = 0
+        input_len = len(self._mod[func_name].params)
+        assert len(inputs) + len(self._parameters_buffer) == input_len
+        to_vm = []
+        for i in range(input_len):
+            if i in self._parameters_indices:
+                to_vm.append(self._parameters_buffer[ptr_params])
+                ptr_params += 1
+            else:
+                to_vm.append(tvm.nd.array(inputs[ptr_inputs]))
+                ptr_inputs += 1
+        return to_vm
+
+    def forward(self, *inputs):
+        """Forward. Return output in numpy."""
+        self._check_setup()
+        return self._vm[self._func_name](*self._prepare_inputs(self._func_name, inputs)).numpy()
+
+    def backward(self, *inputs):
+        """Backward. Return loss in numpy."""
+        self._check_setup()
+        loss, grads = self._vm[self._train_func_name](
+            *self._prepare_inputs(self._train_func_name, inputs)
+        )
+        assert len(grads) == len(self._parameters_buffer)
+        new_params, self._optimizer.state = self._vm[self._optimizer.__class__.__name__](
+            tuple_object(self._parameters_buffer), grads, self._optimizer.state
+        )
+        assert len(new_params) == len(self._parameters_buffer)
+        self._parameters_buffer = new_params
+        return loss.numpy()
+
+    def train(self, epoch: int, loader, data_hook=lambda x: x, show_detail=False):
+        """A simple wrapper for the training loop.
+
+        Parameters
+        ----------
+        epoch: int
+            The number of the training epochs.
+
+        loader:
+            The data loader. It should be a iterable object with the input data returned every iteration.
+
+        data_hook:
+            A hook function which takes the return value of the loader iteration as input, and return things
+            that you want to feed to the module.
+            It is used to preprocess the input data. By default it is an identity function.
+
+        show_detail: boolean
+            Whether to show some information about training.
+        """
+        self._check_setup()
+        for i in range(epoch):
+            loss_buffer = []
+            for dataline in loader:
+                loss = self.backward(*data_hook(dataline))
+                loss_buffer.append(loss)
+            if show_detail:
+                print(f"Train Epoch #{i}, Loss = {np.mean(loss_buffer)}")
+
+    def rand_init_params(self):
+        """Randomly initialize parameters using np.random.uniform."""
+        self._check_setup()
+        self._parameters_buffer = [
+            tvm.nd.array(
+                math.sqrt(6.0 / np.sum(v.shape))
+                * np.random.uniform(-1.0, 1.0, v.shape).astype(np.float32)
+            )
+            for v in self._parameters_buffer
+        ]
+
+    def load_params(self, extern_param_dict: dict):
+        """Load parameters from a dict.
+        The key of the dict should be the same with the parameter name in backbone.
+        """
+        self._check_setup()
+        for key in extern_param_dict:
+            self._parameters_buffer[self._parameters_name_to_pos[key]] = tvm.nd.array(
+                extern_param_dict[key]
+            )

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -50,9 +50,12 @@ class Trainer:
 
     Examples
     --------
-    >>> setup_trainer = SetupTrainer()
-    >>> setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    >>> setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    >>> setup_trainer = setup_trainer = SetupTrainer(
+    ...     MSELoss(reduction="sum"),
+    ...     SGD(0.001),
+    ...     [pred_sinfo, pred_sinfo],
+    ... )
+
     >>> trainer = Trainer(MLP, 2, setup_trainer)
     >>> trainer.build(target="llvm")
     >>> trainer.xaiver_uniform_init_params()

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=not-callable,invalid-name,unused-argument
+# pylint: disable=invalid-name
 """Unified Trainer API for relax training."""
 
 from typing import Union, List, Optional, Dict
@@ -55,7 +55,7 @@ class Trainer:
     >>> setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
     >>> trainer = Trainer(MLP, 2, "main")
     >>> trainer.build(target="llvm")
-    >>> trainer.rand_init_params()
+    >>> trainer.xaiver_uniform_init_params()
     >>> trainer.predict(*predict_inputs)
     >>> trainer.update_params(*update_params_inputs)
 
@@ -154,8 +154,9 @@ class Trainer:
         self._check_build()
         return self._vm
 
-    def rand_init_params(self):
-        """Randomly initialize parameters using np.random.uniform."""
+    def xaiver_uniform_init_params(self):
+        """Randomly initialize parameters using the method described in `Understanding the difficulty
+        of training deep feedforward neural networks` - Glorot, X. & Bengio, Y. (2010)."""
         self._parameters_buffer = [
             tvm.nd.array(
                 np.sqrt(6.0 / np.sum(v.shape))

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -210,7 +210,7 @@ class Trainer:
         )(self._backbone)
         self._train_func_name = forward_with_loss_name + "_adjoint"
 
-        lowered_mod = LegalizeOps()(self._mod)
+        lowered_mod = LegalizeOps()(self._mod)  # type: ignore
 
         # Step 3: Allocate Buffer for Parameters.
         def _convert_from_tvm_shape(tvm_shape):

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -53,7 +53,7 @@ class Trainer:
     >>> setup_trainer = SetupTrainer()
     >>> setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
     >>> setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
-    >>> trainer = Trainer(MLP, 2, "main")
+    >>> trainer = Trainer(MLP, 2, setup_trainer)
     >>> trainer.build(target="llvm")
     >>> trainer.xaiver_uniform_init_params()
     >>> trainer.predict(*predict_inputs)
@@ -155,8 +155,9 @@ class Trainer:
         return self._vm
 
     def xaiver_uniform_init_params(self):
-        """Randomly initialize parameters using the method described in `Understanding the difficulty
-        of training deep feedforward neural networks` - Glorot, X. & Bengio, Y. (2010)."""
+        """Randomly initialize parameters using the method described in `Understanding the
+        difficulty of training deep feedforward neural networks` - Glorot, X. & Bengio, Y.
+        (2010)."""
         self._parameters_buffer = [
             tvm.nd.array(
                 np.sqrt(6.0 / np.sum(v.shape))

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Union, List, Type
+from typing import Union, List, Type, Optional
+
 import tvm
-from tvm import relax
+from tvm import relax, TVMError
 from tvm.ir.module import IRModule
 from tvm.ir.op import Op
 from tvm.runtime.container import tuple_object
@@ -32,6 +33,7 @@ from .utils import append_loss
 from .optimizer import Optimizer
 from ..struct_info import TensorStructInfo
 from ..vm import VirtualMachine, build
+from ..analysis import well_formed
 
 
 class Trainer:
@@ -53,9 +55,8 @@ class Trainer:
     def __init__(
         self,
         backbone: IRModule,
-        func_name: str,
         parameters_indices: Union[int, List[int]],
-        dtype: str = "float32",
+        func_name: str = "main",
     ) -> None:
         """Default initializer for relax.training.Trainer.
 
@@ -63,44 +64,38 @@ class Trainer:
         ----------
         backbone: IRModule
             Backbone of the training module. It should be a relax module with a function
-            whose name is `func_name`.
+            whose name is `func_name`
+
+        parameters_indices:
+            The indices of parameters in the input list of the function.
 
         func_name: str
             The name of the target function. The function should return the output of the module.
-
-        parameters_indices:
-            The indices of parameters in the input list of the target function.
-
-        dtype: str
-            The dtype of all data here. For simplicity, we suppose all data uses the same dtype. It should be
-            a string which can be used to initialize both numpy dtype and relax DynTensorType.
-            By default it is float32.
         """
 
-        # should be config after
+        # Parameter
         if isinstance(parameters_indices, int):
             parameters_indices = [parameters_indices]
         self._parameters_indices = list(parameters_indices)
+        self._parameters_buffer = []
+        self._parameters_name_to_pos = {}
 
+        # Configs
         self._loss_config = None
         self._optim_config = None
         self._vm_config = None
 
+        # Constructor
         self._backbone = backbone
         self._func_name = func_name
-        self._dtype = dtype
 
-        self._parameters_buffer = []
-        self._parameters_name_to_pos = {}
-
+        # Build
         self._train_func_name = ""
         self._optimizer = None
         self._vm = None
         self._mod = None
 
-    def set_loss(
-        self, loss: _Loss, loss_inputs: Union[TensorStructInfo, List[TensorStructInfo]]
-    ) -> Trainer:
+    def set_loss(self, loss: _Loss, *call_args) -> "Trainer":
         """Specify the loss function.
 
         Parameters
@@ -109,7 +104,7 @@ class Trainer:
             The loss function. It will be extended to the backbone using
             relax.training.utils.append_loss automatically.
 
-        loss_inputs: Union[TensorStructInfo, List[TensorStructInfo]]
+        *call_args:
             The struct info of all arguments of loss function.
 
         Returns
@@ -117,10 +112,10 @@ class Trainer:
         self : Trainer
             Return itself to support fluent interface style.
         """
-        self._loss_config = {"loss": loss, "loss_inputs": loss_inputs}
+        self._loss_config = {"loss": loss, "call_args": call_args}
         return self
 
-    def set_optimizer(self, optim_type: Type[Optimizer], *args, **kwargs) -> Trainer:
+    def set_optimizer(self, optim_type: Type[Optimizer], *args, **kwargs) -> "Trainer":
         """Specify the optimizer for training.
 
         Parameters
@@ -128,7 +123,7 @@ class Trainer:
         optim_type: Type[Optimizer]
             The specified optimizer class.
 
-        args, kwargs:
+        *args, **kwargs:
             Arguments passed to the optimize constructor.
 
         Note
@@ -148,9 +143,9 @@ class Trainer:
     def set_vm_config(
         self,
         target: Union[str, tvm.target.Target],
-        device: Union[tvm.runtime.Device, List[tvm.runtime.Device]] = tvm.cpu(),
+        device: Union[tvm.runtime.Device, List[tvm.runtime.Device]] = tvm.cpu(0),
         memory_cfg: Optional[str] = None,
-    ) -> Trainer:
+    ) -> "Trainer":
         """Specify the following vm config: target, device, memory_cfg.
 
         Parameters
@@ -172,23 +167,26 @@ class Trainer:
         self._vm_config = {"target": target, "device": device, "memory_cfg": memory_cfg}
         return self
 
-    def setup(self) -> None:
+    def setup(self) -> "Trainer":
         """Setup the trainer in 4 steps.
         1. Prepare Loss.
         2. Gradient pass and Legalize.
         3. Allocate buffers for parameters.
         4. Build Optimizer and VM.
+
+        Returns
+        ----------
+        self : Trainer
+            Return itself to support fluent interface style.
         """
 
         # Step 1: Prepare Loss.
-        loss = relax.Var("loss", TensorStructInfo((), self._dtype))
-
         if self._loss_config is None:
-            raise TVMError("Trainer Error: Please call 'set_loss' first before you setup")
+            raise TVMError("Setup Error: Please call 'set_loss' first before you setup.")
 
         forward_with_loss = append_loss(
             self._backbone[self._func_name],
-            self._loss_config["loss"](*self._loss_config["loss_inputs"]),
+            self._loss_config["loss"](*self._loss_config["call_args"]),
         )
         forward_with_loss_name = self._func_name + "_loss"
         self._backbone[forward_with_loss_name] = forward_with_loss
@@ -199,7 +197,7 @@ class Trainer:
             for index in self._parameters_indices
         ]
         self._mod = Gradient(
-            func=self._backbone.get_global_var(forward_with_loss_name),
+            self._backbone.get_global_var(forward_with_loss_name),
             require_grads=require_grads,
         )(self._backbone)
         self._train_func_name = forward_with_loss_name + "_adjoint"
@@ -212,40 +210,92 @@ class Trainer:
 
         param_list = []
         self._parameters_buffer = []
-        for i in range(len(self._mod[self._train_func_name].params)):
+        for i, param in enumerate(self._mod[self._train_func_name].params):
             if i in self._parameters_indices:
-                param = self._mod[self._train_func_name].params[i]
                 param_list.append(param)
                 self._parameters_buffer.append(
                     tvm.nd.array(
                         np.zeros(
-                            shape=_convert_from_tvm_shape(param.shape),
-                            dtype=np.dtype(self._dtype),
+                            shape=_convert_from_tvm_shape(param.struct_info.shape),
+                            dtype=np.dtype(param.struct_info.dtype),
                         )
                     )
                 )
                 self._parameters_name_to_pos[param.name_hint] = len(self._parameters_buffer) - 1
 
         # Step 4: Build Optimizer and VM
-        if self._optim_config is None:
-            raise TVMError("Trainer Error: Please call 'set_optimizer' first before you setup")
-        self._optimizer = self._optim_config["optim_type"](
-            param_list=param_list,
-            dtype=self._dtype,
-            *self._optim_config["args"],
-            **self._optim_config["kwargs"],
-        )
-
         if self._vm_config is None:
-            raise TVMError("Trainer Error: Please set vm_config first before you setup")
+            raise TVMError("Setup Error: Please call 'set_vm_config' first before you setup.")
         ex = build(lowered_mod, target=self._vm_config["target"])
         self._vm = VirtualMachine(
             ex, device=self._vm_config["device"], memory_cfg=self._vm_config["memory_cfg"]
         )
 
+        if self._optim_config is None:
+            raise TVMError("Setup Error: Please call `set_optimizer` first before you setup.")
+        self._optimizer = self._optim_config["optim_type"](
+            param_list=param_list,
+            *self._optim_config["args"],
+            **self._optim_config["kwargs"],
+        )
+        self._optimizer.set_vm_config(self._vm_config["target"], self._vm_config["device"])
+
+        # End.
+        return self
+
+    def _check_backbone_validity(self):
+        if not well_formed(self._backbone):
+            raise ValueError("Backbone Invalid: The backbone is not well formed.")
+        ret_sinfo = self._backbone[self._func_name].body.body.struct_info
+        if not isintance(ret_sinfo, TensorStructInfo):
+            raise ValueError(
+                "Backbone Invalid: The backbone function is expected to have a single Tensor \
+                return value, which serves as the prediction result of the module. But got ",
+                ret_sinfo,
+            )
+
     def _check_setup(self):
         if self._vm is None:
-            raise TVMError("Trainer Error: Please setup first.")
+            raise TVMError("Please setup the trainer first. Use `trainer.setup()`.")
+
+    def rand_init_params(self) -> "Trainer":
+        """Randomly initialize parameters using np.random.uniform.
+
+        Returns
+        ----------
+        self : Trainer
+            Return itself to support fluent interface style.
+        """
+        self._check_setup()
+        self._parameters_buffer = [
+            tvm.nd.array(
+                math.sqrt(6.0 / np.sum(v.shape))
+                * np.random.uniform(-1.0, 1.0, v.shape).astype(np.dtype(v.dtype))
+            )
+            for v in self._parameters_buffer
+        ]
+
+    def load_params(self, extern_param_dict: dict) -> "Trainer":
+        """Load parameters from a dict.
+        The key of the dict should be the same with the parameter name in backbone.
+
+        Parameters
+        ----------
+        extern_param_dict : dict
+            The external parameters dict: param_name -> param_value. The param name should
+            be the same as the name hint of corresponding relax Var.
+
+        Returns
+        ----------
+        self : Trainer
+            Return itself to support fluent interface style.
+        """
+        self._check_setup()
+        for key in extern_param_dict:
+            self._parameters_buffer[self._parameters_name_to_pos[key]] = tvm.nd.array(
+                extern_param_dict[key]
+            )
+        return self
 
     def _prepare_inputs(self, func_name, inputs):
         ptr_inputs = 0
@@ -262,70 +312,60 @@ class Trainer:
                 ptr_inputs += 1
         return to_vm
 
-    def forward(self, *inputs):
-        """Forward. Return output in numpy."""
+    def forward(self, *inputs: "Unpack[np.array]"):
+        """Forward process.
+
+        Parameters
+        ----------
+        *inputs: Unpack[np.array]
+            The necessary inputs of the module.
+
+        Returns
+        ----------
+        output : np.array
+            The output result of the forward process. Only support single return value now.
+
+        Note
+        ----------
+        You don't need to provide parameters of the module in `inputs`. Instead, the trainer
+        will maintain them interally. The inputs should be given in the order of the function
+        argument list with skipping all parameters.
+        """
         self._check_setup()
         return self._vm[self._func_name](*self._prepare_inputs(self._func_name, inputs)).numpy()
 
-    def backward(self, *inputs):
-        """Backward. Return loss in numpy."""
+    def backward(self, *inputs: "Unpack[np.array]"):
+        """Backward. It will calculate the gradient of each parameter and
+        update them using optimizer.
+
+        Parameters
+        ----------
+        *inputs: Unpack[np.array]
+            The necessary inputs of the module.
+
+        Returns
+        ----------
+        loss : np.array
+            The loss.
+
+        Note
+        ----------
+        You don't need to provide parameters of the module in `inputs`. Instead, the trainer
+        will maintain them interally. The inputs should be given in the order of the function
+        argument list with skipping all parameters.
+        """
         self._check_setup()
         loss, grads = self._vm[self._train_func_name](
             *self._prepare_inputs(self._train_func_name, inputs)
         )
-        assert len(grads) == len(self._parameters_buffer)
-        new_params, self._optimizer.state = self._vm[self._optimizer.__class__.__name__](
-            tuple_object(self._parameters_buffer), grads, self._optimizer.state
-        )
-        assert len(new_params) == len(self._parameters_buffer)
-        self._parameters_buffer = new_params
+        if len(grads) != len(self._parameters_buffer):
+            raise TVMError(
+                "Internal error: the number of gradients is not matched with the number of parameters."
+            )
+        new_params = self._optimizer(tuple_object(self._parameters_buffer), grads)
+        if len(new_params) != len(self._parameters_buffer):
+            raise TVMError(
+                "Internal error: the number of new params is not matched with the number of parameters."
+            )
+        self._parameters_buffer = [new_params[i] for i in range(len(new_params))]
         return loss.numpy()
-
-    def train(self, epoch: int, loader, data_hook=lambda x: x, show_detail=False):
-        """A simple wrapper for the training loop.
-
-        Parameters
-        ----------
-        epoch: int
-            The number of the training epochs.
-
-        loader:
-            The data loader. It should be a iterable object with the input data returned every iteration.
-
-        data_hook:
-            A hook function which takes the return value of the loader iteration as input, and return things
-            that you want to feed to the module.
-            It is used to preprocess the input data. By default it is an identity function.
-
-        show_detail: boolean
-            Whether to show some information about training.
-        """
-        self._check_setup()
-        for i in range(epoch):
-            loss_buffer = []
-            for dataline in loader:
-                loss = self.backward(*data_hook(dataline))
-                loss_buffer.append(loss)
-            if show_detail:
-                print(f"Train Epoch #{i}, Loss = {np.mean(loss_buffer)}")
-
-    def rand_init_params(self):
-        """Randomly initialize parameters using np.random.uniform."""
-        self._check_setup()
-        self._parameters_buffer = [
-            tvm.nd.array(
-                math.sqrt(6.0 / np.sum(v.shape))
-                * np.random.uniform(-1.0, 1.0, v.shape).astype(np.float32)
-            )
-            for v in self._parameters_buffer
-        ]
-
-    def load_params(self, extern_param_dict: dict):
-        """Load parameters from a dict.
-        The key of the dict should be the same with the parameter name in backbone.
-        """
-        self._check_setup()
-        for key in extern_param_dict:
-            self._parameters_buffer[self._parameters_name_to_pos[key]] = tvm.nd.array(
-                extern_param_dict[key]
-            )

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -17,7 +17,7 @@
 # pylint: disable=not-callable,invalid-name,unused-argument
 """Unified Trainer API for relax training."""
 
-from typing import Union, List, Type, Optional, Any, Dict
+from typing import Union, List, Optional, Dict
 import numpy as np  # type: ignore
 
 import tvm
@@ -26,154 +26,8 @@ from tvm.ir.module import IRModule
 from tvm.runtime.container import tuple_object
 from tvm.runtime.ndarray import NDArray
 
-from ..transform import LegalizeOps, Gradient
-from .loss import Loss
-from .utils import append_loss
-from .optimizer import Optimizer
-from ..struct_info import TensorStructInfo
+from .setup_trainer import SetupTrainer
 from ..vm import VirtualMachine, build
-from ..analysis import well_formed
-
-
-@tvm.transform.module_pass(opt_level=3, name="SetupTrainer")
-class SetupTrainer:
-    """Transform a NN backbone module to a complete, legalized trainer module.
-
-    This pass should be used after setting the loss and the optimizer. The transformed module
-    will contains the following functions:
-    - `predict`: Predicts the result. It is provided in the input module.
-    - `loss`: Calculates the specified loss between the prediction results and the ground truth.
-    - `loss_adjoint`: Calculates the loss and the adjoints of parameters.
-    - `update_params`: Takes the parameters, the adjoints of parameters and the optimizer state as
-    the inputs and returns updated parameters and new optimizer state. It contains a func attr named
-    `optim_state` which is the initial state of the specified optimizer.
-
-    Notes
-    -----
-    This transform requires the input module to have the following properties:
-    - The module should contain a function named `predict`.
-    - This prediction function should only return a single Tensor which is the prediction
-    result of the backbone.
-    - This prediction function should have a func attr `params_num`, which indicates that
-    the first `params_num` inputs are the parameters (which will be gradiented and trained)
-    of the NN module.
-    """
-
-    PREDICT_FUNC_NAME: str = "predict"
-    LOSS_FUNC_NAME: str = "loss"
-    ADJOINT_FUNC_NAME: str = "loss_adjoint"
-    UPDATE_PARAMS_FUNC_NAME: str = "update_params"
-
-    PARAMS_NUM_ATTR_KEY: str = "params_num"
-    OPTIM_STATE_ATTR_KEY: str = "optim_state"
-
-    def __init__(self):
-        self._loss_config: Optional[Dict[str, Any]] = None
-        self._optim_config: Optional[Dict[str, Any]] = None
-
-    @classmethod
-    def _check_backbone_validity(cls, mod: IRModule):
-        if not well_formed(mod):
-            raise ValueError("Backbone Invalid: The backbone is not well formed.")
-        ret_sinfo = mod[cls.PREDICT_FUNC_NAME].body.body.struct_info
-        if not isinstance(ret_sinfo, TensorStructInfo):
-            raise ValueError(
-                "Backbone Invalid: The predict function is expected to have a single Tensor "
-                "return value, which serves as the prediction result of the module. But got ",
-                ret_sinfo,
-            )
-
-    def set_loss(self, loss: Loss, *call_args: TensorStructInfo) -> "SetupTrainer":
-        """Specify the loss function.
-
-        Parameters
-        ----------
-        loss : Loss
-            The loss function. It will be appended to the backbone function using
-            relax.training.utils.append_loss.
-
-        *call_args : TensorStructInfo
-            The struct info a.k.a. the arguments to call the loss function.
-
-        Returns
-        -------
-        self : SetupTrainer
-            Return itself to support fluent interface style.
-        """
-        self._loss_config = {"loss": loss, "call_args": call_args}
-        return self
-
-    def set_optimizer(
-        self, optim_type: Type[Optimizer], *init_args: Any, **init_kwargs: Any
-    ) -> "SetupTrainer":
-        """Specify the optimizer for training.
-
-        Parameters
-        ----------
-        optim_type : Type[Optimizer]
-            The specified optimizer class.
-
-        *init_args : Any
-            Positional arguments passed to the optimize constructor.
-
-        **init_kwargs : Any
-            Keyword arguments passed to the optimize constructor.
-
-        Returns
-        -------
-        self : SetupTrainer
-            Return itself to support fluent interface style.
-
-        Notes
-        -----
-        SetupTrainer will set `param_list` of the optimzer automatically. So you only need
-        to pass the rest initial arguments to it.
-        """
-        self._optim_config = {
-            "optim_type": optim_type,
-            "init_args": init_args,
-            "init_kwargs": init_kwargs,
-        }
-        return self
-
-    def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
-        """Setup the trainer in 3 steps.
-        1. Prepare Loss.
-        2. Gradient pass.
-        3. Build Optimizer.
-        4. Legalize operators.
-        """
-
-        self._check_backbone_validity(mod)
-        # Step 1: Prepare Loss.
-        if self._loss_config is None:
-            raise TVMError("Setup Error: Please call 'set_loss' first before you transform.")
-
-        predict_with_loss = append_loss(
-            mod[self.PREDICT_FUNC_NAME],
-            self._loss_config["loss"](*self._loss_config["call_args"]),
-        )
-        mod[self.LOSS_FUNC_NAME] = predict_with_loss
-
-        # Step 2: Gradient pass.
-        params_num = int(mod[self.PREDICT_FUNC_NAME].attrs[self.PARAMS_NUM_ATTR_KEY])
-        require_grads = mod[self.LOSS_FUNC_NAME].params[:params_num]
-        mod = Gradient(mod.get_global_var(self.LOSS_FUNC_NAME), require_grads=require_grads)(mod)
-
-        # Step 3: Build Optimizer.
-        if self._optim_config is None:
-            raise TVMError("Setup Error: Please call `set_optimizer` first before you setup.")
-        optimizer = self._optim_config["optim_type"](
-            param_list=list(mod[self.ADJOINT_FUNC_NAME].params)[:params_num],
-            *self._optim_config["init_args"],
-            **self._optim_config["init_kwargs"],
-        )
-        mod[self.UPDATE_PARAMS_FUNC_NAME] = optimizer.get_function().with_attr(
-            self.OPTIM_STATE_ATTR_KEY, optimizer.state
-        )
-
-        # Step 4: Legalize operators.
-        return LegalizeOps()(mod)  # type: ignore
 
 
 class Trainer:

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -92,7 +92,7 @@ class SetupTrainer:
             The loss function. It will be appended to the backbone function using
             relax.training.utils.append_loss.
 
-        call_args : TensorStructInfo
+        *call_args : TensorStructInfo
             The struct info a.k.a. the arguments to call the loss function.
 
         Returns
@@ -113,10 +113,10 @@ class SetupTrainer:
         optim_type : Type[Optimizer]
             The specified optimizer class.
 
-        init_args : Any
+        *init_args : Any
             Positional arguments passed to the optimize constructor.
 
-        init_kwargs : Any
+        **init_kwargs : Any
             Keyword arguments passed to the optimize constructor.
 
         Returns
@@ -352,7 +352,7 @@ class Trainer:
 
         Parameters
         ----------
-        inputs : Union[np.ndarray, NDArray]
+        *inputs : Union[np.ndarray, NDArray]
             The necessary inputs of the module.
 
         Returns
@@ -375,7 +375,7 @@ class Trainer:
 
         Parameters
         ----------
-        inputs : Union[np.ndarray, NDArray]
+        *inputs : Union[np.ndarray, NDArray]
             The necessary inputs of the module.
 
         Returns

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=not-callable, invalid-name
+# pylint: disable=not-callable,invalid-name,unused-argument
 """Unified Trainer API for relax training."""
 
 from typing import Union, List, Type, Optional, Any, Dict
@@ -202,7 +202,7 @@ class Trainer:
         backbone[self._predict_fn] = backbone[self._predict_fn].with_attr(
             setup_trainer_pass.PARAMS_NUM_ATTR_KEY, params_num
         )
-        self._mod = setup_trainer_pass(backbone)
+        self._mod = setup_trainer_pass(backbone)  # type: ignore
         self._vm: Optional[VirtualMachine] = None
         self._optim_state = self._mod[self._update_params_fn].attrs[
             setup_trainer_pass.OPTIM_STATE_ATTR_KEY
@@ -215,7 +215,6 @@ class Trainer:
         def _convert_from_tvm_shape(tvm_shape):
             return [int(dim) for dim in tvm_shape]
 
-        param_list = []
         self._parameters_buffer = []
         for i, param in enumerate(self._mod[setup_trainer_pass.ADJOINT_FUNC_NAME].params):
             if i < params_num:
@@ -234,7 +233,7 @@ class Trainer:
         target: Union[str, tvm.target.Target],
         device: Union[tvm.runtime.Device, List[tvm.runtime.Device]] = tvm.cpu(0),
         memory_cfg: Optional[str] = None,
-    ) -> "Trainer":
+    ):
         """Specify the following vm config: target, device, memory_cfg.
 
         Parameters
@@ -247,11 +246,6 @@ class Trainer:
 
         memory_cfg : Optional[str]
             The allocator behavior to use for the VM.
-
-        Returns
-        -------
-        self : Trainer
-            Return itself to support fluent interface style.
         """
         ex = build(self._mod, target=target)
         self._vm = VirtualMachine(ex, device=device, memory_cfg=memory_cfg)
@@ -366,8 +360,8 @@ class Trainer:
         return self._vm[self._predict_fn](*self._prepare_inputs(self._predict_fn, inputs))
 
     def update_params(self, *inputs: List[Union[np.ndarray, NDArray]]) -> NDArray:
-        """Calculate loss and update parameters. It will calculate the gradient of each parameter and
-        update them using optimizer.
+        """Calculate loss and update parameters. It will calculate the gradient of each
+        parameter and update them using optimizer.
 
         Parameters
         ----------

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -28,14 +28,21 @@ def append_loss(orig_func: Function, loss_func: Function) -> Function:
     those arguments of loss_func which are not mapped to some return values, they will be lifted
     and appended to the argument list of result function.
 
-    Note
-    -------
-    1. This uitl is dedicated to loss functions, not for general purposes.
-    2. This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in
-    some sense.
+    Parameters
+    ----------
+    orig_func : Function
+        The function to be appended to.
 
-    Example
+    loss_func : Function
+        The loss function.
+
+    Returns
     -------
+    ret : Function
+        The result function.
+
+    Examples
+    --------
     >>> @R.function
     ... def orig(x: R.Tensor((2, 4), "float32"), y: R.Tensor((2, 4), "float32")):
     ...     with R.dataflow():
@@ -68,17 +75,10 @@ def append_loss(orig_func: Function, loss_func: Function) -> Function:
     ...         R.output(gv)
     ...     return gv
 
-    Parameters
-    ----------
-    orig_func : Function
-        The function to be appended to.
-
-    loss_func : Function
-        The loss function.
-
-    Returns
-    -------
-    ret : Function
-        The result function.
+    Notes
+    -----
+    1. This uitl is dedicated to loss functions, not for general purposes.
+    2. This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in
+    some sense.
     """
     return _ffi_api.AppendLoss(orig_func, loss_func)  # type: ignore

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -77,7 +77,7 @@ def append_loss(orig_func: Function, loss_func: Function) -> Function:
 
     Notes
     -----
-    1. This uitl is dedicated to loss functions, not for general purposes.
+    1. This util is dedicated to loss functions, not for general purposes.
     2. This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in
     some sense.
     """

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -21,9 +21,10 @@ import numpy as np
 from tvm import relax, TVMError
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import ir as I, relax as R, tir as T
+from tvm.relax.training import SetupTrainer
 from tvm.relax.training.optimizer import SGD
 from tvm.relax.training.loss import MSELoss
-from tvm.relax.training.trainer import SetupTrainer, Trainer
+from tvm.relax.training.trainer import Trainer
 
 
 def _get_backbone():

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -14,16 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 import tvm.testing
 import numpy as np
-from tvm import relax
+
+from tvm import relax, TVMError
+from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import ir as I, relax as R
 from tvm.relax.training.optimizer import SGD
 from tvm.relax.training.loss import MSELoss
 from tvm.relax.training.trainer import Trainer
 
 
-def test_basic(target, dev):
+def _get_trainer() -> Trainer:
     @I.ir_module
     class MLP:
         @R.function
@@ -39,14 +42,13 @@ def test_basic(target, dev):
                 R.output(out)
             return out
 
-    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
     trainer = Trainer(MLP, [1, 2])
-    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    trainer.set_vm_config(target="llvm")
-    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup()
+    return trainer
 
+
+def _make_dataset():
     N = 100
-    dataset = [
+    return [
         [
             np.random.uniform(size=(1, 10)).astype(np.float32),
             np.array([[0, 0, 1, 0, 0]]).astype(np.float32),
@@ -54,13 +56,164 @@ def test_basic(target, dev):
         for _ in range(N)
     ]
 
+
+@tvm.testing.parametrize_targets("llvm")
+def test_execute(target, dev):
+    trainer = _get_trainer()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    trainer.set_vm_config(target="llvm")
+    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup().rand_init_params()
+
+    dataset = _make_dataset()
     last_loss = np.inf
     for epoch in range(5):
         for i, data in enumerate(dataset):
             loss = trainer.backward(data[0], data[1])
-        print(f"Epoch #{epoch}. Loss = {loss}.")
-        assert last_loss > loss
-        last_loss = loss
 
 
-test_basic("llvm", tvm.cpu(0))
+@tvm.testing.parametrize_targets("llvm")
+def test_load_export_params(target, dev):
+    trainer = _get_trainer()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    trainer.set_vm_config(target="llvm")
+    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup().rand_init_params()
+
+    dataset = _make_dataset()
+    for i, data in enumerate(dataset):
+        loss = trainer.backward(data[0], data[1])
+
+    param_dict = trainer.export_params()
+    assert "w0" in param_dict
+    assert "b0" in param_dict
+
+    trainer1 = _get_trainer()
+    trainer1.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    trainer1.set_vm_config(target="llvm")
+    trainer1.set_optimizer(optim_type=SGD, lr=0.001).setup().load_params(param_dict)
+
+    x_sample = dataset[np.random.randint(len(dataset))][0]
+    tvm.testing.assert_allclose(
+        trainer.forward(x_sample).numpy(), trainer1.forward(x_sample).numpy()
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_get_mod(target, dev):
+    trainer = _get_trainer()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    trainer.set_vm_config(target="llvm")
+    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup()
+
+    # fmt: off
+    @tvm.script.ir_module
+    class Expected:
+        @R.function
+        def main(x: R.Tensor((1, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32")) -> R.Tensor((1, 5), dtype="float32"):
+            with R.dataflow():
+                lv0: R.Tensor((1, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
+                lv1: R.Tensor((1, 5), dtype="float32") = R.add(lv0, b0)
+                out: R.Tensor((1, 5), dtype="float32") = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+        @R.function
+        def main_loss(x: R.Tensor((1, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), targets: R.Tensor((1, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv0: R.Tensor((1, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
+                lv1: R.Tensor((1, 5), dtype="float32") = R.add(lv0, b0)
+                out: R.Tensor((1, 5), dtype="float32") = R.nn.relu(lv1)
+                lv: R.Tensor((1, 5), dtype="float32") = R.subtract(out, targets)
+                lv11: R.Tensor((1, 5), dtype="float32") = R.multiply(lv, lv)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv11, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+
+        @R.function
+        def main_loss_adjoint(x: R.Tensor((1, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), targets: R.Tensor((1, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((5,), dtype="float32"))):
+            with R.dataflow():
+                lv0: R.Tensor((1, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
+                lv1: R.Tensor((1, 5), dtype="float32") = R.add(lv0, b0)
+                out: R.Tensor((1, 5), dtype="float32") = R.nn.relu(lv1)
+                lv: R.Tensor((1, 5), dtype="float32") = R.subtract(out, targets)
+                lv11: R.Tensor((1, 5), dtype="float32") = R.multiply(lv, lv)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv11, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
+                lv1_adjoint: R.Tensor((1, 5), dtype="float32") = R.broadcast_to(gv_adjoint, (1, 5))
+                lv2: R.Tensor((1, 5), dtype="float32") = R.multiply(lv1_adjoint, lv)
+                lv12: R.Tensor((1, 5), dtype="float32") = R.multiply(lv1_adjoint, lv)
+                lv_adjoint: R.Tensor((1, 5), dtype="float32") = R.add(lv2, lv12)
+                out_adjoint: R.Tensor((1, 5), dtype="float32") = lv_adjoint
+                lv21: R.Tensor((1, 5), dtype="float32") = R.zeros((1, 5), dtype="float32")
+                lv3: R.Tensor((1, 5), dtype="bool") = R.less(lv1, lv21)
+                lv4: R.Tensor((1, 5), dtype="float32") = R.ones((1, 5), dtype="float32")
+                lv5: R.Tensor((1, 5), dtype="float32") = R.multiply(lv4, out_adjoint)
+                lv1_adjoint1: R.Tensor((1, 5), dtype="float32") = R.where(lv3, lv21, lv5)
+                lv0_adjoint: R.Tensor((1, 5), dtype="float32") = lv1_adjoint1
+                lv6: R.Tensor((10, 1), dtype="float32") = R.permute_dims(x, axes=[1, 0])
+                lv7: R.Tensor((10, 5), dtype="float32") = R.matmul(lv6, lv0_adjoint, out_dtype="")
+                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv7, (10, 5))
+                b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(lv1_adjoint1, (5,))
+                R.output(gv, w0_adjoint, b0_adjoint)
+            return (gv, (w0_adjoint, b0_adjoint))
+    # fmt: on
+
+    mod = trainer.mod
+    assert_structural_equal(Expected["main_loss"], trainer.mod["main_loss"])
+    assert_structural_equal(Expected["main_loss_adjoint"], trainer.mod["main_loss_adjoint"])
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_setting_error(target, dev):
+    trainer = _get_trainer()
+
+    with pytest.raises(TVMError):
+        trainer.mod
+    with pytest.raises(TVMError):
+        trainer.vm
+    with pytest.raises(TVMError):
+        trainer.optimizer
+    with pytest.raises(TVMError):
+        trainer.rand_init_params()
+    with pytest.raises(TVMError):
+        trainer.load_params({})
+
+    with pytest.raises(TVMError):
+        trainer.setup()
+
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    with pytest.raises(TVMError):
+        trainer.setup()
+
+    trainer.set_vm_config(target="llvm")
+    with pytest.raises(TVMError):
+        trainer.setup()
+    trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    trainer.setup()
+
+
+def test_invalid_mod():
+    @I.ir_module
+    class InvalidMLP:
+        @R.function
+        def main(
+            x: R.Tensor((1, 10), "float32"),
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                gv = R.add(lv0, b0)
+                out = R.nn.relu(gv)
+                R.output(gv, out)
+            return gv, out
+
+    with pytest.raises(ValueError):
+        trainer = Trainer(InvalidMLP, [1, 2])
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -113,8 +113,7 @@ def test_load_export_params(target, dev):
     )
 
 
-@tvm.testing.parametrize_targets("llvm")
-def test_setting_error(target, dev):
+def test_setting_error():
     backbone, params_num = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm.testing
+import numpy as np
+from tvm import relax
+from tvm.script.parser import ir as I, relax as R
+from tvm.relax.training.optimizer import SGD
+from tvm.relax.training.loss import MSELoss
+from tvm.relax.training.trainer import Trainer
+
+
+def test_basic(target, dev):
+    @I.ir_module
+    class MLP:
+        @R.function
+        def main(
+            x: R.Tensor((1, 10), "float32"),
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.add(lv0, b0)
+                out = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    trainer = Trainer(MLP, [1, 2])
+    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    trainer.set_vm_config(target="llvm")
+    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup()
+
+    N = 100
+    dataset = [
+        [
+            np.random.uniform(size=(1, 10)).astype(np.float32),
+            np.array([[0, 0, 1, 0, 0]]).astype(np.float32),
+        ]
+        for _ in range(N)
+    ]
+
+    last_loss = np.inf
+    for epoch in range(5):
+        for i, data in enumerate(dataset):
+            loss = trainer.backward(data[0], data[1])
+        print(f"Epoch #{epoch}. Loss = {loss}.")
+        assert last_loss > loss
+        last_loss = loss
+
+
+test_basic("llvm", tvm.cpu(0))

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -68,7 +68,7 @@ def test_execute(target, dev):
 
     trainer = Trainer(backbone, params_num, setup_trainer)
     trainer.build(target, dev)
-    trainer.rand_init_params()
+    trainer.xaiver_uniform_init_params()
 
     dataset = _make_dataset()
     last_loss = np.inf
@@ -89,7 +89,7 @@ def test_load_export_params(target, dev):
 
     trainer = Trainer(backbone, params_num, setup_trainer)
     trainer.build(target, dev)
-    trainer.rand_init_params()
+    trainer.xaiver_uniform_init_params()
 
     dataset = _make_dataset()
     for i, data in enumerate(dataset):

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -20,20 +20,20 @@ import numpy as np
 
 from tvm import relax, TVMError
 from tvm.ir.base import assert_structural_equal
-from tvm.script.parser import ir as I, relax as R
+from tvm.script.parser import ir as I, relax as R, tir as T
 from tvm.relax.training.optimizer import SGD
 from tvm.relax.training.loss import MSELoss
-from tvm.relax.training.trainer import Trainer
+from tvm.relax.training.trainer import SetupTrainer, Trainer
 
 
-def _get_trainer() -> Trainer:
+def _get_backbone():
     @I.ir_module
     class MLP:
         @R.function
-        def main(
-            x: R.Tensor((1, 10), "float32"),
+        def predict(
             w0: R.Tensor((10, 5), "float32"),
             b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
         ):
             with R.dataflow():
                 lv0 = R.matmul(x, w0)
@@ -42,8 +42,7 @@ def _get_trainer() -> Trainer:
                 R.output(out)
             return out
 
-    trainer = Trainer(MLP, [1, 2])
-    return trainer
+    return MLP, 2
 
 
 def _make_dataset():
@@ -59,151 +58,88 @@ def _make_dataset():
 
 @tvm.testing.parametrize_targets("llvm")
 def test_execute(target, dev):
-    trainer = _get_trainer()
+    backbone, params_num = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
-    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    trainer.set_vm_config(target="llvm")
-    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup().rand_init_params()
+
+    setup_trainer = SetupTrainer()
+    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+
+    trainer = Trainer(backbone, params_num, setup_trainer)
+    trainer.build(target, dev)
+    trainer.rand_init_params()
 
     dataset = _make_dataset()
     last_loss = np.inf
     for epoch in range(5):
         for i, data in enumerate(dataset):
-            loss = trainer.backward(data[0], data[1])
+            loss = trainer.update_params(data[0], data[1])
+    trainer.predict(dataset[0][0])
 
 
 @tvm.testing.parametrize_targets("llvm")
 def test_load_export_params(target, dev):
-    trainer = _get_trainer()
+    backbone, params_num = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
-    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    trainer.set_vm_config(target="llvm")
-    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup().rand_init_params()
+
+    setup_trainer = SetupTrainer()
+    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+
+    trainer = Trainer(backbone, params_num, setup_trainer)
+    trainer.build(target, dev)
+    trainer.rand_init_params()
 
     dataset = _make_dataset()
     for i, data in enumerate(dataset):
-        loss = trainer.backward(data[0], data[1])
+        trainer.update_params(data[0], data[1])
 
     param_dict = trainer.export_params()
     assert "w0" in param_dict
     assert "b0" in param_dict
 
-    trainer1 = _get_trainer()
-    trainer1.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    trainer1.set_vm_config(target="llvm")
-    trainer1.set_optimizer(optim_type=SGD, lr=0.001).setup().load_params(param_dict)
+    trainer1 = Trainer(backbone, params_num, setup_trainer)
+    trainer1.build(target, dev)
+    trainer1.load_params(param_dict)
 
     x_sample = dataset[np.random.randint(len(dataset))][0]
     tvm.testing.assert_allclose(
-        trainer.forward(x_sample).numpy(), trainer1.forward(x_sample).numpy()
+        trainer.predict(x_sample).numpy(), trainer1.predict(x_sample).numpy()
     )
 
 
 @tvm.testing.parametrize_targets("llvm")
-def test_get_mod(target, dev):
-    trainer = _get_trainer()
-    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
-    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    trainer.set_vm_config(target="llvm")
-    trainer.set_optimizer(optim_type=SGD, lr=0.001).setup()
-
-    # fmt: off
-    @tvm.script.ir_module
-    class Expected:
-        @R.function
-        def main(x: R.Tensor((1, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32")) -> R.Tensor((1, 5), dtype="float32"):
-            with R.dataflow():
-                lv0: R.Tensor((1, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
-                lv1: R.Tensor((1, 5), dtype="float32") = R.add(lv0, b0)
-                out: R.Tensor((1, 5), dtype="float32") = R.nn.relu(lv1)
-                R.output(out)
-            return out
-
-        @R.function
-        def main_loss(x: R.Tensor((1, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), targets: R.Tensor((1, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
-            with R.dataflow():
-                lv0: R.Tensor((1, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
-                lv1: R.Tensor((1, 5), dtype="float32") = R.add(lv0, b0)
-                out: R.Tensor((1, 5), dtype="float32") = R.nn.relu(lv1)
-                lv: R.Tensor((1, 5), dtype="float32") = R.subtract(out, targets)
-                lv11: R.Tensor((1, 5), dtype="float32") = R.multiply(lv, lv)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv11, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
-
-        @R.function
-        def main_loss_adjoint(x: R.Tensor((1, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), targets: R.Tensor((1, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((5,), dtype="float32"))):
-            with R.dataflow():
-                lv0: R.Tensor((1, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
-                lv1: R.Tensor((1, 5), dtype="float32") = R.add(lv0, b0)
-                out: R.Tensor((1, 5), dtype="float32") = R.nn.relu(lv1)
-                lv: R.Tensor((1, 5), dtype="float32") = R.subtract(out, targets)
-                lv11: R.Tensor((1, 5), dtype="float32") = R.multiply(lv, lv)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv11, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv1_adjoint: R.Tensor((1, 5), dtype="float32") = R.broadcast_to(gv_adjoint, (1, 5))
-                lv2: R.Tensor((1, 5), dtype="float32") = R.multiply(lv1_adjoint, lv)
-                lv12: R.Tensor((1, 5), dtype="float32") = R.multiply(lv1_adjoint, lv)
-                lv_adjoint: R.Tensor((1, 5), dtype="float32") = R.add(lv2, lv12)
-                out_adjoint: R.Tensor((1, 5), dtype="float32") = lv_adjoint
-                lv21: R.Tensor((1, 5), dtype="float32") = R.zeros((1, 5), dtype="float32")
-                lv3: R.Tensor((1, 5), dtype="bool") = R.less(lv1, lv21)
-                lv4: R.Tensor((1, 5), dtype="float32") = R.ones((1, 5), dtype="float32")
-                lv5: R.Tensor((1, 5), dtype="float32") = R.multiply(lv4, out_adjoint)
-                lv1_adjoint1: R.Tensor((1, 5), dtype="float32") = R.where(lv3, lv21, lv5)
-                lv0_adjoint: R.Tensor((1, 5), dtype="float32") = lv1_adjoint1
-                lv6: R.Tensor((10, 1), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                lv7: R.Tensor((10, 5), dtype="float32") = R.matmul(lv6, lv0_adjoint, out_dtype="")
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv7, (10, 5))
-                b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(lv1_adjoint1, (5,))
-                R.output(gv, w0_adjoint, b0_adjoint)
-            return (gv, (w0_adjoint, b0_adjoint))
-    # fmt: on
-
-    mod = trainer.mod
-    assert_structural_equal(Expected["main_loss"], trainer.mod["main_loss"])
-    assert_structural_equal(Expected["main_loss_adjoint"], trainer.mod["main_loss_adjoint"])
-
-
-@tvm.testing.parametrize_targets("llvm")
 def test_setting_error(target, dev):
-    trainer = _get_trainer()
+    backbone, params_num = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
+    setup_trainer = SetupTrainer()
     with pytest.raises(TVMError):
-        trainer.mod
+        setup_trainer(backbone)
+
+    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    trainer = Trainer(backbone, params_num, setup_trainer)
+
     with pytest.raises(TVMError):
         trainer.vm
+    dataset = _make_dataset()
     with pytest.raises(TVMError):
-        trainer.optimizer
+        trainer.predict(dataset[0][0])
     with pytest.raises(TVMError):
-        trainer.rand_init_params()
-    with pytest.raises(TVMError):
-        trainer.load_params({})
-
-    with pytest.raises(TVMError):
-        trainer.setup()
-
-    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
-    trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    with pytest.raises(TVMError):
-        trainer.setup()
-
-    trainer.set_vm_config(target="llvm")
-    with pytest.raises(TVMError):
-        trainer.setup()
-    trainer.set_optimizer(optim_type=SGD, lr=0.001)
-    trainer.setup()
+        trainer.update_params(dataset[0][0], dataset[0][1])
 
 
 def test_invalid_mod():
     @I.ir_module
-    class InvalidMLP:
+    class NotReturnSingleTensor:
         @R.function
-        def main(
-            x: R.Tensor((1, 10), "float32"),
+        def predict(
             w0: R.Tensor((10, 5), "float32"),
             b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
         ):
+            R.func_attr({"params_num": 2})
             with R.dataflow():
                 lv0 = R.matmul(x, w0)
                 gv = R.add(lv0, b0)
@@ -211,8 +147,31 @@ def test_invalid_mod():
                 R.output(gv, out)
             return gv, out
 
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    setup_trainer = SetupTrainer()
+    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
+    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+
     with pytest.raises(ValueError):
-        trainer = Trainer(InvalidMLP, [1, 2])
+        setup_trainer(NotReturnSingleTensor)
+
+    @I.ir_module
+    class NoParamsNumAttr:
+        @R.function
+        def predict(
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.add(lv0, b0)
+                out = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+    with pytest.raises(TypeError):
+        setup_trainer(NoParamsNumAttr)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -62,9 +62,11 @@ def test_execute(target, dev):
     backbone, params_num = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
-    setup_trainer = SetupTrainer()
-    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
 
     trainer = Trainer(backbone, params_num, setup_trainer)
     trainer.build(target, dev)
@@ -83,9 +85,11 @@ def test_load_export_params(target, dev):
     backbone, params_num = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
-    setup_trainer = SetupTrainer()
-    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
 
     trainer = Trainer(backbone, params_num, setup_trainer)
     trainer.build(target, dev)
@@ -114,12 +118,11 @@ def test_setting_error(target, dev):
     backbone, params_num = _get_backbone()
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
 
-    setup_trainer = SetupTrainer()
-    with pytest.raises(TVMError):
-        setup_trainer(backbone)
-
-    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
     trainer = Trainer(backbone, params_num, setup_trainer)
 
     with pytest.raises(TVMError):
@@ -149,9 +152,11 @@ def test_invalid_mod():
             return gv, out
 
     pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
-    setup_trainer = SetupTrainer()
-    setup_trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
-    setup_trainer.set_optimizer(optim_type=SGD, lr=0.001)
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
 
     with pytest.raises(ValueError):
         setup_trainer(NotReturnSingleTensor)


### PR DESCRIPTION
This PR brings a wrapper for relax training. The following things are done internally in this trainer:
- Maintain (store/update) the parameters of the module.
- Merge backbone and specified loss function together.
- Build/Compile/Run the module.
- Build/Compile/Run the optimizer. (using the same vm_config as we run the module.)

And it also provides two interfaces for loading params/exporting params.

Example:
```
trainer = Trainer(MLP, [1, 2], "main") # [1, 2] means input[1] and input[2] are parameters in this module.
trainer.set_loss(MSELoss(reduction="sum"), pred_sinfo, pred_sinfo)
trainer.set_vm_config(target="llvm")
trainer.set_optimizer(optim_type=SGD, lr=0.001).setup()
trainer.setup()
trainer.rand_init_params()
trainer.forward(*fwd_inputs)
trainer.backward(*bwd_inputs)
```