### PR TITLE
[Relax][Training] Refactor Optimizer and Gradient

### DIFF
--- a/include/tvm/relax/transform.h
+++ b/include/tvm/relax/transform.h
@@ -235,23 +235,22 @@ TVM_DLL Pass ConvertLayout(Map<String, Array<String>> desired_layouts);
 /*!
  * \brief Reverse-mode automatic differentiation.
  *
- * Now only supports differentiating one function in the IRModule with one dataflow block
- * with respect to the only return value of the function, which needs to be scalar.
+ * Now only supports differentiating one function in the IRModule with one dataflow block with
+ * respect to the only return value of the function, which needs to be scalar.
  *
- * For a given function specified by the input global var, it generates a new function with the name
- * `[name of original function] + "_adjoint"`. The new function computes the adjoints of the
- * specified arguments of the original function with respect to the only one return value of the
- * original function.
+ * For a given function specified by the input name, it generates a new function with the name
+ * `func_name + "_adjoint"`. The new function computes the adjoints of the specified arguments of
+ * the original function with respect to the only one return value of the original function.
  *
  * For examples, see the MLP examples in `tests/python/relax/test_transform_gradient.py` and
  * `tests/python/relax/test_transform_gradient_numeric.py`.
  *
- * \param global_var The GlobalVar of the specified function.
+ * \param func_name The name of the specified function.
  * \param require_grads The relax variables whose adjoints are needed. Must be parameters of the
  * given function. If it is not specified, adjoints of all arguments would be computed.
  * \return The Pass.
  */
