### PR TITLE
[Parser] Support R.ShapeExpr

### DIFF
--- a/python/tvm/script/ir_builder/relax/ir.py
+++ b/python/tvm/script/ir_builder/relax/ir.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import tvm
 from tvm import DataType, relax
 from tvm.ir import PrimExpr
-from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, const
+from tvm.relax import Call, Expr, ExternFunc, TupleGetItem, Var, const, ShapeExpr
 
 ############################### Operators ###############################
 from tvm.relax.op import (
@@ -454,6 +454,7 @@ __all__ = [
     "If",
     "Then",
     "TupleGetItem",
+    "ShapeExpr",
     "abs",
     "acos",
     "acosh",

--- a/tests/python/relax/test_op_manipulate.py
+++ b/tests/python/relax/test_op_manipulate.py
@@ -58,6 +58,7 @@ def test_reshape_infer_struct_info():
     s0 = relax.Var("s", R.Shape((3, 8, 5)))
     s1 = relax.Var("s", R.Shape(ndim=3))
     s2 = relax.Var("s", R.Shape())
+    s3 = relax.ShapeExpr((3, 8, 5))
 
     _check_inference(
         bb, relax.op.reshape(x0, (3, 8, 5)), relax.TensorStructInfo((3, 8, 5), "float32")
@@ -90,6 +91,12 @@ def test_reshape_infer_struct_info():
     _check_inference(bb, relax.op.reshape(x3, s0), relax.TensorStructInfo(s0, dtype=""))
     _check_inference(bb, relax.op.reshape(x4, s0), relax.TensorStructInfo(s0, dtype=""))
     _check_inference(bb, relax.op.reshape(x5, s0), relax.TensorStructInfo(s0, dtype=""))
+    _check_inference(bb, relax.op.reshape(x0, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(bb, relax.op.reshape(x1, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(bb, relax.op.reshape(x2, s3), relax.TensorStructInfo(s3, "float32"))
+    _check_inference(bb, relax.op.reshape(x3, s3), relax.TensorStructInfo(s3, dtype=""))
+    _check_inference(bb, relax.op.reshape(x4, s3), relax.TensorStructInfo(s3, dtype=""))
+    _check_inference(bb, relax.op.reshape(x5, s3), relax.TensorStructInfo(s3, dtype=""))
     _check_inference(bb, relax.op.reshape(x0, s1), relax.TensorStructInfo(s1, "float32"))
     _check_inference(bb, relax.op.reshape(x1, s1), relax.TensorStructInfo(s1, "float32"))
     _check_inference(bb, relax.op.reshape(x2, s1), relax.TensorStructInfo(s1, "float32"))
@@ -113,6 +120,7 @@ def test_reshape_infer_struct_info_shape_symbolic():
     x = relax.Var("x", R.Tensor((a, b, c, d), "float32"))
     s0 = relax.Var("s", R.Shape((c, a, d, b)))
     s1 = relax.Var("s", R.Shape())
+    s2 = relax.ShapeExpr((c, a, d, b))
 
     _check_inference(
         bb, relax.op.reshape(x, (c, a, d, b)), relax.TensorStructInfo((c, a, d, b), "float32")
@@ -151,6 +159,7 @@ def test_reshape_infer_struct_info_shape_symbolic():
     )
     _check_inference(bb, relax.op.reshape(x, s0), relax.TensorStructInfo(s0, "float32"))
     _check_inference(bb, relax.op.reshape(x, s1), relax.TensorStructInfo(s1, "float32"))
+    _check_inference(bb, relax.op.reshape(x, s2), relax.TensorStructInfo(s2, "float32"))
 
 
 def test_reshape_infer_struct_info_shape_var():

--- a/tests/python/relax/test_parser.py
+++ b/tests/python/relax/test_parser.py
@@ -329,6 +329,20 @@ def test_tuplegetitem():
     check_call(bind_4.value, "relax.add", [bind_2.var, bind_3.var])
 
 
+def test_shape_expr():
+    @R.function
+    def f(x: R.Tensor((2, 2), "float32")):
+        a = R.ShapeExpr((1, 1, 4))
+        b = R.reshape(x, a)
+        return b
+
+    bind_0 = f.body.blocks[0].bindings[0]
+    bind_1 = f.body.blocks[0].bindings[1]
+    assert isinstance(bind_0.value, relax.ShapeExpr)
+    assert_structural_equal(bind_0.value, relax.ShapeExpr((1, 1, 4)))
+    assert_structural_equal(bind_1.var.struct_info.shape.struct_info, R.Shape([1, 1, 4]))
+
+
 def test_local_func():
     @R.function
     def f(x: R.Tensor):


### PR DESCRIPTION
This PR supports `R.ShapeExpr` in IRBuilder.

Also adds some testcases for ShapeExpr used in `relax.reshape`.