### PR TITLE
[Op] Support legalizing strided_slice when no strides provided

### DIFF
--- a/include/tvm/relax/attrs/index.h
+++ b/include/tvm/relax/attrs/index.h
@@ -43,7 +43,7 @@ struct StridedSliceAttrs : public tvm::AttrsNode<StridedSliceAttrs> {
   Array<Integer> axes;
   Array<PrimExpr> begin;
   Array<PrimExpr> end;
-  Optional<Array<PrimExpr>> strides;
+  Array<PrimExpr> strides;
 
   TVM_DECLARE_ATTRS(StridedSliceAttrs, "relax.attrs.StridedSliceAttrs") {
     TVM_ATTR_FIELD(axes).describe("Axes along which slicing is applied.");


### PR DESCRIPTION
Previously `strided_slice` cannot be legalized when `strides = None`. The reason is that TOPI does not support None strides. 

This PR will assign a default value for None strides from C++ side when constructing `relax.strided_slice` Op.