-TVM_DLL Pass Gradient(GlobalVar global_var, Optional<Array<Var>> require_grads = NullOpt);
+TVM_DLL Pass Gradient(String func_name, Optional<Array<Var>> require_grads = NullOpt);
 
 /*!
  * \brief Split a PrimFunc into 2 parts: the first part is a TIR PrimFunc which is

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -34,8 +34,6 @@ class Optimizer:
     """Relax training optimizer. This class could generate relax Functions for optimizing specified
     parameters, and store the states used in the optimization process, such as momentum.
 
-    See `@property state` for details about the state of the optimizer.
-
     Parameters
     ----------
     name : str

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -24,10 +24,8 @@ import numpy as np  # type: ignore
 import tvm
 from tvm.runtime.container import tuple_object
 
-from ..vm import VirtualMachine, build
 from ..block_builder import BlockBuilder
 from ..struct_info import TensorStructInfo, TupleStructInfo
-from ..transform.legalize_ops import LegalizeOps
 from ..op import add, subtract, multiply, divide, sqrt
 from ..expr import const, Var, Function, TupleGetItem, Tuple as RxTuple
 
@@ -43,12 +41,29 @@ class Optimizer:
     name : str
         The name of the optimizer function. This parameter is provided by subclasses.
 
-    params : Union[Var, List[Var]]
-        The parameter or the list of parameters to optimize.
+    Attributes
+    ----------
+    dtype : str
+        The only dtype of the optimizer. It will be used as the dtype of the optimizer states,
+        and the dtype of necessary constants, such as the learning rate. Will be set in `init()`.
 
-        Parameters should all be Vars of floating point Tensors, including float32, float64,
-        float16, etc. Currently, all parameters should have the same dtype, and that dtype
-        will be used as the dtype of the optimizer states.
+    name : str
+        The name of the optimizer.
+
+    param_list : Optional[List[Var]]
+        The list of variables to optimize. Will be set in `init()`.
+
+    state : tvm.runtime.container.ADT
+        `state` is an runtime ADT object representing the state of the optimizer. Will be set in
+        `init()`.
+
+        The states of the optimizer can store necessary information in the optimization process at
+        runtime, such as the number of steps, the momentum in momentum SGD, etc.
+
+        `opt.state` should be used as the last argument of the function that is got through
+        `get_function()`, and its new value is returned as the last return value of that function.
+
+        See examples for more details.
 
     Examples
     --------
@@ -58,43 +73,59 @@ class Optimizer:
     .. code-block:: python
         # Initialize the optimizer.
         # x is the relax Var we want to optimize
-        opt = relax.optimizer.SGD(x, 0.1)
+        opt = relax.optimizer.SGD(0.1)
+        # Initialize parameter list, dtype and optimizer state
+        opt.init(x)
 
-        # Backward process
-        # adjoint_function is a runtime function that takes TVM runtime objects as input and output
-        # It accepts parameters and other inputs, returns loss and gradients of the parameters
-        # See also relax.transform.Gradient.
-        loss, param_gradient = adjoint_function(*param_tuple, label)
-
+        #TODO
         # Optimization process
+        # param_tuple is a runtime tuple of parameters
+        # param_gradient is a runtime tuple of the gradient of parameters in param_tuple,
+        # respectively
+        # param_gradient can be gained by the automatic gradient pass. Please see
+        # `relax.transform.Gradient`
         param_tuple = opt(param_tuple, param_gradient)
     """
 
+    dtype: str
     name: str
-    _param_list: List[Var]
-    _state: tvm.runtime.container.ADT
-    _dtype: str
+    param_list: List[Var]
+    state: tvm.runtime.container.ADT
 
-    # these attributes are for the building and running process of the optimizer function
-    _vm_module: VirtualMachine
-    _target: Union[str, tvm.target.Target]
-    _device: Union[tvm.runtime.Device, List[tvm.runtime.Device]]
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.param_list = None
+        self.state = None
+        self.dtype = None
 
-    def __init__(self, name: str, params: Union[Var, List[Var]]) -> None:
+    def init(self, params: Union[Var, List[Var]]) -> "Optimizer":
+        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
+
+        Returns
+        -------
+        self : Optimizer
+            The optimizer itself. You can do more operations on the return value.
+        """
         if not isinstance(params, list):
             params = [params]
-        self._state = None
-        self._dtype = None
-        self._check_params_and_dtype(params)
-        self._param_list = params
-        self.name = name
-        self._vm_module = None
-        self._target = None
-        self._device = None
+        self._set_params_and_dtype(params)
+        # State should be initialized in any implementation of optimizer.
+        self.state = None
+        return self
 
-    def _check_params_and_dtype(self, params: List[Var]) -> None:
-        """Check params is legal and set the dtype of the optimizer."""
+    def _set_params_and_dtype(self, params: List[Var]) -> None:
+        """Check params is legal and set the param_list and dtype of the optimizer."""
         params_set = set()
+        dtype = None
         for x in params:
             if not isinstance(x, Var):
                 raise ValueError(f"Parameter {x} is not a Var")
@@ -109,49 +140,31 @@ class Optimizer:
                     f"Optimizers only support Tensor parameters of floating point dtype, but dtype "
                     f"of {x.name_hint} is {x.struct_info.dtype}"
                 )
-            if self._dtype is None:
-                self._dtype = x.struct_info.dtype
+            if dtype is None:
+                dtype = x.struct_info.dtype
             else:
-                if self._dtype != x.struct_info.dtype:
+                if dtype != x.struct_info.dtype:
                     raise ValueError(
                         f"All parameters should have the same dtype, but parameter {x.name_hint} "
                         f"has dtype {x.struct_info.dtype}, which differs from the previous dtype "
-                        f"{self._dtype}"
+                        f"{dtype}"
                     )
             if x in params_set:
                 raise ValueError(f"Parameter {x.name_hint} appears more than once")
             params_set.add(x)
+        self.param_list = params
+        self.dtype = dtype
 
-    @property
-    def state(self) -> tvm.runtime.container.ADT:
-        """Return the state of the optimizer.
-
-        The states of the optimizer can store information useful in the optimization process, such
-        as the number of steps, the momentum in momentum SGD, etc.
-
-        `opt.state` should be used as the last argument of the function that is got through
-        `get_function()`, and its new value is returned as the last return value of that function.
-
-        The state of an optimizer will be constructed when `opt.state` is called for the first time.
-
-        Returns
-        -------
-        res : ADT
-            An ADT object representing the state of the optimizer.
+    def _check_init(self):
+        """Check that the optimizer is initialized. This method should be called at the start of
+        get_function().
         """
-        return self._state
-
-    @state.setter
-    def state(self, new_value: tvm.runtime.container.ADT) -> None:
-        """Setter of state.
-
-        If `state` property is overloaded, `state` setter must be overloaded at the same time.
-        """
-        self._state = new_value
+        if self.param_list is None or self.state is None or self.dtype is None:
+            raise RuntimeError("Please call init() for the optimizer before calling get_function()")
 
     def get_function(self) -> Function:
-        """We will use blockbuilder in get_function() to build an optimizer function that executes
-        the update of parameters and the optimizer state.
+        """Use blockbuilder to build an optimizer function that executes updates of the parameters
+        and the optimizer state.
 
         The optimizer function will take in a tuple of parameters, a tuple of gradients of
         parameters, and a tuple of optimizer states. It will return a tuple of updated parameters,
@@ -196,64 +209,8 @@ class Optimizer:
                     R.output(params_new, optim_states_new)
                 return (params_new, optim_states_new)
         """
+        self._check_init()
         raise NotImplementedError()
-
-    def set_vm_config(
-        self,
-        target: Union[str, tvm.target.Target],
-        device: Union[tvm.runtime.Device, List[tvm.runtime.Device]],
-    ) -> "Optimizer":
-        """Set the building and virtual machine configs of the optimizer function.
-
-        Parameters
-        ----------
-        target : Union[str, tvm.target.Target]
-            The target of building the module containing the optimizer function.
-
-        device : Union[tvm.runtime.Device, List[tvm.runtime.Device]]
-            The device to deploy the module containing the optimizer function.
-
-        Returns
-        -------
-        self : Optimizer
-            Returns the optimizer itself.
-        """
-        self._target = target
-        self._device = device
-        return self
-
-    def __call__(
-        self, params_adt: tvm.runtime.container.ADT, grads_adt: tvm.runtime.container.ADT
-    ) -> tvm.runtime.container.ADT:
-        """Optimization process. This function takes an ADT tuple of the input parameters and an ADT
-        tuple of the gradients of the input parameters, and returns an ADT tuple of parameters
-        after a step op optimization. This is equilvant to `optimizer.step()` in most deep learning
-        frameworks.
-
-        This function will build a module containing the optimizer function when called for the
-        first time. Before this function is called, you should call `set_vm_config()` to set the
-        building and vm configs first.
-
-        Parameters
-        ----------
-        params_adt : tvm.runtime.container.ADT
-            An ADT tuple of the input parameters. A TVM runtime object.
-
-        grads_adt : tvm.runtime.container.ADT
-            An ADT tuple of the gradients of the input parameters. A TVM runtime object.
-        """
-        if self._vm_module is None:
-            if self._target is None or self._device is None:
-                raise RuntimeError(
-                    "The vm configs of the optimizer is not set. Please call set_vm_config first"
-                )
-            mod = tvm.IRModule({self.name: self.get_function()})
-            # pylint: disable=not-callable
-            lowered_mod = LegalizeOps()(mod)  # type: ignore
-            executable = build(lowered_mod, self._target)
-            self._vm_module = VirtualMachine(executable, self._device)
-        new_params, self.state = self._vm_module[self.name](params_adt, grads_adt, self.state)
-        return new_params
 
 
 # TODO(chaofan, yixin): Support symbolic shapes
@@ -263,7 +220,7 @@ def _get_shape_as_int_list(var: Var) -> List[int]:
 
 # We need to subtract on hyperparameters, but do not want to introduce floating point error.
 # Floating point error would lead to a few problems, such as making assert_structural_equal not
-# passed in unit tests
+# pass in unit tests
 def _high_precision_subtract(lhs: float, rhs: float) -> float:
     return float(Decimal(str(lhs)) - Decimal(str(rhs)))
 
@@ -271,7 +228,7 @@ def _high_precision_subtract(lhs: float, rhs: float) -> float:
 class SGD(Optimizer):
     """Implements stochastic gradient descent.
 
-    The returned function is equivalent to the following numpy code:
+    The returned function of `get_function()` is equivalent to the following numpy code:
 
     .. code-block:: python
         def SGD(param_tuple, grad_tuple, state_tuple):
@@ -286,13 +243,6 @@ class SGD(Optimizer):
 
     Parameters
     ----------
-    params : Union[Var, List[Var]]
-        The parameter or the list of parameters to optimize.
-
-        Parameters should all be Vars of floating point Tensors, including float32, float64,
-        float16, etc. Currently, all parameters should have the same dtype, and that dtype
-        will be used as the dtype of the optimizer states.
-
     lr : float
         learning rate
 
@@ -300,39 +250,55 @@ class SGD(Optimizer):
         weight decay (L2 penalty) (default: 0)
     """
 
-    def __init__(
-        self, param_list: Union[Var, List[Var]], lr: float, weight_decay: float = 0
-    ) -> None:
-        super().__init__("SGD", param_list)
+    def __init__(self, lr: float, weight_decay: float = 0) -> None:
+        super().__init__("SGD")
         self.lr = float(lr)
         self.weight_decay = float(weight_decay)
 
-    @property
-    def state(self) -> tvm.runtime.container.ADT:
-        """The state of SGD is `(num_steps,)`.
+    def init(self, params: Union[Var, List[Var]]) -> "SGD":
+        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+
+        The state of SGD is `(num_steps,)`.
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
 
         Returns
         -------
-        res : ADT
-            The state of SGD.
+        self : SGD
+            The SGD optimizer itself. You can do more operations on the return value.
         """
-        if self._state is None:
-            self._state = tuple_object(
-                (
-                    # num_steps = 0
-                    tvm.nd.array(np.zeros((), "int64")),
-                )
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        self.state = tuple_object(
+            (
+                # num_steps = 0
+                tvm.nd.array(np.zeros((), "int64")),
             )
-        return self._state
-
-    @state.setter
-    def state(self, new_value: tvm.runtime.container.ADT) -> None:
-        self._state = new_value
+        )
+        return self
 
     def get_function(self) -> Function:
-        plist = self._param_list
+        """Use blockbuilder to build an optimizer function that executes updates of the parameters
+        and the optimizer state. `init()` should be called before `get_function()`.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+        """
+        self._check_init()
+
+        plist = self.param_list
         len_param = len(plist)
-        dtype = self._dtype
+        dtype = self.dtype
 
         # input variables
         param_var = Var("params", TupleStructInfo([p.struct_info for p in plist]))
@@ -356,7 +322,7 @@ class SGD(Optimizer):
 
                 # computation logics
                 for i in range(len_param):
-                    name = self._param_list[i].name_hint
+                    name = self.param_list[i].name_hint
                     p = builder.emit(TupleGetItem(param_var, i), name)
                     g = builder.emit(TupleGetItem(grad_var, i), name + "_grad")
                     if self.weight_decay:
@@ -375,7 +341,7 @@ class MomentumSGD(Optimizer):
     """Implements stochastic gradient descent with momentum. Optionally supports Nesterov
     momentum.
 
-    The returned function is equivalent to the following numpy code:
+    The returned function of `get_function()` is equivalent to the following numpy code:
 
     .. code-block:: python
         def MomentumSGD(param_tuple, grad_tuple, state_tuple):
@@ -400,13 +366,6 @@ class MomentumSGD(Optimizer):
 
     Parameters
     ----------
-    params : Union[Var, List[Var]]
-        The parameter or the list of parameters to optimize.
-
-        Parameters should all be Vars of floating point Tensors, including float32, float64,
-        float16, etc. Currently, all parameters should have the same dtype, and that dtype
-        will be used as the dtype of the optimizer states.
-
     lr : float
         learning rate
 
@@ -425,52 +384,68 @@ class MomentumSGD(Optimizer):
 
     def __init__(
         self,
-        param_list: Union[Var, List[Var]],
         lr: float,
         momentum: float,
         dampening: float = 0,
         weight_decay: float = 0,
         nesterov: bool = False,
     ) -> None:
-        super().__init__("MomentumSGD", param_list)
+        super().__init__("MomentumSGD")
         self.lr = float(lr)
         self.momentum = float(momentum)
         self.weight_decay = float(weight_decay)
         self.dampening = float(dampening)
         self.nesterov = nesterov
 
-    @property
-    def state(self) -> tvm.runtime.container.ADT:
-        """The state of momentum SGD is
-        `(num_steps, velocity_of_param_0, ..., velocity_of_param_n-1)`
+    def init(self, params: Union[Var, List[Var]]) -> "MomentumSGD":
+        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+
+        The state of MomentumSGD is
+        `(num_steps, velocity_of_param_0, ..., velocity_of_param_n-1)`.
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
 
         Returns
         -------
-        res : ADT
-            The state of momentum SGD.
+        self : MomentumSGD
+            The MomentumSGD optimizer itself. You can do more operations on the return value.
         """
-        if self._state is None:
-            self._state = tuple_object(
-                (
-                    # num_steps = 0
-                    tvm.nd.array(np.zeros((), "int64")),
-                    # v_{param} is initialized to all zeros
-                    *(
-                        tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
-                        for p in self._param_list
-                    ),
-                )
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        self.state = tuple_object(
+            (
+                # num_steps = 0
+                tvm.nd.array(np.zeros((), "int64")),
+                # v_{param} is initialized to all zeros
+                *(
+                    tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
+                    for p in self.param_list
+                ),
             )
-        return self._state
-
-    @state.setter
-    def state(self, new_value: tvm.runtime.container.ADT) -> None:
-        self._state = new_value
+        )
+        return self
 
     def get_function(self) -> Function:
-        plist = self._param_list
+        """Use blockbuilder to build an optimizer function that executes updates of the parameters
+        and the optimizer state. `init()` should be called before `get_function()`.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+        """
+        self._check_init()
+        plist = self.param_list
         len_param = len(plist)
-        dtype = self._dtype
+        dtype = self.dtype
 
         # input variables
         param_var = Var("params", TupleStructInfo([p.struct_info for p in plist]))
@@ -499,7 +474,7 @@ class MomentumSGD(Optimizer):
 
                 # computation logics
                 for i in range(len_param):
-                    name = self._param_list[i].name_hint
+                    name = self.param_list[i].name_hint
                     p = builder.emit(TupleGetItem(param_var, i), name)
                     g = builder.emit(TupleGetItem(grad_var, i), name + "_grad")
                     v = builder.emit(TupleGetItem(state_var, i + 1), name + "_v")
@@ -526,7 +501,7 @@ class MomentumSGD(Optimizer):
 class Adam(Optimizer):
     """Implements Adam optimization algorithm.
 
-    The returned function is equivalent to the following numpy code:
+    The returned function of `get_function()` is equivalent to the following numpy code:
 
     .. code-block:: python
         def Adam(param_tuple, grad_tuple, state_tuple):
@@ -558,13 +533,6 @@ class Adam(Optimizer):
 
     Parameters
     ----------
-    params : Union[Var, List[Var]]
-        The parameter or the list of parameters to optimize.
-
-        Parameters should all be Vars of floating point Tensors, including float32, float64,
-        float16, etc. Currently, all parameters should have the same dtype, and that dtype
-        will be used as the dtype of the optimizer states.
-
     lr : float
         learning rate
 
@@ -581,22 +549,22 @@ class Adam(Optimizer):
 
     def __init__(
         self,
-        param_list: Union[Var, List[Var]],
         lr: float,
         betas: Tuple[float, float] = (0.9, 0.999),
         eps: float = 1e-08,
         weight_decay: float = 0,
     ) -> None:
-        super().__init__("Adam", param_list)
+        super().__init__("Adam")
         self.lr = float(lr)
         self.beta1 = float(betas[0])
         self.beta2 = float(betas[1])
         self.eps = float(eps)
         self.weight_decay = float(weight_decay)
 
-    @property
-    def state(self) -> tvm.runtime.container.ADT:
-        """The state of Adam is
+    def init(self, params: Union[Var, List[Var]]) -> "Adam":
+        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+
+        The state of Adam is
 
         .. code-block:: python
             (num_steps, beta_0_prod, # beta0 ** num_steps
@@ -604,40 +572,56 @@ class Adam(Optimizer):
             first_momentum_of_param_0, ..., first_momentum_of_param_n-1,
             second_momentum_of_param_0, ..., second_momentum_of_param_n-1)
 
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
+
         Returns
         -------
-        res : ADT
-            The state of Adam.
+        self : Adam
+            The Adam optimizer itself. You can do more operations on the return value.
         """
-        if self._state is None:
-            self._state = tuple_object(
-                (
-                    # num_steps, beta_0_prod, beta_1_prod
-                    tvm.nd.array(np.zeros((), "int64")),
-                    tvm.nd.array(np.ones((), self._dtype)),
-                    tvm.nd.array(np.ones((), self._dtype)),
-                    # first_momentum
-                    *(
-                        tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
-                        for p in self._param_list
-                    ),
-                    # second_momentum
-                    *(
-                        tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
-                        for p in self._param_list
-                    ),
-                )
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        self.state = tuple_object(
+            (
+                # num_steps, beta_0_prod, beta_1_prod
+                tvm.nd.array(np.zeros((), "int64")),
+                tvm.nd.array(np.ones((), self.dtype)),
+                tvm.nd.array(np.ones((), self.dtype)),
+                # first_momentum
+                *(
+                    tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
+                    for p in self.param_list
+                ),
+                # second_momentum
+                *(
+                    tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
+                    for p in self.param_list
+                ),
             )
-        return self._state
-
-    @state.setter
-    def state(self, new_value: tvm.runtime.container.ADT) -> None:
-        self._state = new_value
+        )
+        return self
 
     def get_function(self) -> Function:
-        plist = self._param_list
+        """Use blockbuilder to build an optimizer function that executes updates of the parameters
+        and the optimizer state. `init()` should be called before `get_function()`.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+        """
+        self._check_init()
+        plist = self.param_list
         len_param = len(plist)
-        dtype = self._dtype
+        dtype = self.dtype
 
         # input variables
         param_var = Var("params", TupleStructInfo([p.struct_info for p in plist]))
@@ -683,7 +667,7 @@ class Adam(Optimizer):
 
                 # computation logics
                 for i in range(len_param):
-                    name = self._param_list[i].name_hint
+                    name = self.param_list[i].name_hint
                     p = builder.emit(TupleGetItem(param_var, i), name)
                     g = builder.emit(TupleGetItem(grad_var, i), name + "_grad")
                     m = builder.emit(TupleGetItem(state_var, i + 3), name + "_m")

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -29,6 +29,7 @@ from ..struct_info import TensorStructInfo, TupleStructInfo
 from ..op import add, subtract, multiply, divide, sqrt
 from ..expr import const, Var, Function, TupleGetItem, Tuple as RxTuple
 
+
 # TODO(chaofan, yixin): Migrate key logics to C++
 class Optimizer:
     """Relax training optimizer. This class could generate relax Functions for optimizing specified

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -70,20 +70,29 @@ class Optimizer:
     For detailed examples, please see the tutorial.
 
     .. code-block:: python
-        # Initialize the optimizer.
+        # Initialize the optimizer
         # x is the relax Var we want to optimize
         opt = relax.optimizer.SGD(0.1)
+
         # Initialize parameter list, dtype and optimizer state
         opt.init(x)
 
-        #TODO
+        # Get the optimizer function
+        # mod is an IRModule constructed earlier
+        mod["SGD"] = opt.get_function()
+
+        # legalize and build mod
+        lowered_mod = LegalizeOps()(mod)
+        ex = relax.vm.build(lowered_mod, target="llvm")
+        vm = relax.VirtualMachine(ex, tvm.cpu())
+
         # Optimization process
         # param_tuple is a runtime tuple of parameters
         # param_gradient is a runtime tuple of the gradient of parameters in param_tuple,
         # respectively
-        # param_gradient can be gained by the automatic gradient pass. Please see
+        # param_gradient can be gained by the automatic differentiation pass. Please see
         # `relax.transform.Gradient`
-        param_tuple = opt(param_tuple, param_gradient)
+        param_tuple, opt.state = vm["SGD"](param_tuple, param_gradient, opt.state)
     """
 
     dtype: str

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -565,10 +565,13 @@ class Adam(Optimizer):
         The state of Adam is
 
         .. code-block:: python
-            (num_steps, beta_0_prod, # beta0 ** num_steps
-            beta_1_prod, # beta1 ** num_steps
-            first_momentum_of_param_0, ..., first_momentum_of_param_n-1,
-            second_momentum_of_param_0, ..., second_momentum_of_param_n-1)
+            (
+                num_steps,
+                beta_0_prod, # beta0 ** num_steps
+                beta_1_prod, # beta1 ** num_steps
+                first_momentum_of_param_0, ..., first_momentum_of_param_n-1,
+                second_momentum_of_param_0, ..., second_momentum_of_param_n-1
+            )
 
         Parameters
         ----------

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -98,7 +98,8 @@ class Optimizer:
         self.dtype = None
 
     def init(self, params: Union[Var, List[Var]]) -> "Optimizer":
-        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
 
         Parameters
         ----------
@@ -162,8 +163,8 @@ class Optimizer:
             raise RuntimeError("Please call init() for the optimizer before calling get_function()")
 
     def get_function(self) -> Function:
-        """Use blockbuilder to build an optimizer function that executes updates of the parameters
-        and the optimizer state.
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state.
 
         The optimizer function will take in a tuple of parameters, a tuple of gradients of
         parameters, and a tuple of optimizer states. It will return a tuple of updated parameters,
@@ -255,7 +256,8 @@ class SGD(Optimizer):
         self.weight_decay = float(weight_decay)
 
     def init(self, params: Union[Var, List[Var]]) -> "SGD":
-        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
 
         The state of SGD is `(num_steps,)`.
 
@@ -285,8 +287,8 @@ class SGD(Optimizer):
         return self
 
     def get_function(self) -> Function:
-        """Use blockbuilder to build an optimizer function that executes updates of the parameters
-        and the optimizer state. `init()` should be called before `get_function()`.
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state. `init()` should be called before `get_function()`.
 
         Returns
         -------
@@ -397,7 +399,8 @@ class MomentumSGD(Optimizer):
         self.nesterov = nesterov
 
     def init(self, params: Union[Var, List[Var]]) -> "MomentumSGD":
-        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
 
         The state of MomentumSGD is
         `(num_steps, velocity_of_param_0, ..., velocity_of_param_n-1)`.
@@ -433,8 +436,8 @@ class MomentumSGD(Optimizer):
         return self
 
     def get_function(self) -> Function:
-        """Use blockbuilder to build an optimizer function that executes updates of the parameters
-        and the optimizer state. `init()` should be called before `get_function()`.
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state. `init()` should be called before `get_function()`.
 
         Returns
         -------
@@ -561,7 +564,8 @@ class Adam(Optimizer):
         self.weight_decay = float(weight_decay)
 
     def init(self, params: Union[Var, List[Var]]) -> "Adam":
-        """Set the parameters, determine the dtype, and build the initial state for the optimizer.
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
 
         The state of Adam is
 
@@ -612,8 +616,8 @@ class Adam(Optimizer):
         return self
 
     def get_function(self) -> Function:
-        """Use blockbuilder to build an optimizer function that executes updates of the parameters
-        and the optimizer state. `init()` should be called before `get_function()`.
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state. `init()` should be called before `get_function()`.
 
         Returns
         -------

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -77,6 +77,9 @@ class Optimizer:
         # Initialize parameter list, dtype and optimizer state
         opt.init(x)
 
+        # The above two lines is equivalent to one line:
+        opt = relax.optimizer.SGD(0.1).init(x)
+
         # Get the optimizer function
         # mod is an IRModule constructed earlier
         mod["SGD"] = opt.get_function()

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -49,7 +49,7 @@ class Optimizer:
     name : str
         The name of the optimizer.
 
-    param_list : Optional[List[Var]]
+    param_list : List[Var]
         The list of variables to optimize. Will be set in `init()`.
 
     state : tvm.runtime.container.ADT
@@ -70,11 +70,11 @@ class Optimizer:
     For detailed examples, please see the tutorial.
 
     .. code-block:: python
-        # Initialize the optimizer
-        # x is the relax Var we want to optimize
+        # Construct the optimizer
         opt = relax.optimizer.SGD(0.1)
 
-        # Initialize parameter list, dtype and optimizer state
+        # Initialize the parameter list, the dtype and the optimizer state
+        # x is the relax Var we want to optimize
         opt.init(x)
 
         # The above two lines is equivalent to one line:
@@ -84,14 +84,14 @@ class Optimizer:
         # mod is an IRModule constructed earlier
         mod["SGD"] = opt.get_function()
 
-        # legalize and build mod
+        # Legalize and build mod
         lowered_mod = LegalizeOps()(mod)
         ex = relax.vm.build(lowered_mod, target="llvm")
         vm = relax.VirtualMachine(ex, tvm.cpu())
 
         # Optimization process
         # param_tuple is a runtime tuple of parameters
-        # param_gradient is a runtime tuple of the gradient of parameters in param_tuple,
+        # param_gradient is a runtime tuple of the gradient of the parameters in param_tuple,
         # respectively
         # param_gradient can be gained by the automatic differentiation pass. Please see
         # `relax.transform.Gradient`

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -111,7 +111,7 @@ class Optimizer:
         Returns
         -------
         self : Optimizer
-            The optimizer itself. You can do more operations on the return value.
+            The optimizer itself.
         """
         if not isinstance(params, list):
             params = [params]
@@ -270,7 +270,7 @@ class SGD(Optimizer):
         Returns
         -------
         self : SGD
-            The SGD optimizer itself. You can do more operations on the return value.
+            The SGD optimizer itself.
         """
         if not isinstance(params, list):
             params = [params]
@@ -413,7 +413,7 @@ class MomentumSGD(Optimizer):
         Returns
         -------
         self : MomentumSGD
-            The MomentumSGD optimizer itself. You can do more operations on the return value.
+            The MomentumSGD optimizer itself.
         """
         if not isinstance(params, list):
             params = [params]
@@ -582,7 +582,7 @@ class Adam(Optimizer):
         Returns
         -------
         self : Adam
-            The Adam optimizer itself. You can do more operations on the return value.
+            The Adam optimizer itself.
         """
         if not isinstance(params, list):
             params = [params]

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -25,7 +25,7 @@ import numpy as np  # type: ignore
 import tvm.ir
 from tvm.runtime import NDArray
 from . import _ffi_api
-from ..expr import Var, GlobalVar
+from ..expr import Var
 
 
 @tvm._ffi.register_object("relax.FunctionPass")

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -429,25 +429,24 @@ def ConvertLayout(desired_layouts: Dict[str, List[str]]) -> tvm.ir.transform.Pas
 
 
 def Gradient(
-    global_var: GlobalVar, require_grads: Optional[Union[Var, List[Var]]] = None
+    func_name: str, require_grads: Optional[Union[Var, List[Var]]] = None
 ) -> tvm.ir.transform.Pass:
     """Reverse-mode automatic differentiation.
 
     Now only supports differentiating one function in the IRModule with one dataflow block
     with respect to the only return value of the function, which needs to be scalar.
 
-    For a given function specified by the input global var, it generates a new function with the
-    name `[name of original function] + "_adjoint"`. The new function computes the adjoints of the
-    specified arguments of the original function with respect to the only one return value of the
-    original function.
+    For a given function specified by the input name, it generates a new function with the name
+    `func_name + "_adjoint"`. The new function computes the adjoints of the specified arguments
+    of the original function with respect to the only one return value of the original function.
 
     For examples, see the MLP examples in tests/python/relax/test_transform_gradient.py and
     tests/python/relax/test_transform_gradient_numeric.py.
 
     Parameters
     ----------
-    global_var : relax.GlobalVar
-        The GlobalVar of the specific function.
+    func_name : str
+        The name of the specific function.
 
     require_grads : Optional[Union[relax.Var, List[relax.Var]]]
         The relax variables whose adjoints is needed. Must be parameters of the given function and
@@ -462,7 +461,7 @@ def Gradient(
     if require_grads is not None and not isinstance(require_grads, list):
         require_grads = [require_grads]
 
-    return _ffi_api.Gradient(global_var, require_grads)  # type: ignore
+    return _ffi_api.Gradient(func_name, require_grads)  # type: ignore
 
 
 def SplitCallTIRByPattern(patterns, fcodegen) -> tvm.ir.transform.Pass:

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -412,7 +412,8 @@ class GradientMutator : private ExprMutator {
  * \param require_grads The relax variables whose adjoints are needed.
  * \return The module after transformation.
  */
