### PR TITLE
[Op] Registering Gradients for Relax Operators

### DIFF
--- a/python/tvm/relax/op/__init__.py
+++ b/python/tvm/relax/op/__init__.py
@@ -35,6 +35,7 @@ from . import builtin
 from . import image
 from . import memory
 from . import nn
+from . import _op_gradient
 
 
 def _register_op_make():

--- a/python/tvm/relax/op/_op_gradient.py
+++ b/python/tvm/relax/op/_op_gradient.py
@@ -1,0 +1,730 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument, redefined-builtin
+"""Gradient definitions for Relax operators."""
+from typing import List
+from tvm import relax
+from tvm.arith import Analyzer
+from tvm.relax.expr import Call, Var, Expr, ShapeExpr
+from tvm._ffi.base import TVMError
+
+from ..block_builder import BlockBuilder
+from ...tir import PrimExpr
+from .base import register_gradient
+
+from .unary import (
+    cos,
+    exp,
+    sin,
+    sqrt,
+)
+from .binary import less
+from .statistical import sum
+from .create import (
+    zeros,
+    ones,
+    zeros_like,
+)
+from .search import where
+from .linear_algebra import matmul
+from .manipulate import (
+    collapse_sum_to,
+    broadcast_to,
+    permute_dims,
+    expand_dims,
+    concat,
+    split,
+    squeeze,
+)
+
+
+def _get_shape(expr: Expr) -> ShapeExpr:
+    """Get the shape from a Tensor expr."""
+    try:
+        shape = expr.struct_info.shape
+    except Exception as error:
+        raise TVMError(
+            f"Get the shape of {expr} failed. Please normalize it first and ensure it is a Tensor."
+        ) from error
+    return shape
+
+
+def _get_dtype(expr: Expr) -> str:
+    """Get the dtype from a Tensor expr."""
+    try:
+        dtype = expr.struct_info.dtype
+    except Exception as error:
+        raise TVMError(
+            f"Get the dtype of {expr} failed. Please normalize it first and ensure it is a Tensor."
+        ) from error
+    return dtype
+
+
+def _ones(expr: Expr) -> Expr:
+    return ones(_get_shape(expr), _get_dtype(expr))
+
+
+def _zeros(expr: Expr) -> Expr:
+    return zeros(_get_shape(expr), _get_dtype(expr))
+
+
+def _fit_shape(expr: Expr, expr_shape: ShapeExpr, target: Expr) -> Expr:
+    target_shape = _get_shape(target)
+    expr_sinfo = expr_shape.struct_info
+    target_sinfo = target_shape.struct_info
+    assert isinstance(expr_sinfo, relax.ShapeStructInfo)
+    assert isinstance(target_sinfo, relax.ShapeStructInfo)
+
+    def _check_shape_equal():
+        if len(expr_sinfo.values) != len(target_sinfo.values):
+            return False
+        analyzer = Analyzer()
+        for i, field in enumerate(expr_sinfo.values):
+            if not analyzer.can_prove_equal(field, target_sinfo.values[i]):
+                return False
+        return True
+
+    return expr if _check_shape_equal() else collapse_sum_to(expr, target_shape)
+
+
+##################### Binary #####################
+
+
+@register_gradient("relax.add")
+def add_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of add.
+
+    Forward Form:
+        z = relax.add(x, y)
+
+    Backward:
+        Returns [z_output_grad, z_grad].
+    """
+    output_grad_shape = _get_shape(output_grad)
+    return [
+        _fit_shape(output_grad, output_grad_shape, orig_call.args[0]),
+        _fit_shape(output_grad, output_grad_shape, orig_call.args[1]),
+    ]
+
+
+@register_gradient("relax.subtract")
+def subtract_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of subtract.
+
+    Forward Form:
+        z = relax.subtract(x, y)
+
+    Backward:
+        Returns [z_output_grad, -z_grad].
+    """
+    output_grad_shape = _get_shape(output_grad)
+    return [
+        _fit_shape(output_grad, output_grad_shape, orig_call.args[0]),
+        _fit_shape(-output_grad, output_grad_shape, orig_call.args[1]),
+    ]
+
+
+@register_gradient("relax.multiply")
+def multiply_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of multiply.
+
+    Forward Form:
+        z = relax.multiply(x, y)
+
+    Backward:
+        Returns [z_grad * y, z_grad * x].
+    """
+    x, y = orig_call.args
+    output_grad_shape = _get_shape(output_grad)
+    return [
+        _fit_shape(output_grad * y, output_grad_shape, x),
+        _fit_shape(output_grad * x, output_grad_shape, y),
+    ]
+
+
+@register_gradient("relax.divide")
+def divide_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of divide.
+
+    Forward Form:
+        z = relax.divide(x, y)
+
+    Backward:
+        Returns [z_grad / y,  - z_grad * z / y].
+    """
+    x, y = orig_call.args
+    output_grad_shape = _get_shape(output_grad)
+    return [
+        _fit_shape(output_grad / y, output_grad_shape, x),
+        _fit_shape(-output_grad * orig_var / y, output_grad_shape, y),
+    ]
+
+
+# TODO(chaofan): floor-divide
+
+# For most comparison operators, the gradients are just zeros.
+def _binary_zeros(call: Call) -> List[Expr]:
+    return [_zeros(call.args[0]), _zeros(call.args[1])]
+
+
+@register_gradient("relax.equal")
+def equal_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return _binary_zeros(orig_call)
+
+
+@register_gradient("relax.greater")
+def greater_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return _binary_zeros(orig_call)
+
+
+@register_gradient("relax.greater_equal")
+def greater_equal_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return _binary_zeros(orig_call)
+
+
+@register_gradient("relax.less")
+def less_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return _binary_zeros(orig_call)
+
+
+@register_gradient("relax.less_equal")
+def less_equal_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return _binary_zeros(orig_call)
+
+
+@register_gradient("relax.not_equal")
+def not_equal_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return _binary_zeros(orig_call)
+
+
+##################### Create #####################
+
+
+# For these create operators, the gradients are just zeros.
+@register_gradient("relax.zeros_like")
+def zeros_like_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return [orig_var]
+
+
+@register_gradient("relax.ones_like")
+def ones_like_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return [zeros_like(orig_call.args[0], orig_call.attrs.dtype)]
+
+
+@register_gradient("relax.full_like")
+def full_like_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    return [zeros_like(orig_call.args[0], orig_call.attrs.dtype)]
+
+
+##################### Unary #####################
+
+
+@register_gradient("relax.abs")
+def abs_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of abs.
+
+    Forward Form:
+        y = relax.abs(x)
+
+    Backward:
+        Returns [y_grad * where(x < 0, -1, 1)].
+    """
+    x = orig_call.args[0]
+    x_zeros = _zeros(x)
+    x_ones = _ones(x)
+    return [output_grad * where(less(x, x_zeros), -x_ones, x_ones)]
+
+
+@register_gradient("relax.cos")
+def cos_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of cos.
+
+    Forward Form:
+        y = relax.cos(x)
+
+    Backward:
+        Returns [-y_grad * sin(x)].
+    """
+    return [-output_grad * sin(orig_call.args[0])]
+
+
+@register_gradient("relax.exp")
+def exp_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of exp.
+
+    Forward Form:
+        y = relax.exp(x)
+
+    Backward:
+        Returns [y_grad * y].
+    """
+    return [output_grad * orig_var]
+
+
+@register_gradient("relax.log")
+def log_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of log.
+
+    Forward Form:
+        y = relax.log(x)
+
+    Backward:
+        Returns [y_grad / x].
+    """
+    return [output_grad / orig_call.args[0]]
+
+
+@register_gradient("relax.negative")
+def negative_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of negative.
+
+    Forward Form:
+        y = relax.negative(x)
+
+    Backward:
+        Returns [- y_grad].
+    """
+    return [-output_grad]
+
+
+@register_gradient("relax.sigmoid")
+def sigmoid_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of sigmoid.
+
+    Forward Form:
+        y = relax.sigmoid(x)
+
+    Backward:
+        Returns [y_grad * y * (1 - y)].
+    """
+    x_ones = _ones(orig_call.args[0])
+    return [output_grad * orig_var * (x_ones - orig_var)]
+
+
+@register_gradient("relax.sin")
+def sin_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of sin.
+
+    Forward Form:
+        y = relax.sin(x)
+
+    Backward:
+        Returns [y_grad * cos(x)].
+    """
+    return [output_grad * cos(orig_call.args[0])]
+
+
+@register_gradient("relax.sqrt")
+def sqrt_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of sqrt.
+
+    Forward Form:
+        y = relax.sqrt(x)
+
+    Backward:
+        Returns [0.5 * y_grad / sqrt(x)].
+    """
+    x = orig_call.args[0]
+    cst = relax.const(0.5, dtype=_get_dtype(x))
+    return [cst * output_grad / sqrt(x)]
+
+
+@register_gradient("relax.tanh")
+def tanh_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of tanh.
+
+    Forward Form:
+        y = relax.tanh(x)
+
+    Backward:
+        Returns [y_grad * (1 - y * y)].
+    """
+    x_ones = _ones(orig_call.args[0])
+    return [output_grad * (x_ones - orig_var * orig_var)]
+
+
+##################### Statistical #####################
+
+
+@register_gradient("relax.sum")
+def sum_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of sum.
+
+    Forward Form:
+        y = relax.sum(x, axis, keepdims)
+
+    Backward:
+        Returns [broadcast_to(y_output_grad, x.shape)].
+        If `keepdims=False`, the summed axis will be added back.
+    """
+    axis = orig_call.attrs["axis"]
+    keepdims = orig_call.attrs["keepdims"]
+    if not keepdims and axis:
+        output_grad = expand_dims(output_grad, axis)
+    return [broadcast_to(output_grad, _get_shape(orig_call.args[0]))]
+
+
+##################### Manipulate #####################
+
+
+@register_gradient("relax.permute_dims")
+def permute_dims_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of permute_dims.
+
+    Forward Form:
+        y = relax.permute_dims(x, axes)
+
+    Backward:
+        Returns grad transposed over the **inverse permutation** of the original permute_dims axes.
+    """
+    axes = orig_call.attrs["axes"]
+    if axes:
+        dims = len(axes)
+        new_axes = [0] * dims
+        for i in range(dims):
+            new_axes[int(axes[i])] = i
+        return [permute_dims(output_grad, axes=new_axes)]
+    else:
+        return [permute_dims(output_grad)]
+
+
+# TODO(yixin, chaofan): handle symbolic shape
+@register_gradient("relax.concat")
+def concat_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of concat.
+
+    Forward Form:
+        y = concat((x1, x2, x3), axis)
+
+    Backward:
+        Returns [split(y_output_grad, [x1.shape[axis], x1.shape[axis] + x2.shape[axis]], axis)].
+    """
+    axis = orig_call.attrs["axis"]
+    assert axis is not None
+    axis = int(axis)
+    split_indices: List[PrimExpr] = []
+    sinfo = orig_call.args[0].struct_info
+    assert isinstance(sinfo, relax.TupleStructInfo)
+    for i in range(len(sinfo.fields) - 1):
+        tensor_sinfo = sinfo.fields[i]
+        assert isinstance(tensor_sinfo, relax.TensorStructInfo)
+        assert tensor_sinfo.shape is not None
+        index = tensor_sinfo.shape[axis]
+        if i > 0:
+            index += split_indices[i - 1]
+        split_indices.append(index)
+    return [split(output_grad, split_indices, axis)]
+
+
+@register_gradient("relax.split")
+def split_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of split.
+
+    Forward Form:
+        y = split(x, indices, axis)
+
+    Backward:
+        Returns [concat(y_output_grad, axis)].
+    """
+    axis = orig_call.attrs["axis"]
+    assert axis is not None
+    axis = int(axis)
+    return [concat(output_grad, axis)]
+
+
+##################### Linear Algebra #####################
+
+
+@register_gradient("relax.matmul")
+def matmul_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of matmul.
+
+    Forward Form:
+        c = relax.matmul(a, b)
+
+    Backward:
+        Generally, returns [c_grad @ b^T, a^T @ c_grad].
+        Here we only transpose the last two dimensions because of the definition
+        of batch matmul. Note that ndim=1 should be treaded specially.
+    """
+
+    tensor_a, tensor_b = orig_call.args
+
+    a_dim = len(_get_shape(tensor_a))
+    b_dim = len(_get_shape(tensor_b))
+
+    def _transpose_last_two_dim(tensor, ndim):
+        """Helper function for reversing the last two dimensions."""
+        assert ndim > 1
+        return permute_dims(
+            tensor, axes=[i if i < ndim - 2 else 2 * ndim - 3 - i for i in range(ndim)]
+        )
+
+    if a_dim > 1 and b_dim > 1:
+        a_grad = matmul(output_grad, _transpose_last_two_dim(tensor_b, b_dim))
+        b_grad = matmul(_transpose_last_two_dim(tensor_a, a_dim), output_grad)
+    elif a_dim == 1 and b_dim > 1:
+        a_expand = expand_dims(tensor_a, 1)
+        grad_expand = expand_dims(output_grad, -2)
+        a_grad = matmul(grad_expand, _transpose_last_two_dim(tensor_b, b_dim))
+        b_grad = matmul(a_expand, grad_expand)
+    elif b_dim == 1 and a_dim > 1:
+        b_expand = expand_dims(tensor_b, 0)
+        grad_expand = expand_dims(output_grad, -1)
+        a_grad = matmul(grad_expand, b_expand)
+        b_grad = squeeze(
+            matmul(_transpose_last_two_dim(tensor_a, a_dim), grad_expand), axis=-1
+        )  # squeeze last dim
+    else:
+        assert a_dim == 1 and b_dim == 1
+        a_grad = output_grad * tensor_b
+        b_grad = output_grad * tensor_a
+
+    output_grad_shape = _get_shape(output_grad)
+
+    return [
+        _fit_shape(a_grad, output_grad_shape, tensor_a),
+        _fit_shape(b_grad, output_grad_shape, tensor_b),
+    ]
+
+
+##################### Neural network #####################
+
+
+@register_gradient("relax.nn.relu")
+def relu_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of relu.
+
+    Forward Form:
+        y = relax.relu(x)
+
+    Backward:
+        Returns [y_grad * (where(x < 0, 0, 1))].
+    """
+    x = orig_call.args[0]
+    x_zeros = _zeros(x)
+    x_ones = _ones(x)
+    return [where(less(x, x_zeros), x_zeros, x_ones) * output_grad]
+
+
+@register_gradient("relax.nn.softmax")
+def softmax_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of softmax.
+
+    Forward Form:
+        y = relax.softmax(x, axis)
+
+    Backward:
+        Returns [(y_grad - sum(y_grad * y, axis, keepdims=True)) * y]
+    """
+    return [(output_grad - sum(output_grad * orig_var, orig_call.attrs.axis, True)) * orig_var]
+
+
+@register_gradient("relax.nn.log_softmax")
+def log_softmax_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of log_softmax.
+
+    Forward Form:
+        y = relax.log_softmax(x, axis)
+
+    Backward:
+        Returns [y_grad - sum(y_output_grad, axis, keepdims=True) * softmax(x)]
+    """
+    x_softmax = exp(orig_var)
+    return [(output_grad - sum(output_grad, orig_call.attrs.axis, True) * x_softmax)]
+
+
+def _divide_batch(x: Expr, expr: Expr):
+    if x.struct_info.ndim > 1:
+        # TODO(chaofan, yixin): support symbolic shape
+        x_shape = _get_shape(x)
+        batch_size = int(x_shape[0])
+        # batch_size = take(shape_of(x), relax.const(0, dtype="int32"), axis=0)
+        # expr = divide(expr, batch_size)
+        expr = expr / relax.const(batch_size, dtype=_get_dtype(expr))
+    return expr
+
+
+@register_gradient("relax.nn.cross_entropy_with_logits")
+def cross_entropy_with_logits_grad(
+    orig_var: Var,
+    orig_call: Call,
+    output_grad: Var,
+    ctx: BlockBuilder,
+) -> List[Expr]:
+    """Gradient of cross_entropy_with_logits.
+
+    Forward Form:
+        z = cross_entropy_with_logits(x, y)
+
+    Backward:
+        Returns [-z_grad * y, -z_grad * x].
+        If it has batch_size N, the results should divide by N.
+    """
+    x, y = orig_call.args
+    output_grad = _divide_batch(x, output_grad)
+    return [-output_grad * y, -output_grad * x]

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,14 +15,14 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
-from typing import Union, List, Tuple, Optional
+from typing import Union, List, Tuple, Optional, Callable
 
 
 import tvm
 from tvm.runtime.object import Object
 
 from . import _ffi_api
-from ..expr import Expr, ShapeExpr, Call, ExternFunc
+from ..expr import Expr, ShapeExpr, Call, ExternFunc, Var
 from ..expr import Tuple as RxTuple
 from ..struct_info import StructInfo, TensorStructInfo
 from ...ir import PrimExpr
@@ -356,3 +356,21 @@ def shape_of(expr: Expr) -> Expr:
         A relax Call, which gets the shape of the input
     """
     return _ffi_api.shape_of(expr)  # type: ignore # pylint: disable=no-member