-IRModule Gradient(const IRModule& mod, const String& func_name, Optional<Array<Var>> require_grads) {
+IRModule Gradient(const IRModule& mod, const String& func_name,
+                  Optional<Array<Var>> require_grads) {
   auto* func = mod->Lookup(func_name).as<FunctionNode>();
   CHECK(func) << func_name << "is not a Relax Function";
 

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -298,9 +298,9 @@ class BackwardBindingGenerator : private ExprVisitor {
 
 class GradientMutator : private ExprMutator {
  public:
-  static IRModule Transform(IRModule mod, GlobalVar gvar, Array<Var> require_grads) {
-    Function old_func = Downcast<Function>(mod->Lookup(gvar));
-    CheckRequireGrads(require_grads, old_func->params, gvar->name_hint);
+  static IRModule Transform(IRModule mod, String func_name, Array<Var> require_grads) {
+    Function old_func = Downcast<Function>(mod->Lookup(func_name));
+    CheckRequireGrads(require_grads, old_func->params, func_name);
 
     Function new_func = CopyWithNewParams(old_func);
     // map the parameter list into new params
@@ -314,7 +314,7 @@ class GradientMutator : private ExprMutator {
     Function new_func_transformed = Downcast<Function>(mutator.VisitExpr(new_func));
 
     IRModule new_module = GetRef<IRModule>(mod.CopyOnWrite());
-    new_module->Add(GlobalVar(gvar->name_hint + "_adjoint"), new_func_transformed);
+    new_module->Add(GlobalVar(func_name + "_adjoint"), new_func_transformed);
     return new_module;
   }
 
@@ -408,27 +408,27 @@ class GradientMutator : private ExprMutator {
 /*!
  * \brief This is the internal function of tvm::relax::transform::Gradient.
  * \param mod The module
- * \param gvar The GlobalVar of the specified function
+ * \param func_name The name of the specified function
  * \param require_grads The relax variables whose adjoints are needed.
  * \return The module after transformation.
  */
-IRModule Gradient(const IRModule& mod, const GlobalVar& gvar, Optional<Array<Var>> require_grads) {
-  auto* func = mod->Lookup(gvar).as<FunctionNode>();
-  CHECK(func) << "Relax function " << gvar->name_hint << " is not found";
+IRModule Gradient(const IRModule& mod, const String& func_name, Optional<Array<Var>> require_grads) {
+  auto* func = mod->Lookup(func_name).as<FunctionNode>();
+  CHECK(func) << func_name << "is not a Relax Function";
 
   if (!require_grads.defined()) {
     // when require_grads is not specified, it would be set to all params of the function
     require_grads = func->params;
   }
 
-  return GradientMutator::Transform(mod, gvar, require_grads.value());
+  return GradientMutator::Transform(mod, func_name, require_grads.value());
 }
 
 namespace transform {
 
-Pass Gradient(GlobalVar global_var, Optional<Array<Var>> require_grads) {
+Pass Gradient(String func_name, Optional<Array<Var>> require_grads) {
   runtime::TypedPackedFunc<IRModule(IRModule, PassContext)> pass_func =
-      [=](IRModule mod, PassContext pc) { return relax::Gradient(mod, global_var, require_grads); };
+      [=](IRModule mod, PassContext pc) { return relax::Gradient(mod, func_name, require_grads); };
   return CreateModulePass(/*pass_function=*/pass_func,
                           /*opt_level=*/0,
                           /*pass_name=*/"Gradient",

--- a/tests/python/relax/test_training_optimizer.py
+++ b/tests/python/relax/test_training_optimizer.py
@@ -32,31 +32,31 @@ def test_optimizer_error():
     x5 = relax.Tuple([x1])
 
     # fine cases
-    SGD(x1, 0.01)
-    SGD([x1], 0.01)
-    assert SGD([x2], 0.01)._dtype == "float64"
+    SGD(0.01).init(x1)
+    SGD(0.01).init([x1])
+    assert SGD(0.01).init([x2]).dtype == "float64"
 
     with pytest.raises(ValueError):
-        SGD([x1, x1], 0.01)
+        SGD(0.01).init([x1, x1])
     with pytest.raises(ValueError):
-        SGD(x5, 0.01)
+        SGD(0.01).init([x1, x2])
     with pytest.raises(ValueError):
-        SGD(x3, 0.01)
+        SGD(0.01).init(x3)
     with pytest.raises(ValueError):
-        SGD(x4, 0.01)
+        SGD(0.01).init(x4)
     with pytest.raises(ValueError):
-        SGD([x1, x2], 0.01)
+        SGD(0.01).init(x5)
     with pytest.raises(
         RuntimeError,
-        match="The vm configs of the optimizer is not set. Please call set_vm_config first",
+        match="Please call init\\(\\) for the optimizer before calling get_function\\(\\)",
     ):
-        SGD(x1, 0.01)(None, None)
+        SGD(0.01).get_function()
 
 
 def test_sgd_simple():
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    sgd = SGD([x, y], 0.01).get_function()
+    sgd = SGD(0.01).init([x, y]).get_function()
 
     @R.function
     def sgd_expected(
@@ -93,7 +93,7 @@ def test_sgd_simple():
 def test_sgd_complex():
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    sgd = SGD([x, y], 0.01, 0.02).get_function()
+    sgd = SGD(0.01, 0.02).init([x, y]).get_function()
 
     @R.function
     def sgd_expected(
@@ -133,7 +133,7 @@ def test_sgd_complex():
 def test_momentum_sgd_simple():
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    msgd = MomentumSGD([x, y], 0.01, 0.9).get_function()
+    msgd = MomentumSGD(0.01, 0.9).init([x, y]).get_function()
 
     @R.function
     def msgd_expected(
@@ -182,7 +182,7 @@ def test_momentum_sgd_complex():
 
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    msgd = MomentumSGD([x, y], lr, mom, damp, wd, nest).get_function()
+    msgd = MomentumSGD(lr, mom, damp, wd, nest).init([x, y]).get_function()
 
     @R.function
     def msgd_expected(
@@ -237,7 +237,7 @@ def test_momentum_sgd_nesterov():
 
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    msgd = MomentumSGD([x, y], lr, mom, damp, wd, nest).get_function()
+    msgd = MomentumSGD(lr, mom, damp, wd, nest).init([x, y]).get_function()
 
     @R.function
     def msgd_expected(
@@ -294,7 +294,7 @@ def test_momentum_sgd_nesterov():
 def test_adam_simple():
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    adam = Adam([x, y], 0.01).get_function()
+    adam = Adam(0.01).init([x, y]).get_function()
 
     @R.function
     def adam_expected(
@@ -391,7 +391,7 @@ def test_adam_simple():
 def test_adam_complex():
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    adam = Adam([x, y], 0.01, (0.8, 0.85), 1e-7, 0.1).get_function()
+    adam = Adam(0.01, (0.8, 0.85), 1e-7, 0.1).init([x, y]).get_function()
 
     @R.function
     def adam_expected(
@@ -492,7 +492,7 @@ def test_adam_complex():
 def test_adam_float64():
     x = relax.Var("x", R.Tensor((3, 3), "float64"))
     y = relax.Var("y", R.Tensor((3,), "float64"))
-    adam = Adam([x, y], 0.01, (0.8, 0.85), 1e-7, 0.1).get_function()
+    adam = Adam(0.01, (0.8, 0.85), 1e-7, 0.1).init([x, y]).get_function()
 
     @R.function
     def adam_expected(

--- a/tests/python/relax/test_training_optimizer_numeric.py
+++ b/tests/python/relax/test_training_optimizer_numeric.py
@@ -79,15 +79,6 @@ def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
     _assert_run_result_same(tvm_func, np_func, [param_arr, grad_arr, state_arr])
 
 
-# TODO
-# test the step function
-# opt.set_vm_config(target, dev)
-# result_params = _tvm_to_numpy(opt(_numpy_to_tvm(param_arr), _numpy_to_tvm(grad_arr)))
-# expected_params, expected_state = np_func(param_arr, grad_arr, state_arr)
-# _assert_allclose_nested(result_params, expected_params)
-# _assert_allclose_nested(_tvm_to_numpy(opt.state), expected_state)
-
-
 lr, weight_decay = tvm.testing.parameters(
     (0.01, 0),
     (0.01, 0.02),

--- a/tests/python/relax/test_training_optimizer_numeric.py
+++ b/tests/python/relax/test_training_optimizer_numeric.py
@@ -68,7 +68,7 @@ def _assert_run_result_same(tvm_func: Callable, np_func: Callable, np_inputs: Li
 def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
-    opt = opt_type([x, y], *args, **kwargs)
+    opt = opt_type(*args, **kwargs).init([x, y])
     mod = IRModule.from_expr(opt.get_function())
     tvm_func = _legalize_and_build(mod, target, dev)["main"]
 
@@ -78,12 +78,14 @@ def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
 
     _assert_run_result_same(tvm_func, np_func, [param_arr, grad_arr, state_arr])
 
-    # test the step function
-    opt.set_vm_config(target, dev)
-    result_params = _tvm_to_numpy(opt(_numpy_to_tvm(param_arr), _numpy_to_tvm(grad_arr)))
-    expected_params, expected_state = np_func(param_arr, grad_arr, state_arr)
-    _assert_allclose_nested(result_params, expected_params)
-    _assert_allclose_nested(_tvm_to_numpy(opt.state), expected_state)
+
+# TODO
+# test the step function
+# opt.set_vm_config(target, dev)
+# result_params = _tvm_to_numpy(opt(_numpy_to_tvm(param_arr), _numpy_to_tvm(grad_arr)))
+# expected_params, expected_state = np_func(param_arr, grad_arr, state_arr)
+# _assert_allclose_nested(result_params, expected_params)
+# _assert_allclose_nested(_tvm_to_numpy(opt.state), expected_state)
 
 
 lr, weight_decay = tvm.testing.parameters(

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -29,7 +29,7 @@ def test_simple():
     @tvm.script.ir_module
     class Before:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")):
+        def main(x: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 gv = R.sum(x)
                 R.output(gv)
@@ -38,23 +38,23 @@ def test_simple():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor(None, dtype="float32", ndim=0):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor(None, "float32", ndim=0):
             with R.dataflow():
-                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor(None, dtype="float32", ndim=0),R.Tuple(R.Tensor(None, dtype="float32", ndim=2)),):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor(None, "float32", ndim=0),R.Tuple(R.Tensor(None, "float32", ndim=2)),):
             with R.dataflow():
-                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                x_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main"], Expected["main"])
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
@@ -75,30 +75,30 @@ def test_assign_binding():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             # block 0
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = x
-                lv2: R.Tensor((3, 3), dtype="float32") = lv1
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), "float32") = x
+                lv2: R.Tensor((3, 3), "float32") = lv1
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = x
-                lv2: R.Tensor((3, 3), dtype="float32") = lv1
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                lv1: R.Tensor((3, 3), "float32") = x
+                lv2: R.Tensor((3, 3), "float32") = lv1
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -118,30 +118,30 @@ def test_multiple_uses():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
-                lv: R.Tensor((3, 3), dtype="float32") = R.add(lv2_adjoint, lv1_adjoint)
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.add(lv, lv1_adjoint)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
+                lv: R.Tensor((3, 3), "float32") = R.add(lv2_adjoint, lv1_adjoint)
+                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv, lv1_adjoint)
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -161,27 +161,27 @@ def test_unused():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
-                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
+                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
-                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
+                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                x_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -206,67 +206,67 @@ def test_default_require_grads():
     class Expected1:
         @R.function
         def main(
-            x: R.Tensor((3, 3), dtype="float32"),
-            y: R.Tensor((3, 3), dtype="float32"),
-            z: R.Tensor((3, 3), dtype="float32"),
-     ) -> R.Tensor((), dtype="float32"):
+            x: R.Tensor((3, 3), "float32"),
+            y: R.Tensor((3, 3), "float32"),
+            z: R.Tensor((3, 3), "float32"),
+     ) -> R.Tensor((), "float32"):
             # block 0
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
-                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
+                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
+                z_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
                 R.output(gv, x_adjoint, y_adjoint, z_adjoint)
             return (gv, (x_adjoint, y_adjoint, z_adjoint))
     # fmt: on
 
-    After1 = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After1 = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After1["main_adjoint"], Expected1["main_adjoint"])
 
     # fmt: off
     @tvm.script.ir_module
     class Expected2:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             # block 0
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
             # block 0
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
     After2 = relax.transform.Gradient(
-        Before.get_global_var("main"), require_grads=Before["main"].params[0]
+        "main", require_grads=Before["main"].params[0]
     )(Before)
     assert_structural_equal(After2["main_adjoint"], Expected2["main_adjoint"])
 
@@ -293,39 +293,39 @@ def test_tuple():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor(None, dtype="float32", ndim=0):
+        def main(x: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tensor(None, "float32", ndim=0):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (y, z)
-                lv2: R.Tensor((3, 3), dtype="float32") = x[0]
-                lv3: R.Tensor((3, 3), dtype="float32") = lv1[0]
-                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv3)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (y, z)
+                lv2: R.Tensor((3, 3), "float32") = x[0]
+                lv3: R.Tensor((3, 3), "float32") = lv1[0]
+                lv4: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (y, z)
-                lv2: R.Tensor((3, 3), dtype="float32") = x[0]
-                lv3: R.Tensor((3, 3), dtype="float32") = lv1[0]
-                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv3)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
-                lv: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv1_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv)
-                lv11: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                x_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_adjoint, lv11)
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[0]
-                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (y, z)
+                lv2: R.Tensor((3, 3), "float32") = x[0]
+                lv3: R.Tensor((3, 3), "float32") = lv1[0]
+                lv4: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
+                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv3_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
+                lv2_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
+                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv1_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv)
+                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                x_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv2_adjoint, lv11)
+                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[0]
+                z_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
                 R.output(gv, x_adjoint, y_adjoint, z_adjoint)
             return (gv, (x_adjoint, y_adjoint, z_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -352,48 +352,48 @@ def test_tuple_assignment():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
-                lv4: R.Tensor((3, 3), dtype="float32") = lv1[0]
-                lv7: R.Tensor((3, 3), dtype="float32") = R.add(lv4, x)
-                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1
-                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
-                lv5: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv7)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
+                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
+                lv4: R.Tensor((3, 3), "float32") = lv1[0]
+                lv7: R.Tensor((3, 3), "float32") = R.add(lv4, x)
+                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1
+                lv3: R.Tensor((3, 3), "float32") = lv2[0]
+                lv5: R.Tensor((3, 3), "float32") = R.add(lv3, lv7)
+                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             # block 0
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
-                lv4: R.Tensor((3, 3), dtype="float32") = lv1[0]
-                lv7: R.Tensor((3, 3), dtype="float32") = R.add(lv4, x)
-                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1
-                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
-                lv5: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv7)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv5_adjoint
-                lv: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv)
-                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv5_adjoint
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = lv7_adjoint
-                lv11: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[0]
-                lv21: R.Tensor((3, 3), dtype="float32") = R.add(lv11, lv4_adjoint)
-                lv31: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[1]
-                lv1_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv21, lv31)
-                lv41: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[0]
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.add(lv7_adjoint, lv41)
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
+                lv4: R.Tensor((3, 3), "float32") = lv1[0]
+                lv7: R.Tensor((3, 3), "float32") = R.add(lv4, x)
+                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1
+                lv3: R.Tensor((3, 3), "float32") = lv2[0]
+                lv5: R.Tensor((3, 3), "float32") = R.add(lv3, lv7)
+                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv5_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv3_adjoint: R.Tensor((3, 3), "float32") = lv5_adjoint
+                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv)
+                lv7_adjoint: R.Tensor((3, 3), "float32") = lv5_adjoint
+                lv4_adjoint: R.Tensor((3, 3), "float32") = lv7_adjoint
+                lv11: R.Tensor((3, 3), "float32") = lv2_adjoint[0]
+                lv21: R.Tensor((3, 3), "float32") = R.add(lv11, lv4_adjoint)
+                lv31: R.Tensor((3, 3), "float32") = lv2_adjoint[1]
+                lv1_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv21, lv31)
+                lv41: R.Tensor((3, 3), "float32") = lv1_adjoint[0]
+                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv7_adjoint, lv41)
+                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
                 R.output(gv, x_adjoint, y_adjoint)
             return (gv, (x_adjoint, y_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -427,54 +427,54 @@ def test_tuple_nested():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((y, z), u)
-                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x[0]
-                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
-                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1[0]
-                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
-                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv5)
-                lv7: R.Tensor((3, 3), dtype="float32") = x[1]
-                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv6, lv7)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv8, axis=None, keepdims=False)
+                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = ((y, z), u)
+                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x[0]
+                lv3: R.Tensor((3, 3), "float32") = lv2[0]
+                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1[0]
+                lv5: R.Tensor((3, 3), "float32") = lv4[1]
+                lv6: R.Tensor((3, 3), "float32") = R.add(lv3, lv5)
+                lv7: R.Tensor((3, 3), "float32") = x[1]
+                lv8: R.Tensor((3, 3), "float32") = R.add(lv6, lv7)
+                gv: R.Tensor((), "float32") = R.sum(lv8, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((y, z), u)
-                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x[0]
-                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
-                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1[0]
-                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
-                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv5)
-                lv7: R.Tensor((3, 3), dtype="float32") = x[1]
-                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv6, lv7)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv8, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
-                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
-                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
-                lv: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv, lv5_adjoint)
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
-                lv11: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv11)
-                lv21: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv1_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = (lv4_adjoint, lv21)
-                x_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = (lv2_adjoint, lv7_adjoint)
-                lv31: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1_adjoint[0]
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv31[0]
-                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv31[1]
-                u_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = ((y, z), u)
+                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x[0]
+                lv3: R.Tensor((3, 3), "float32") = lv2[0]
+                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1[0]
+                lv5: R.Tensor((3, 3), "float32") = lv4[1]
+                lv6: R.Tensor((3, 3), "float32") = R.add(lv3, lv5)
+                lv7: R.Tensor((3, 3), "float32") = x[1]
+                lv8: R.Tensor((3, 3), "float32") = R.add(lv6, lv7)
+                gv: R.Tensor((), "float32") = R.sum(lv8, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv8_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv7_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
+                lv6_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
+                lv5_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
+                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv, lv5_adjoint)
+                lv3_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
+                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv11)
+                lv21: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv1_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = (lv4_adjoint, lv21)
+                x_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = (lv2_adjoint, lv7_adjoint)
+                lv31: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1_adjoint[0]
+                y_adjoint: R.Tensor((3, 3), "float32") = lv31[0]
+                z_adjoint: R.Tensor((3, 3), "float32") = lv31[1]
+                u_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
                 R.output(gv, x_adjoint, y_adjoint, z_adjoint, u_adjoint)
             return (gv, (x_adjoint, y_adjoint, z_adjoint, u_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -504,64 +504,64 @@ def test_tuple_update():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = lv0[0]
-                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, y)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv1, lv3)
-                lv5: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
-                lv6: R.Tensor((3, 3), dtype="float32") = lv5[0]
-                lv7: R.Tensor((3, 3), dtype="float32") = lv0[0]
-                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv4, lv6)
-                lv9: R.Tensor((3, 3), dtype="float32") = R.add(lv8, lv7)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                lv0: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), "float32") = lv0[0]
+                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, y)
+                lv4: R.Tensor((3, 3), "float32") = R.add(lv1, lv3)
+                lv5: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
+                lv6: R.Tensor((3, 3), "float32") = lv5[0]
+                lv7: R.Tensor((3, 3), "float32") = lv0[0]
+                lv8: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
+                lv9: R.Tensor((3, 3), "float32") = R.add(lv8, lv7)
+                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), dtype="float32") = lv0[0]
-                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, y)
-                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv1, lv3)
-                lv5: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
-                lv6: R.Tensor((3, 3), dtype="float32") = lv5[0]
-                lv7: R.Tensor((3, 3), dtype="float32") = lv0[0]
-                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv4, lv6)
-                lv9: R.Tensor((3, 3), dtype="float32") = R.add(lv8, lv7)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv9_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = lv9_adjoint
-                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv9_adjoint
-                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
-                lv: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv5_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv6_adjoint, lv)
-                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
-                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
-                lv11: R.Tensor((3, 3), dtype="float32") = R.add(lv7_adjoint, lv2_adjoint)
-                lv21: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv0_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv11, lv21)
-                lv31: R.Tensor((3, 3), dtype="float32") = lv5_adjoint[0]
-                lv41: R.Tensor((3, 3), dtype="float32") = R.add(lv31, lv1_adjoint)
-                lv51: R.Tensor((3, 3), dtype="float32") = lv0_adjoint[0]
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.add(lv41, lv51)
-                lv61: R.Tensor((3, 3), dtype="float32") = lv5_adjoint[1]
-                lv71: R.Tensor((3, 3), dtype="float32") = R.add(lv61, lv3_adjoint)
-                lv81: R.Tensor((3, 3), dtype="float32") = R.add(lv71, lv1_adjoint)
-                lv91: R.Tensor((3, 3), dtype="float32") = lv0_adjoint[1]
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.add(lv81, lv91)
+                lv0: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), "float32") = lv0[0]
+                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, y)
+                lv4: R.Tensor((3, 3), "float32") = R.add(lv1, lv3)
+                lv5: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
+                lv6: R.Tensor((3, 3), "float32") = lv5[0]
+                lv7: R.Tensor((3, 3), "float32") = lv0[0]
+                lv8: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
+                lv9: R.Tensor((3, 3), "float32") = R.add(lv8, lv7)
+                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv9_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv8_adjoint: R.Tensor((3, 3), "float32") = lv9_adjoint
+                lv7_adjoint: R.Tensor((3, 3), "float32") = lv9_adjoint
+                lv6_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
+                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv5_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv6_adjoint, lv)
+                lv4_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
+                lv3_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
+                lv2_adjoint: R.Tensor((3, 3), "float32") = lv3_adjoint
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
+                lv11: R.Tensor((3, 3), "float32") = R.add(lv7_adjoint, lv2_adjoint)
+                lv21: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv0_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv11, lv21)
+                lv31: R.Tensor((3, 3), "float32") = lv5_adjoint[0]
+                lv41: R.Tensor((3, 3), "float32") = R.add(lv31, lv1_adjoint)
+                lv51: R.Tensor((3, 3), "float32") = lv0_adjoint[0]
+                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv41, lv51)
+                lv61: R.Tensor((3, 3), "float32") = lv5_adjoint[1]
+                lv71: R.Tensor((3, 3), "float32") = R.add(lv61, lv3_adjoint)
+                lv81: R.Tensor((3, 3), "float32") = R.add(lv71, lv1_adjoint)
+                lv91: R.Tensor((3, 3), "float32") = lv0_adjoint[1]
+                y_adjoint: R.Tensor((3, 3), "float32") = R.add(lv81, lv91)
                 R.output(gv, x_adjoint, y_adjoint)
             return (gv, (x_adjoint, y_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -583,29 +583,29 @@ def test_tuple_op_simple():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((6,), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((6,), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(x, indices_or_sections=2, axis=0)
-                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(x, indices_or_sections=2, axis=0)
+                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((6,), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((6,), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((6,), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((6,), "float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(x, indices_or_sections=2, axis=0)
-                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv2_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv1_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                x_adjoint: R.Tensor((6,), dtype="float32") = R.concat(lv1_adjoint, axis=0)
+                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(x, indices_or_sections=2, axis=0)
+                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
+                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv2_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
+                lv1_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((6,), "float32") = R.concat(lv1_adjoint, axis=0)
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -632,49 +632,49 @@ def test_tuple_op_construct():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3,), dtype="float32"), y: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32"))) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3,), "float32"), y: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32"))) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = (x, x)
-                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
-                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), dtype="float32") = R.concat(y, axis=0)
-                lv5: R.Tensor((6,), dtype="float32") = R.add(lv2, lv3)
-                lv6: R.Tensor((6,), dtype="float32") = R.add(lv5, lv4)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = (x, x)
+                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
+                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), "float32") = R.concat(y, axis=0)
+                lv5: R.Tensor((6,), "float32") = R.add(lv2, lv3)
+                lv6: R.Tensor((6,), "float32") = R.add(lv5, lv4)
+                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3,), dtype="float32"), y: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32"))) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")))):
+        def main_adjoint(x: R.Tensor((3,), "float32"), y: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32"))) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3,), "float32"), R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = (x, x)
-                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
-                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), dtype="float32") = R.concat(y, axis=0)
-                lv5: R.Tensor((6,), dtype="float32") = R.add(lv2, lv3)
-                lv6: R.Tensor((6,), dtype="float32") = R.add(lv5, lv4)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv6_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv5_adjoint: R.Tensor((6,), dtype="float32") = lv6_adjoint
-                lv4_adjoint: R.Tensor((6,), dtype="float32") = lv6_adjoint
-                lv3_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
-                lv2_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
-                lv1_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                lv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
-                lv11: R.Tensor((3,), dtype="float32") = lv[0]
-                lv21: R.Tensor((3,), dtype="float32") = lv[1]
-                lv31: R.Tensor((3,), dtype="float32") = R.add(lv11, lv21)
-                lv41: R.Tensor((3,), dtype="float32") = lv1_adjoint[0]
-                lv51: R.Tensor((3,), dtype="float32") = R.add(lv31, lv41)
-                lv61: R.Tensor((3,), dtype="float32") = lv1_adjoint[1]
-                x_adjoint: R.Tensor((3,), dtype="float32") = R.add(lv51, lv61)
-                y_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv4_adjoint, indices_or_sections=[3], axis=0)
+                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = (x, x)
+                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
+                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), "float32") = R.concat(y, axis=0)
+                lv5: R.Tensor((6,), "float32") = R.add(lv2, lv3)
+                lv6: R.Tensor((6,), "float32") = R.add(lv5, lv4)
+                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv6_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
+                lv5_adjoint: R.Tensor((6,), "float32") = lv6_adjoint
+                lv4_adjoint: R.Tensor((6,), "float32") = lv6_adjoint
+                lv3_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
+                lv2_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
+                lv1_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                lv: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
+                lv11: R.Tensor((3,), "float32") = lv[0]
+                lv21: R.Tensor((3,), "float32") = lv[1]
+                lv31: R.Tensor((3,), "float32") = R.add(lv11, lv21)
+                lv41: R.Tensor((3,), "float32") = lv1_adjoint[0]
+                lv51: R.Tensor((3,), "float32") = R.add(lv31, lv41)
+                lv61: R.Tensor((3,), "float32") = lv1_adjoint[1]
+                x_adjoint: R.Tensor((3,), "float32") = R.add(lv51, lv61)
+                y_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv4_adjoint, indices_or_sections=[3], axis=0)
                 R.output(gv, x_adjoint, y_adjoint)
             return (gv, (x_adjoint, y_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -703,52 +703,52 @@ def test_tuple_op_const():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3,), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3,), "float32")) -> R.Tensor((), "float32"):
             # block 0
             with R.dataflow():
-                lv1: R.Tensor((6,), dtype="float32") = R.concat((c1, c2), axis=0)
-                lv2: R.Tensor((6,), dtype="float32") = R.concat((c3, x), axis=0)
-                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), dtype="float32") = R.add(lv1, lv2)
-                lv5: R.Tensor((6,), dtype="float32") = R.add(lv4, lv3)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
+                lv1: R.Tensor((6,), "float32") = R.concat((c1, c2), axis=0)
+                lv2: R.Tensor((6,), "float32") = R.concat((c3, x), axis=0)
+                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), "float32") = R.add(lv1, lv2)
+                lv5: R.Tensor((6,), "float32") = R.add(lv4, lv3)
+                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3,), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3,), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3,), "float32"))):
             # block 0
             with R.dataflow():
-                lv1: R.Tensor((6,), dtype="float32") = R.concat((c1, c2), axis=0)
-                lv2: R.Tensor((6,), dtype="float32") = R.concat((c3, x), axis=0)
-                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), dtype="float32") = R.add(lv1, lv2)
-                lv5: R.Tensor((6,), dtype="float32") = R.add(lv4, lv3)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv5_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv4_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
-                lv3_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
-                lv2_adjoint: R.Tensor((6,), dtype="float32") = lv4_adjoint
-                lv1_adjoint: R.Tensor((6,), dtype="float32") = lv4_adjoint
-                lv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
-                lv11: R.Tensor((3,), dtype="float32") = lv[0]
-                lv21: R.Tensor((3,), dtype="float32") = lv[1]
-                lv31: R.Tensor((3,), dtype="float32") = R.add(lv11, lv21)
-                lv41: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                lv51: R.Tensor((3,), dtype="float32") = lv41[1]
-                x_adjoint: R.Tensor((3,), dtype="float32") = R.add(lv31, lv51)
+                lv1: R.Tensor((6,), "float32") = R.concat((c1, c2), axis=0)
+                lv2: R.Tensor((6,), "float32") = R.concat((c3, x), axis=0)
+                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), "float32") = R.add(lv1, lv2)
+                lv5: R.Tensor((6,), "float32") = R.add(lv4, lv3)
+                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv5_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
+                lv4_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
+                lv3_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
+                lv2_adjoint: R.Tensor((6,), "float32") = lv4_adjoint
+                lv1_adjoint: R.Tensor((6,), "float32") = lv4_adjoint
+                lv: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
+                lv11: R.Tensor((3,), "float32") = lv[0]
+                lv21: R.Tensor((3,), "float32") = lv[1]
+                lv31: R.Tensor((3,), "float32") = R.add(lv11, lv21)
+                lv41: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                lv51: R.Tensor((3,), "float32") = lv41[1]
+                x_adjoint: R.Tensor((3,), "float32") = R.add(lv31, lv51)
                 R.output(gv, x_adjoint)
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
 def test_const():
     """const could be used in variable assignment, call argument, and as a part of tuple"""