+
+
+def register_gradient(
+    op_name: str, fgradient: Callable[[Call, Var], List[Expr]] = None, level: int = 10
+):
+    """Register operator gradient function for a relax operator.
+
+    Parameters
+    ----------
+    op_name: str
+        The name of the op.
+    fgradient: function (orig_var: Var, orig_call: Call, output_grad: Var, ctx: BlockBuilder)
+         -> partials: List[Expr]
+        The gradient function being used.
+    level: int
+        The priority level
+    """
+    return tvm.ir.register_op_attr(op_name, "FPrimalGradient", fgradient, level)

--- a/tests/python/relax/test_op_gradient_numeric.py
+++ b/tests/python/relax/test_op_gradient_numeric.py
@@ -1,0 +1,444 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Callable, Union, Tuple, List
+
+import numpy as np
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.relax.transform import LegalizeOps
+from tvm.testing.utils import check_numerical_grads
+from tvm.ir.op import Op
+
+
+def relax_check_gradients(
+    op_func: Callable,
+    op_name: str,
+    inputs_numpy: np.array,
+    target: Union[str, tvm.target.Target],
+    dev: tvm._ffi.runtime_ctypes.Device,
+    output_shape: Union[Tuple, List[Tuple]],
+    tuple_input: bool = False,
+    **kwargs,  # attr for operators
+):
+    """Generate module and run it to check numberic gradients."""
+
+    func_name = "main"
+
+    # prepare input
+    def _numpy_to_var(data, var_name):
+        if isinstance(data, list):
+            struct_infos = []
+            for _data in data:
+                tvm_var = _numpy_to_var(_data, "")
+                struct_infos.append(tvm_var.struct_info)
+            return relax.Var(var_name, relax.TupleStructInfo(struct_infos))
+        return relax.Var(var_name, relax.TensorStructInfo(data.shape, str(data.dtype)))
+
+    def _numpy_to_tvm(data):
+        if isinstance(data, list):
+            ret_data = []
+            for _data in data:
+                tvm_data = _numpy_to_tvm(_data)
+                ret_data.append(tvm_data)
+            return ret_data
+        return tvm.nd.array(data)
+
+    def _tvm_to_numpy(data):
+        if isinstance(data, tvm.ir.Array):
+            return [_tvm_to_numpy(i) for i in data]
+        return data.numpy()
+
+    def _gen_weights(shape, dtype):
+        if isinstance(shape, list):
+            ret = []
+            for s in shape:
+                ret.append(_gen_weights(s, dtype))
+            return ret
+        else:
+            return np.random.uniform(size=shape).astype(dtype)
+
+    param_vars = [
+        _numpy_to_var(input_numpy, "x_" + str(i)) for i, input_numpy in enumerate(inputs_numpy)
+    ]
+    weights = _gen_weights(output_shape, inputs_numpy[0].dtype)
+    grad_var = _numpy_to_var(weights, "grad")
+
+    # get gradient
+    op = Op.get(op_name)
+    op_grad_func = op.get_attr("FPrimalGradient")
+    if tuple_input:
+        t = relax.Tuple(param_vars)
+        call = op_func(t, **kwargs)
+    else:
+        call = op_func(*param_vars, **kwargs)
+
+    bb = relax.BlockBuilder()
+    with bb.function(func_name, param_vars):
+        with bb.dataflow():
+            out = bb.emit_output(call)
+        bb.emit_func_output(out)
+    mod = bb.get()
+    lower_mod = LegalizeOps()(mod)
+    ex_0 = relax.vm.build(lower_mod, target)
+    vm_0 = relax.VirtualMachine(ex_0, dev)
+
+    def forward(*inputs):
+        inputs_tvm = [_numpy_to_tvm(i) for i in inputs]
+        result = vm_0[func_name](*inputs_tvm)
+        result_numpy = _tvm_to_numpy(result)
+        if isinstance(result_numpy, list):
+            assert isinstance(weights, list)
+            assert len(weights) == len(result_numpy)
+            ret = 0
+            for i, weight in enumerate(weights):
+                ret += np.sum(weight * result_numpy[i])
+            return ret
+        return np.sum(weights * result_numpy)
+
+    bb1 = relax.BlockBuilder()
+    with bb1.function(func_name, param_vars + [grad_var]):
+        with bb1.dataflow():
+            orig_var = bb1.emit(call)
+            grad_call = relax.Tuple(op_grad_func(orig_var, call, grad_var, bb1))
+            if tuple_input:
+                adjoints = bb1.emit(grad_call)
+                out = bb1.emit_output(relax.TupleGetItem(adjoints, 0))
+            else:
+                out = bb1.emit_output(grad_call)
+        bb1.emit_func_output(out)
+    grad_mod = bb1.get()
+    lower_grad_mod = LegalizeOps()(grad_mod)
+
+    ex_1 = relax.vm.build(lower_grad_mod, target)
+    vm_1 = relax.VirtualMachine(ex_1, dev)
+    inputs_tvm = [_numpy_to_tvm(i) for i in inputs_numpy]
+    weights_tvm = _numpy_to_tvm(weights)
+    result = vm_1[func_name](*inputs_tvm, weights_tvm)
+
+    check_numerical_grads(forward, inputs_numpy, _tvm_to_numpy(result))
+
+
+##################### Binary #####################
+
+binary_arith_op_func, binary_arith_op_name = tvm.testing.parameters(
+    (relax.op.add, "relax.add"),
+    (relax.op.subtract, "relax.subtract"),
+    (relax.op.multiply, "relax.multiply"),
+    (relax.op.divide, "relax.divide"),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_binary_arith(target, dev, binary_arith_op_func, binary_arith_op_name):
+    data1_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
+    data2_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        binary_arith_op_func, binary_arith_op_name, [data1_numpy, data2_numpy], target, dev, (3, 3)
+    )
+
+
+binary_cmp_op_func, binary_cmp_op_name = tvm.testing.parameters(
+    (relax.op.equal, "relax.equal"),
+    (relax.op.greater, "relax.greater"),
+    (relax.op.greater_equal, "relax.greater_equal"),
+    (relax.op.less, "relax.less"),
+    (relax.op.less_equal, "relax.less_equal"),
+    (relax.op.not_equal, "relax.not_equal"),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_binary_cmp(target, dev, binary_cmp_op_func, binary_cmp_op_name):
+    # We must assure data1_numpy[i] != data2_numpy[i] for all possible i-s
+    # If data1_numpy[i] == data2_numpy[i], the operator is not differentiable w.r.t. place i
+    data1_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
+    delta = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
+    sign = np.random.randint(0, 2, (3, 3)).astype(np.float32) * 2 - 1
+    data2_numpy = data1_numpy + delta * sign
+    relax_check_gradients(
+        binary_cmp_op_func, binary_cmp_op_name, [data1_numpy, data2_numpy], target, dev, (3, 3)
+    )
+
+
+##################### Unary #####################
+
+unary_op_func, unary_op_name, can_be_neg = tvm.testing.parameters(
+    (relax.op.abs, "relax.abs", True),
+    (relax.op.cos, "relax.cos", True),
+    (relax.op.exp, "relax.exp", True),
+    (relax.op.log, "relax.log", False),
+    (relax.op.negative, "relax.negative", True),
+    (relax.op.sigmoid, "relax.sigmoid", True),
+    (relax.op.sin, "relax.sin", True),
+    (relax.op.sqrt, "relax.sqrt", False),
+    (relax.op.tanh, "relax.tanh", True),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_unary(target, dev, unary_op_func, unary_op_name, can_be_neg):
+    (low, high) = (-1, 1) if can_be_neg else (0.1, 1)
+    data_numpy = np.random.uniform(low, high, (3, 3)).astype(np.float32)
+    relax_check_gradients(unary_op_func, unary_op_name, [data_numpy], target, dev, (3, 3))
+
+
+##################### Create #####################
+
+
+like_op_func, like_op_name, is_full = tvm.testing.parameters(
+    (relax.op.zeros_like, "relax.zeros_like", False),
+    (relax.op.ones_like, "relax.ones_like", False),
+    (relax.op.full_like, "relax.full_like", True),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_create_like(target, dev, like_op_func, like_op_name, is_full):
+    data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
+    if is_full:
+        full_value = np.random.uniform(-1, 1, ()).astype(np.float32)
+        relax_check_gradients(
+            like_op_func, like_op_name, [data_numpy, full_value], target, dev, (3, 3)
+        )
+    else:
+        relax_check_gradients(like_op_func, like_op_name, [data_numpy], target, dev, (3, 3))
+
+
+##################### Statistical #####################
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sum(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(relax.op.sum, "relax.sum", [data1_numpy], target, dev, ())
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sum_with_axis(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.sum, "relax.sum", [data1_numpy], target, dev, (2, 4), axis=[1, 3]
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sum_keepdims(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.sum, "relax.sum", [data1_numpy], target, dev, (3, 1), keepdims=True, axis=1
+    )
+
+
+##################### Manipulate #####################
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_permute_dims(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.permute_dims, "relax.permute_dims", [data1_numpy], target, dev, (5, 4, 3, 2)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_permute_dims_with_axes(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.permute_dims,
+        "relax.permute_dims",
+        [data1_numpy],
+        target,
+        dev,
+        (2, 5, 3, 4),
+        axes=(0, 3, 1, 2),
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_concat(target, dev):
+    data_numpy1 = np.random.randint(1, 16, (3, 3)).astype(np.float32)
+    data_numpy2 = np.random.randint(1, 16, (3, 4)).astype(np.float32)
+    data_numpy3 = np.random.randint(1, 16, (3, 5)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.concat,
+        "relax.concat",
+        [data_numpy1, data_numpy2, data_numpy3],
+        target,
+        dev,
+        (3, 12),
+        tuple_input=True,
+        axis=1,
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_split_indices(target, dev):
+    data_numpy = np.random.randint(1, 16, (3, 12)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.split,
+        "relax.split",
+        [data_numpy],
+        target,
+        dev,
+        [(3, 3), (3, 4), (3, 5)],
+        indices_or_sections=[3, 7],
+        axis=1,
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_split_section(target, dev):
+    data_numpy = np.random.randint(1, 16, (3, 12)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.split,
+        "relax.split",
+        [data_numpy],
+        target,
+        dev,
+        [(3, 4), (3, 4), (3, 4)],
+        indices_or_sections=3,
+        axis=1,
+    )
+
+
+##################### Linear Algebra #####################
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_matmul_2_2(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (3, 4)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.matmul, "relax.matmul", [data1_numpy, data2_numpy], target, dev, (2, 4)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_matmul_1_1(target, dev):
+    data1_numpy = np.random.randint(0, 16, (4,)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (4,)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.matmul, "relax.matmul", [data1_numpy, data2_numpy], target, dev, ()
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_matmul_1_4(target, dev):
+    data1_numpy = np.random.randint(0, 16, (4,)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.matmul, "relax.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 5)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_matmul_4_1(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3, 4, 5)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (5,)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.matmul, "relax.matmul", [data1_numpy, data2_numpy], target, dev, (2, 3, 4)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_matmul_5_4(target, dev):
+    data1_numpy = np.random.randint(0, 16, (2, 3, 1, 4, 5)).astype(np.float32)
+    data2_numpy = np.random.randint(0, 16, (3, 2, 5, 4)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.matmul,
+        "relax.matmul",
+        [data1_numpy, data2_numpy],
+        target,
+        dev,
+        (2, 3, 2, 4, 4),
+    )
+
+
+##################### Neural network #####################
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_relu(target, dev):
+    data1_numpy = np.random.uniform(0.2, 1, (3, 3)).astype(np.float32)
+    sign = np.random.randint(0, 2, (3, 3)).astype(np.float32) * 2 - 1
+    data1_numpy *= sign
+    relax_check_gradients(relax.op.nn.relu, "relax.nn.relu", [data1_numpy], target, dev, (3, 3))
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_softmax(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.softmax, "relax.nn.softmax", [data1_numpy], target, dev, (3, 3)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_softmax_with_axis(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.softmax, "relax.nn.softmax", [data1_numpy], target, dev, (3, 3), axis=1
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_log_softmax(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.log_softmax, "relax.nn.log_softmax", [data1_numpy], target, dev, (3, 3)
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_log_softmax_with_axis(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.log_softmax, "relax.nn.log_softmax", [data1_numpy], target, dev, (3, 3), axis=1
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_cross_entropy_with_logits(target, dev):
+    data_numpy1 = np.random.randint(1, 16, (3,)).astype(np.float32)
+    data_numpy2 = np.random.randint(1, 16, (3,)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.cross_entropy_with_logits,
+        "relax.nn.cross_entropy_with_logits",
+        [data_numpy1, data_numpy2],
+        target,
+        dev,
+        (),
+    )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_cross_entropy_with_logits_batch(target, dev):
+    data_numpy1 = np.random.randint(1, 16, (2, 3)).astype(np.float32)
+    data_numpy2 = np.random.randint(1, 16, (2, 3)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.nn.cross_entropy_with_logits,
+        "relax.nn.cross_entropy_with_logits",
+        [data_numpy1, data_numpy2],
+        target,
+        dev,
+        (),
+    )
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR registers gradients for Relax high-level operators and contains corresponding numerical tests.

In fact this PR is a migration which brings our previous work to new branch. The main part was done in https://github.com/mlc-ai/relax/pull/98 and it also contains some follow-up patches such as https://github.com/mlc-ai/relax/pull/136.

Co-authored-by: Yixin Dong [ubospica@gmail.com](mailto:ubospica@gmail.com)