-    cst = relax.const(np.ones((3, 3)), dtype="float32")
+    cst = relax.const(np.ones((3, 3)), "float32")
 
     # fmt: off
     @tvm.script.ir_module
@@ -772,45 +772,45 @@ def test_const():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, cst)
-                lv2: R.Tensor((3, 3), dtype="float32") = cst
-                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (cst, (cst, lv1))
-                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3[1]
-                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
-                lv6: R.Tensor((3, 3), dtype="float32") = R.subtract(lv5, lv2)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, cst)
+                lv2: R.Tensor((3, 3), "float32") = cst
+                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (cst, (cst, lv1))
+                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3[1]
+                lv5: R.Tensor((3, 3), "float32") = lv4[1]
+                lv6: R.Tensor((3, 3), "float32") = R.subtract(lv5, lv2)
+                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
                 R.output(gv)
             return gv
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, cst)
-                lv2: R.Tensor((3, 3), dtype="float32") = cst
-                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (cst, (cst, lv1))
-                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3[1]
-                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
-                lv6: R.Tensor((3, 3), dtype="float32") = R.subtract(lv5, lv2)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
-                lv: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv, lv5_adjoint)
-                lv11: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
-                lv3_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (lv11, lv4_adjoint)
-                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.negative(lv6_adjoint)
-                lv21: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3_adjoint[1]
-                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv21[1]
-                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
-                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros((3, 3), dtype="float32")
+                lv1: R.Tensor((3, 3), "float32") = R.add(x, cst)
+                lv2: R.Tensor((3, 3), "float32") = cst
+                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (cst, (cst, lv1))
+                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3[1]
+                lv5: R.Tensor((3, 3), "float32") = lv4[1]
+                lv6: R.Tensor((3, 3), "float32") = R.subtract(lv5, lv2)
+                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv6_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
+                lv5_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
+                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv, lv5_adjoint)
+                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
+                lv3_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (lv11, lv4_adjoint)
+                lv2_adjoint: R.Tensor((3, 3), "float32") = R.negative(lv6_adjoint)
+                lv21: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3_adjoint[1]
+                lv1_adjoint: R.Tensor((3, 3), "float32") = lv21[1]
+                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
+                y_adjoint: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
                 R.output(gv, x_adjoint, y_adjoint)
             return (gv, (x_adjoint, y_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 
@@ -832,7 +832,7 @@ def test_params_copy():
                 R.output(gv)
             return gv
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
     assert len(Before["main"].params) == len(After["main"].params)
     assert len(Before["main"].params) == len(After["main_adjoint"].params)
     for i in range(len(After["main"].params)):
@@ -858,7 +858,7 @@ def test_function_copy():
                 R.output(gv)
             return gv
 
-    After = relax.transform.Gradient(Before.get_global_var("main"))(Before)
+    After = relax.transform.Gradient("main")(Before)
 
     # After should have the same "main" function as Before
     assert_structural_equal(Before["main"], After["main"])
@@ -881,7 +881,7 @@ def test_report_error():
             return gv
 
     with pytest.raises(TVMError):
-        relax.transform.Gradient(TargetNotScalar.get_global_var("main"))(TargetNotScalar)
+        relax.transform.Gradient("main")(TargetNotScalar)
 
     @tvm.script.ir_module
     class NoDataflow:
@@ -891,7 +891,7 @@ def test_report_error():
             return gv
 
     with pytest.raises(TVMError):
-        relax.transform.Gradient(NoDataflow.get_global_var("main"))(NoDataflow)
+        relax.transform.Gradient("main")(NoDataflow)
 
     @tvm.script.ir_module
     class MultiBlocks:
@@ -906,7 +906,7 @@ def test_report_error():
             return gv1
 
     with pytest.raises(TVMError):
-        relax.transform.Gradient(MultiBlocks.get_global_var("main"))(MultiBlocks)
+        relax.transform.Gradient("main")(MultiBlocks)
 
     @tvm.script.ir_module
     class NormalModule:
@@ -917,13 +917,30 @@ def test_report_error():
                 R.output(gv)
             return gv
 
-    main_gv = NormalModule.get_global_var("main")
+        @T.prim_func
+        def sum(
+            rxplaceholder: T.Buffer[(T.int64(3), T.int64(3)), "float32"],
+            rxplaceholder_red: T.Buffer[(), "float32"],
+        ):
+            T.func_attr({"tir.noalias": True})
+            for k0, k1 in T.grid(T.int64(3), T.int64(3)):
+                with T.block("rxplaceholder_red"):
+                    v_k0, v_k1 = T.axis.remap("RR", [k0, k1])
+                    T.reads(rxplaceholder[v_k0, v_k1])
+                    T.writes(rxplaceholder_red[()])
+                    with T.init():
+                        rxplaceholder_red[()] = T.float32(0)
+                    rxplaceholder_red[()] = (rxplaceholder_red[()] + rxplaceholder[v_k0, v_k1])
+
     # no such function
+    with pytest.raises(ValueError):
+        relax.transform.Gradient("main1")(NormalModule)
+    # wrong function type
     with pytest.raises(TVMError):
-        relax.transform.Gradient(MultiBlocks.get_global_var("main"))(NormalModule)
+        relax.transform.Gradient("sum")(NormalModule)
     # no such var
     with pytest.raises(TVMError):
-        relax.transform.Gradient(main_gv, require_grads=MultiBlocks["main"].params[0])(NormalModule)
+        relax.transform.Gradient("main", require_grads=MultiBlocks["main"].params[0])(NormalModule)
 
     @tvm.script.ir_module
     class IntDtype:
@@ -936,7 +953,7 @@ def test_report_error():
             return gv
 
     with pytest.raises(TVMError):
-        relax.transform.Gradient(IntDtype.get_global_var("main"))(IntDtype)
+        relax.transform.Gradient("main")(IntDtype)
 
     @tvm.script.ir_module
     class IntDtypeTuple:
@@ -951,7 +968,7 @@ def test_report_error():
             return gv
 
     with pytest.raises(TVMError):
-        relax.transform.Gradient(IntDtypeTuple.get_global_var("main"))(IntDtypeTuple)
+        relax.transform.Gradient("main")(IntDtypeTuple)
 
 
 def test_mlp_script():
@@ -960,15 +977,14 @@ def test_mlp_script():
 
     For n-layer perceptron, see test_transform_gradient_numeric.py.
     """
-
     # fmt: off
     @tvm.script.ir_module
     class Before:
         @R.function
         def main(
-            x: R.Tensor((3, 10), "float32"),
             w0: R.Tensor((10, 5), "float32"),
             b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((3, 10), "float32"),
             label: R.Tensor((3, 5), "float32"),
         ):
             with R.dataflow():
@@ -982,43 +998,42 @@ def test_mlp_script():
     @tvm.script.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), label: R.Tensor((3, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
+        def main(w0: R.Tensor((10, 5), "float32"), b0: R.Tensor((5,), "float32"), x: R.Tensor((3, 10), "float32"), label: R.Tensor((3, 5), "float32")) -> R.Tensor((), "float32"):
+            # block 0
             with R.dataflow():
-                lv0: R.Tensor((3, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
-                out: R.Tensor((3, 5), dtype="float32") = R.add(lv0, b0)
-                logits: R.Tensor((3, 5), dtype="float32") = R.nn.log_softmax(out, axis=-1)
-                loss: R.Tensor((), dtype="float32") = R.nn.cross_entropy_with_logits(logits, label)
+                lv0: R.Tensor((3, 5), "float32") = R.matmul(x, w0, out_dtype="")
+                out: R.Tensor((3, 5), "float32") = R.add(lv0, b0)
+                logits: R.Tensor((3, 5), "float32") = R.nn.log_softmax(out, axis=-1)
+                loss: R.Tensor((), "float32") = R.nn.cross_entropy_with_logits(logits, label)
                 R.output(loss)
             return loss
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), label: R.Tensor((3, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((10, 5), dtype="float32"), R.Tensor((5,), dtype="float32"))):
+        def main_adjoint(w0: R.Tensor((10, 5), "float32"), b0: R.Tensor((5,), "float32"), x: R.Tensor((3, 10), "float32"), label: R.Tensor((3, 5), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((10, 5), "float32"), R.Tensor((5,), "float32"))):
             # block 0
             with R.dataflow():
-                lv0: R.Tensor((3, 5), dtype="float32") = R.matmul(x, w0, out_dtype="")
-                out: R.Tensor((3, 5), dtype="float32") = R.add(lv0, b0)
-                logits: R.Tensor((3, 5), dtype="float32") = R.nn.log_softmax(out, axis=-1)
-                loss: R.Tensor((), dtype="float32") = R.nn.cross_entropy_with_logits(logits, label)
-                loss_adjoint: R.Tensor((), dtype="float32") = R.ones((), dtype="float32")
-                lv: R.Tensor((), dtype="float32") = R.divide(loss_adjoint, R.const(3, "float32"))
-                lv1: R.Tensor((3, 5), dtype="float32") = R.multiply(lv, label)
-                logits_adjoint: R.Tensor((3, 5), dtype="float32") = R.negative(lv1)
-                lv2: R.Tensor((3, 1), dtype="float32") = R.sum(logits_adjoint, axis=[-1], keepdims=True)
-                lv3: R.Tensor((3, 5), dtype="float32") = R.exp(logits)
-                lv4: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv3)
-                out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv4)
-                lv0_adjoint: R.Tensor((3, 5), dtype="float32") = out_adjoint
-                lv5: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                lv6: R.Tensor((10, 5), dtype="float32") = R.matmul(lv5, lv0_adjoint, out_dtype="")
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv6, (10, 5))
-                b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(out_adjoint, (5,))
+                lv0: R.Tensor((3, 5), "float32") = R.matmul(x, w0, out_dtype="")
+                out: R.Tensor((3, 5), "float32") = R.add(lv0, b0)
+                logits: R.Tensor((3, 5), "float32") = R.nn.log_softmax(out, axis=-1)
+                loss: R.Tensor((), "float32") = R.nn.cross_entropy_with_logits(logits, label)
+                loss_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
+                lv: R.Tensor((), "float32") = R.divide(loss_adjoint, R.const(3, "float32"))
+                lv1: R.Tensor((3, 5), "float32") = R.multiply(lv, label)
+                logits_adjoint: R.Tensor((3, 5), "float32") = R.negative(lv1)
+                lv2: R.Tensor((3, 1), "float32") = R.sum(logits_adjoint, axis=[-1], keepdims=True)
+                lv3: R.Tensor((3, 5), "float32") = R.exp(logits)
+                lv4: R.Tensor((3, 5), "float32") = R.multiply(lv2, lv3)
+                out_adjoint: R.Tensor((3, 5), "float32") = R.subtract(logits_adjoint, lv4)
+                lv0_adjoint: R.Tensor((3, 5), "float32") = out_adjoint
+                lv5: R.Tensor((10, 3), "float32") = R.permute_dims(x, axes=[1, 0])
+                lv6: R.Tensor((10, 5), "float32") = R.matmul(lv5, lv0_adjoint, out_dtype="")
+                w0_adjoint: R.Tensor((10, 5), "float32") = R.collapse_sum_to(lv6, (10, 5))
+                b0_adjoint: R.Tensor((5,), "float32") = R.collapse_sum_to(out_adjoint, (5,))
                 R.output(loss, w0_adjoint, b0_adjoint)
             return (loss, (w0_adjoint, b0_adjoint))
     # fmt: on
 
-    After = relax.transform.Gradient(
-        Before.get_global_var("main"), require_grads=Before["main"].params[1:3]
-    )(Before)
+    After = relax.transform.Gradient("main", require_grads=Before["main"].params[:2])(Before)
     assert_structural_equal(After["main_adjoint"], Expected["main_adjoint"])
 
 

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -265,9 +265,7 @@ def test_default_require_grads():
             return (gv, (x_adjoint,))
     # fmt: on
 
-    After2 = relax.transform.Gradient(
-        "main", require_grads=Before["main"].params[0]
-    )(Before)
+    After2 = relax.transform.Gradient("main", require_grads=Before["main"].params[0])(Before)
     assert_structural_equal(After2["main_adjoint"], Expected2["main_adjoint"])
 
 
@@ -930,7 +928,7 @@ def test_report_error():
                     T.writes(rxplaceholder_red[()])
                     with T.init():
                         rxplaceholder_red[()] = T.float32(0)
-                    rxplaceholder_red[()] = (rxplaceholder_red[()] + rxplaceholder[v_k0, v_k1])
+                    rxplaceholder_red[()] = rxplaceholder_red[()] + rxplaceholder[v_k0, v_k1]
 
     # no such function
     with pytest.raises(ValueError):


### PR DESCRIPTION
Update optimizer APIs.
- Remove `@property state` and `@state.setter`
- Add `init()` interface
- Remove `Optimizer.__call__()`
- Remove underscores before attributes, and unnecessary attributes

Current interfaces:
```
class Optimizer:
    dtype: str
    name: str
    param_list: List[Var]
    state: tvm.runtime.container.ADT

    def __init__(self, name: str) -> None:
        self.name = name
        self.param_list = None
        self.state = None
        self.dtype = None

    def init(self, params: Union[Var, List[Var]]) -> "Optimizer":
        """Set the parameters, determine the dtype, and build the initial state for the optimizer."""
		pass

    def get_function(self) -> Function:
        """Use blockbuilder to build an optimizer function that executes updates of the parameters
        and the optimizer state."""
		pass
```

Use examples:

See <https://github.com/ACMClass-TVM-20/AD-Example/blob/dc255150dc6a4a6de2fffc2c093a8b2bacc1b030/optimizer_api_example.py>

And also updates Gradient APIs:
- Before: `def Gradient(global_var: GlobalVar, require_grads: Optional[Union[Var, List[Var]]]) -> tvm.ir.transform.Pass`
- After: `def Gradient(func_name: str, require_grads: Optional[Union[Var, List[Var]]]) -> tvm.ir.transform.Pass`

Unit tests are changed accordingly.