### PR TITLE
[Training] Relax Training Suite

### DIFF
--- a/python/tvm/relax/__init__.py
+++ b/python/tvm/relax/__init__.py
@@ -87,6 +87,7 @@ from . import transform
 from . import block_builder
 from . import op
 from . import struct_info
+from . import training
 
 # VM
 from .vm_build import build, Executable

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -365,7 +365,7 @@ class BlockBuilder(Object):
         """
         return DataflowScope(self)
 
-    def emit(self, expr: Expr) -> Var:
+    def emit(self, expr: Expr, name_hint: str = "") -> Var:
         """Emit an expr.
         This infers the shape and type of the expr, create a variable,
         and bind the expr to the variable.
@@ -375,12 +375,15 @@ class BlockBuilder(Object):
         expr : tvm.relax.Expr
             The Expr to be emitted.
 
+        name_hint : str
+            Name hint for the bound variable.
+
         Returns
         -------
         ret : tvm.relax.Var
             A newly created variable that gets bound to the input expr.
         """
-        return _ffi_api.BlockBuilderEmit(self, expr)  # type: ignore
+        return _ffi_api.BlockBuilderEmit(self, expr, name_hint)  # type: ignore
 
     def call_te(self, func: Callable, *args: Any, **kwargs: Any) -> Expr:
         """Generate a call node according to the te function.
@@ -601,13 +604,16 @@ class BlockBuilder(Object):
         """
         return _ffi_api.BlockBuilderEmitMatchCast(self, value, struct_info)  # type: ignore
 
-    def emit_output(self, output: Union[Expr, Tuple, List[Expr]]) -> None:
+    def emit_output(self, output: Union[Expr, Tuple, List[Expr]], name_hint: str = "") -> Var:
         """Emit output for the current dataflow block or function.
 
         Parameters
         ----------
         output : Expr | Tuple | List[Expr]
             The output of the current block/function.
+
+        name_hint : str
+            Name hint for the bound variable.
 
         Returns
         -------
@@ -616,7 +622,7 @@ class BlockBuilder(Object):
         """
         if isinstance(output, (list, tuple)):
             output = Tuple(output)
-        return _ffi_api.BlockBuilderEmitOutput(self, output)  # type: ignore
+        return _ffi_api.BlockBuilderEmitOutput(self, output, name_hint)  # type: ignore
 
     def emit_func_output(
         self,

--- a/python/tvm/relax/training/__init__.py
+++ b/python/tvm/relax/training/__init__.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""The Relax training APIs."""
+
+from . import optimizer
+from . import trainer
+from . import utils
+from . import loss
+
+from .setup_trainer import SetupTrainer

--- a/python/tvm/relax/training/_ffi_api.py
+++ b/python/tvm/relax/training/_ffi_api.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""FFI APIs for tvm.relax.training"""
+import tvm._ffi
+
+tvm._ffi._init_api("relax.training", __name__)

--- a/python/tvm/relax/training/loss.py
+++ b/python/tvm/relax/training/loss.py
@@ -1,0 +1,251 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=redefined-builtin, invalid-name
+"""Loss functions library for relax."""
+
+from typing import Optional, Union
+
+# isort: off
+from typing_extensions import Literal
+
+# isort: on
+
+from ..block_builder import BlockBuilder
+from ..expr import Expr, Var, Function, StructInfo
+
+from ..op import abs, sum, mean, subtract, multiply
+from ..op.nn import log_softmax, nll_loss
+
+
+def _create_param_var(param: Union[Var, StructInfo], param_name: str) -> Var:
+    if isinstance(param, StructInfo):
+        param = Var(param_name, param)
+    if not isinstance(param, Var):
+        raise TypeError("The type of param should be Var or StructInfo, but got " + type(param))
+    return Var(param.name_hint, param.struct_info)
+
+
+class Loss:
+    r"""Base class of all loss.
+
+    Parameters
+    ----------
+    loss_name : str
+        The name of the loss function.
+
+    reduction : Literal["mean", "sum", "none"]
+        The reduction method to apply to output. Can be "mean", "sum" or "none".
+
+        none : no reduction will be applied,
+        mean : the sum of the output will be divided by the batch_size,
+        sum : the output will be summed.
+    """
+
+    _valid_reductions = ["mean", "sum", "none"]
+
+    def __init__(self, loss_name: str, reduction: Literal["mean", "sum", "none"] = "mean") -> None:
+        self._loss_name = loss_name
+        self._reduction = reduction
+
+        if self._reduction not in self._valid_reductions:
+            raise ValueError("Reduction can only be one of these values: ", self._valid_reductions)
+
+    def _with_reduction(self, expr: Expr) -> Expr:
+        """Add a reduction to the final loss.
+
+        Parameters
+        ----------
+        expr : Expr
+            The loss expr.
+        """
+        if self._reduction == "sum":
+            expr = sum(expr)
+        elif self._reduction == "mean":
+            expr = mean(expr)
+        elif self._reduction != "none":
+            raise ValueError("Reduction can only be one of these values: ", self._valid_reductions)
+        return expr
+
+
+class L1Loss(Loss):
+    r"""Mean element-wise absolute value difference.
+
+    Parameters
+    ----------
+    reduction : Literal["mean", "sum", "none"]
+        The reduction method to apply to output. Can be "mean", "sum" or "none".
+
+        none : no reduction will be applied,
+        mean : the sum of the output will be divided by the batch_size,
+        sum : the output will be summed.
+    """
+
+    def __init__(self, reduction: Literal["mean", "sum", "none"] = "mean") -> None:
+        super().__init__("l1_loss", reduction)
+
+    def __call__(
+        self,
+        predictions: Union[Var, StructInfo],
+        targets: Union[Var, StructInfo],
+    ) -> Function:
+        """Get the relax function of L1Loss. If the parameters are
+        struct info, it will create corresponding variables.
+
+        Parameters
+        ----------
+        predictions : Union[Var, StructInfo]
+            The predictions of the model in the calculation of loss.
+        targets : Union[Var, StructInfo]
+            The ground truth in the calculation of loss.
+
+        Returns
+        -------
+        The relax function of L1Loss with the loss name as its global symbol.
+        """
+        bb = BlockBuilder()
+
+        predictions = _create_param_var(predictions, "predictions")
+        targets = _create_param_var(targets, "targets")
+
+        with bb.function(self._loss_name, [predictions, targets]):
+            with bb.dataflow():
+                lv = abs(subtract(predictions, targets))
+                loss = bb.emit_output(self._with_reduction(lv))
+            bb.emit_func_output(loss)
+
+        return bb.get()[self._loss_name]
+
+
+class MSELoss(Loss):
+    r"""Measures the element-wise mean squared error.
+
+    Parameters
+    ----------
+    reduction : Literal["mean", "sum", "none"]
+        The reduction method to apply to output. Can be "mean", "sum" or "none".
+
+        none : no reduction will be applied,
+        mean : the sum of the output will be divided by the batch_size,
+        sum : the output will be summed.
+    """
+
+    def __init__(self, reduction: Literal["mean", "sum", "none"] = "mean") -> None:
+        super().__init__("mse_loss", reduction)
+
+    def __call__(
+        self,
+        predictions: Union[Var, StructInfo],
+        targets: Union[Var, StructInfo],
+    ) -> Function:
+        """Get the relax function of MSELoss. If the parameters are
+        struct info, it will create corresponding variables.
+
+        Parameters
+        ----------
+        predictions : Union[Var, StructInfo]
+            The predictions of the model in the calculation of loss.
+        targets : Union[Var, StructInfo]
+            The ground truth in the calculation of loss.
+
+        Returns
+        -------
+        The relax function of MSELoss with the loss name as its global symbol.
+        """
+        bb = BlockBuilder()
+
+        predictions = _create_param_var(predictions, "predictions")
+        targets = _create_param_var(targets, "targets")
+
+        with bb.function(self._loss_name, [predictions, targets]):
+            with bb.dataflow():
+                lv = subtract(predictions, targets)
+                lv = multiply(lv, lv)
+                loss = bb.emit_output(self._with_reduction(lv))
+            bb.emit_func_output(loss)
+
+        return bb.get()[self._loss_name]
+
+
+class CrossEntropyLoss(Loss):
+    r"""CrossEntropyLoss. It is a combination of a log_softmax computation and a nll_loss.
+
+    Parameters
+    ----------
+    reduction : Literal["mean", "sum", "none"]
+        The reduction method to apply to output. Can be "mean", "sum" or "none".
+
+        none : no reduction will be applied,
+        mean : the sum of the output will be divided by the batch_size,
+        sum : the output will be summed.
+
+    ignore_index : int
+        Specifies a target value that is ignored and does not contribute to the input gradient.
+    """
+
+    ignore_index: int
+
+    def __init__(
+        self,
+        reduction: Literal["mean", "sum", "none"] = "mean",
+        ignore_index: int = -100,
+    ) -> None:
+        super().__init__("cross_entropy_loss", reduction)
+        self.ignore_index = ignore_index
+
+    def __call__(
+        self,
+        predictions: Union[Var, StructInfo],
+        targets: Union[Var, StructInfo],
+        weights: Optional[Union[Var, StructInfo]] = None,
+    ) -> Function:
+        """Get the relax function of CrossEntropyLoss. If the parameters are
+        struct info, it will create corresponding variables.
+
+        Parameters
+        ----------
+        predictions : Union[Var, StructInfo]
+            The predictions of the model in the calculation of loss.
+
+        targets : Union[Var, StructInfo]
+            The ground truth in the calculation of loss.
+
+        weights : Optional[Union[Var, StructInfo]]
+            a manual rescaling weight given to each class. It has to be a Tensor of size C.
+
+        Returns
+        -------
+        The relax function of CrossEntropyLoss with the loss name as its global symbol.
+        """
+        bb = BlockBuilder()
+
+        predictions = _create_param_var(predictions, "predictions")
+        targets = _create_param_var(targets, "targets")
+
+        arg_list = [predictions, targets]
+        if weights:
+            weights = _create_param_var(weights, "weights")
+            arg_list.append(weights)
+
+        with bb.function(self._loss_name, arg_list):
+            with bb.dataflow():
+                logits = bb.emit(log_softmax(predictions))
+                loss = bb.emit_output(
+                    nll_loss(logits, targets, weights, self._reduction, self.ignore_index)
+                )
+            bb.emit_func_output(loss)
+
+        return bb.get()[self._loss_name]

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -1,0 +1,713 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Provide abstraction for defining optimizers and a set of common optimizers."""
+
+from decimal import Decimal
+from typing import List, Optional, Tuple, Union
+
+import numpy as np  # type: ignore
+
+import tvm
+
+from ..block_builder import BlockBuilder
+from ..struct_info import TensorStructInfo, TupleStructInfo
+from ..op import add, subtract, multiply, divide, sqrt
+from ..expr import const, Var, Function, TupleGetItem, Tuple as RxTuple
+
+
+# TODO(chaofan, yixin): Migrate key logics to C++
+class Optimizer:
+    """Relax training optimizer. This class could generate relax Functions for optimizing specified
+    parameters, and store the states used in the optimization process, such as momentum.
+
+    Parameters
+    ----------
+    name : str
+        The name of the optimizer function. This parameter is provided by subclasses.
+
+    Attributes
+    ----------
+    dtype : str
+        The only dtype of the optimizer. It will be used as the dtype of the optimizer states,
+        and the dtype of necessary constants, such as the learning rate. Will be set in `init()`.
+
+    name : str
+        The name of the optimizer.
+
+    param_list : List[Var]
+        The list of variables to optimize. Will be set in `init()`.
+
+    state : tvm.ir.Array
+        `state` is an runtime Array representing the state of the optimizer. Will be set in
+        `init()`.
+
+        The states of the optimizer can store necessary information in the optimization process at
+        runtime, such as the number of steps, the momentum in momentum SGD, etc.
+
+        `opt.state` should be used as the last argument of the function that is got through
+        `get_function()`, and its new value is returned as the last return value of that function.
+
+        See examples for more details.
+
+    Examples
+    --------
+    The usage of optimizers should resemble the following pattern. We will take SGD as an example.
+    For detailed examples, please see the tutorial.
+
+    .. code-block:: python
+        # Construct the optimizer
+        opt = relax.optimizer.SGD(0.1)
+
+        # Initialize the parameter list, the dtype and the optimizer state
+        # x is the relax Var we want to optimize
+        opt.init(x)
+
+        # The above two lines is equivalent to one line:
+        opt = relax.optimizer.SGD(0.1).init(x)
+
+        # Get the optimizer function
+        # mod is an IRModule constructed earlier
+        mod["SGD"] = opt.get_function()
+
+        # Legalize and build mod
+        lowered_mod = LegalizeOps()(mod)
+        ex = relax.vm.build(lowered_mod, target="llvm")
+        vm = relax.VirtualMachine(ex, tvm.cpu())
+
+        # Optimization process
+        # param_tuple is a runtime tuple of parameters
+        # param_gradient is a runtime tuple of the gradient of the parameters in param_tuple,
+        # respectively
+        # param_gradient can be gained by the automatic differentiation pass. Please see
+        # `relax.transform.Gradient`
+        param_tuple, opt.state = vm["SGD"](param_tuple, param_gradient, opt.state)
+    """
+
+    dtype: str
+    name: str
+    param_list: List[Var]
+    state: tvm.ir.Array
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.param_list = None
+        self.state = None
+        self.dtype = None
+
+    def init(self, params: Union[Var, List[Var]]) -> "Optimizer":
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
+
+        Returns
+        -------
+        self : Optimizer
+            The optimizer itself.
+        """
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        # State should be initialized in any implementation of optimizer.
+        self.state = None
+        return self
+
+    def _set_params_and_dtype(self, params: List[Var]) -> None:
+        """Check params is legal and set the param_list and dtype of the optimizer."""
+        params_set = set()
+        dtype = None
+        for x in params:
+            if not isinstance(x, Var):
+                raise ValueError(f"Parameter {x} is not a Var")
+            if not isinstance(x.struct_info, TensorStructInfo):
+                raise ValueError(
+                    f"Optimizers only support Tensor parameters, but parameter {x.name_hint} has "
+                    f"struct info {x.struct_info}"
+                )
+            data_type = tvm.DataType(x.struct_info.dtype)
+            if not data_type.type_code in (tvm.DataTypeCode.BFLOAT, tvm.DataTypeCode.FLOAT):
+                raise ValueError(
+                    f"Optimizers only support Tensor parameters of floating point dtype, but dtype "
+                    f"of {x.name_hint} is {x.struct_info.dtype}"
+                )
+            if dtype is None:
+                dtype = x.struct_info.dtype
+            else:
+                if dtype != x.struct_info.dtype:
+                    raise ValueError(
+                        f"All parameters should have the same dtype, but parameter {x.name_hint} "
+                        f"has dtype {x.struct_info.dtype}, which differs from the previous dtype "
+                        f"{dtype}"
+                    )
+            if x in params_set:
+                raise ValueError(f"Parameter {x.name_hint} appears more than once")
+            params_set.add(x)
+        self.param_list = params
+        self.dtype = dtype
+
+    def _check_init(self):
+        """Check that the optimizer is initialized. This method should be called at the start of
+        get_function().
+        """
+        if self.param_list is None or self.state is None or self.dtype is None:
+            raise RuntimeError("Please call init() for the optimizer before calling get_function()")
+
+    def get_function(self) -> Function:
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state.
+
+        The optimizer function will take in a tuple of parameters, a tuple of gradients of
+        parameters, and a tuple of optimizer states. It will return a tuple of updated parameters,
+        and a tuple of optimizer states.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+
+        Examples
+        --------
+        An example of the returned optimizer function. This function executes the stochastic
+        gradient descent method with lr = 0.1.
+
+        .. code-block:: python
+            @R.function
+            def SGD(
+                params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+                gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+                optim_states: R.Tuple(R.Tensor((), "int64")),
+            ) -> R.Tuple(
+                R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+                R.Tuple(R.Tensor((), "int64")),
+            ):
+                with R.dataflow():
+                    num_steps: R.Tensor((), "int64") = optim_states[0]
+                    num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+                    x: R.Tensor((3, 3), "float32") = params[0]
+                    x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+                    lv: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), x_grad)
+                    x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv)
+                    y: R.Tensor((3,), "float32") = params[1]
+                    y_grad: R.Tensor((3,), "float32") = gradients[1]
+                    lv1: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), y_grad)
+                    y_new: R.Tensor((3,), "float32") = R.subtract(y, lv1)
+                    params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                        x_new,
+                        y_new,
+                    )
+                    optim_states_new: R.Tuple(R.Tensor((), "int64")) = (num_steps_new,)
+                    R.output(params_new, optim_states_new)
+                return (params_new, optim_states_new)
+        """
+        self._check_init()
+        raise NotImplementedError()
+
+
+# TODO(chaofan, yixin): Support symbolic shapes
+def _get_shape_as_int_list(var: Var) -> List[int]:
+    return [int(val) for val in var.struct_info.shape]
+
+
+# We need to subtract on hyperparameters, but do not want to introduce floating point error.
+# Floating point error would lead to a few problems, such as making assert_structural_equal not
+# pass in unit tests
+def _high_precision_subtract(lhs: float, rhs: float) -> float:
+    return float(Decimal(str(lhs)) - Decimal(str(rhs)))
+
+
+class SGD(Optimizer):
+    """Implements stochastic gradient descent.
+
+    The returned function of `get_function()` is equivalent to the following numpy code:
+
+    .. code-block:: python
+        def SGD(param_tuple, grad_tuple, state_tuple):
+            num_steps = state_tuple[0]
+            param_tuple_new, state_tuple_new = [], []
+            state_tuple_new.append(num_steps + 1)
+            for i in range(len(param_tuple)):
+                param = param_tuple[i]
+                grad = grad_tuple[i]
+                param_tuple_new.append(param - lr * (grad + weight_decay * param))
+            return param_tuple_new, state_tuple_new
+
+    Parameters
+    ----------
+    lr : float
+        learning rate
+
+    weight_decay : float
+        weight decay (L2 penalty) (default: 0)
+    """
+
+    def __init__(self, lr: float, weight_decay: float = 0) -> None:
+        super().__init__("SGD")
+        self.lr = float(lr)
+        self.weight_decay = float(weight_decay)
+
+    def init(self, params: Union[Var, List[Var]]) -> "SGD":
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
+
+        The state of SGD is `(num_steps,)`.
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
+
+        Returns
+        -------
+        self : SGD
+            The SGD optimizer itself.
+        """
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        self.state = (
+            # num_steps = 0
+            tvm.nd.array(np.zeros((), "int64")),
+        )
+        return self
+
+    def get_function(self) -> Function:
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state. `init()` should be called before `get_function()`.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+        """
+        self._check_init()
+
+        plist = self.param_list
+        len_param = len(plist)
+        dtype = self.dtype
+
+        # input variables
+        param_var = Var("params", TupleStructInfo([p.struct_info for p in plist]))
+        grad_var = Var("gradients", TupleStructInfo([p.struct_info for p in plist]))
+        state_var = Var("optim_states", TupleStructInfo([TensorStructInfo((), "int64")]))
+
+        # constants
+        lr = const(self.lr, dtype)
+        weight_decay = const(self.weight_decay, dtype)
+        one = const(1, "int64")
+
+        builder = BlockBuilder()
+        with builder.function(self.name, [param_var, grad_var, state_var]):
+            with builder.dataflow():
+                param_list_new, state_list_new = [], []
+
+                # handle num_steps
+                num_steps = builder.emit(TupleGetItem(state_var, 0), "num_steps")
+                num_steps_new = builder.emit(add(num_steps, one), "num_steps_new")
+                state_list_new.append(num_steps_new)
+
+                # computation logics
+                for i in range(len_param):
+                    name = self.param_list[i].name_hint
+                    p = builder.emit(TupleGetItem(param_var, i), name)
+                    g = builder.emit(TupleGetItem(grad_var, i), name + "_grad")
+                    if self.weight_decay:
+                        g = builder.emit(add(multiply(weight_decay, p), g), name + "_grad_new")
+                    p_new = builder.emit(subtract(p, multiply(lr, g)), name + "_new")
+                    param_list_new.append(p_new)
+
+                # handle return values
+                params_new = builder.emit_output(RxTuple(param_list_new), "params_new")
+                optim_states_new = builder.emit_output(RxTuple(state_list_new), "optim_states_new")
+            builder.emit_func_output((params_new, optim_states_new))
+        return builder.get()[self.name]
+
+
+class MomentumSGD(Optimizer):
+    """Implements stochastic gradient descent with momentum. Optionally supports Nesterov
+    momentum.
+
+    The returned function of `get_function()` is equivalent to the following numpy code:
+
+    .. code-block:: python
+        def MomentumSGD(param_tuple, grad_tuple, state_tuple):
+            num_steps = state_tuple[0]
+            param_tuple_new, state_tuple_new = [], []
+            state_tuple_new.append(num_steps + 1)
+
+            for i in range(len(param_tuple)):
+                param = param_tuple[i]
+                grad = grad_tuple[i]
+                velocity = state_tuple[i + 1]
+                grad = param * weight_decay + grad
+                velocity = momentum * velocity + grad * (1 - dampening)
+                if nesterov:
+                    param = param - (grad + momentum * velocity) * lr
+                else:
+                    param = param - velocity * lr
+                param_tuple_new.append(param)
+                state_tuple_new.append(velocity)
+
+            return param_tuple_new, state_tuple_new
+
+    Parameters
+    ----------
+    lr : float
+        learning rate
+
+    momentum : float
+        momentum factor (default: 0)
+
+    weight_decay : float
+        weight decay (L2 penalty) (default: 0)
+
+    dampening : float
+        dampening for momentum (default: 0)
+
+    nesterov : bool
+        enables Nesterov momentum (default: False)
+    """
+
+    def __init__(
+        self,
+        lr: float,
+        momentum: float,
+        dampening: float = 0,
+        weight_decay: float = 0,
+        nesterov: bool = False,
+    ) -> None:
+        super().__init__("MomentumSGD")
+        self.lr = float(lr)
+        self.momentum = float(momentum)
+        self.weight_decay = float(weight_decay)
+        self.dampening = float(dampening)
+        self.nesterov = nesterov
+
+    def init(self, params: Union[Var, List[Var]]) -> "MomentumSGD":
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
+
+        The state of MomentumSGD is
+        `(num_steps, velocity_of_param_0, ..., velocity_of_param_n-1)`.
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
+
+        Returns
+        -------
+        self : MomentumSGD
+            The MomentumSGD optimizer itself.
+        """
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        self.state = (
+            # num_steps = 0
+            tvm.nd.array(np.zeros((), "int64")),
+            # v_{param} is initialized to all zeros
+            *(
+                tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
+                for p in self.param_list
+            ),
+        )
+        return self
+
+    def get_function(self) -> Function:
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state. `init()` should be called before `get_function()`.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+        """
+        self._check_init()
+        plist = self.param_list
+        len_param = len(plist)
+        dtype = self.dtype
+
+        # input variables
+        param_var = Var("params", TupleStructInfo([p.struct_info for p in plist]))
+        grad_var = Var("gradients", TupleStructInfo([p.struct_info for p in plist]))
+        state_var = Var(
+            "optim_states",
+            TupleStructInfo([TensorStructInfo((), "int64"), *(p.struct_info for p in plist)]),
+        )
+
+        # constants
+        lr = const(self.lr, dtype)
+        momentum = const(self.momentum, dtype)
+        weight_decay = const(self.weight_decay, dtype)
+        dampening_inv = const(_high_precision_subtract(1, self.dampening), dtype)
+        one = const(1, "int64")
+
+        builder = BlockBuilder()
+        with builder.function(self.name, [param_var, grad_var, state_var]):
+            with builder.dataflow():
+                param_list_new, state_list_new = [], []
+
+                # handle num_steps
+                num_steps = builder.emit(TupleGetItem(state_var, 0), "num_steps")
+                num_steps_new = builder.emit(add(num_steps, one), "num_steps_new")
+                state_list_new.append(num_steps_new)
+
+                # computation logics
+                for i in range(len_param):
+                    name = self.param_list[i].name_hint
+                    p = builder.emit(TupleGetItem(param_var, i), name)
+                    g = builder.emit(TupleGetItem(grad_var, i), name + "_grad")
+                    v = builder.emit(TupleGetItem(state_var, i + 1), name + "_v")
+                    if self.weight_decay:
+                        g = builder.emit(add(multiply(weight_decay, p), g), name + "_grad_new")
+                    damp_g = multiply(dampening_inv, g) if self.dampening else g
+                    v_new = builder.emit(add(multiply(momentum, v), damp_g), name + "_v_new")
+                    g_new = (
+                        builder.emit(add(g, multiply(momentum, v_new)), name + "_g_nest")
+                        if self.nesterov
+                        else v_new
+                    )
+                    p_new = builder.emit(subtract(p, multiply(lr, g_new)), name + "_new")
+                    param_list_new.append(p_new)
+                    state_list_new.append(v_new)
+
+                # handle return values
+                params_new = builder.emit_output(RxTuple(param_list_new), "params_new")
+                optim_states_new = builder.emit_output(RxTuple(state_list_new), "optim_states_new")
+            builder.emit_func_output((params_new, optim_states_new))
+        return builder.get()[self.name]
+
+
+class Adam(Optimizer):
+    """Implements Adam optimization algorithm.
+
+    The returned function of `get_function()` is equivalent to the following numpy code:
+
+    .. code-block:: python
+        def Adam(param_tuple, grad_tuple, state_tuple):
+            num_steps = state_tuple[0]
+            num_steps_new = num_steps + 1
+
+            param_tuple_new = []
+            state_tuple_new = [None] * len(state_tuple)
+            state_tuple_new[0] = num_steps_new
+            state_tuple_new[1] = state_tuple[1] * betas[0]
+            state_tuple_new[2] = state_tuple[2] * betas[1]
+
+            for i in range(len(param_tuple)):
+                param = param_tuple[i]
+                grad = grad_tuple[i]
+                m = state_tuple[i + 3]
+                v = state_tuple[i + 3 + len(param_tuple)]
+                grad = grad + weight_decay * param
+                m = betas[0] * m + (1 - betas[0]) * grad
+                v = betas[1] * v + (1 - betas[1]) * grad * grad
+                m_hat = m / (1 - betas[0] ** num_steps_new)
+                v_hat = v / (1 - betas[1] ** num_steps_new)
+                param = param - lr * m_hat / (np.sqrt(v_hat) + eps)
+                param_tuple_new.append(param)
+                state_tuple_new[i + 3] = m
+                state_tuple_new[i + 3 + len(param_tuple)] = v
+
+            return param_tuple_new, state_tuple_new
+
+    Parameters
+    ----------
+    lr : float
+        learning rate
+
+    betas : Tuple[float, float]
+        coefficients used for computing running averages of gradient and its square
+        (default: (0.9, 0.999))
+
+    eps : float
+        term added to the denominator to improve numerical stability (default: 1e-8)
+
+    weight_decay : float
+        weight decay (L2 penalty) (default: 0)
+    """
+
+    def __init__(
+        self,
+        lr: float,
+        betas: Tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-08,
+        weight_decay: float = 0,
+    ) -> None:
+        super().__init__("Adam")
+        self.lr = float(lr)
+        self.beta1 = float(betas[0])
+        self.beta2 = float(betas[1])
+        self.eps = float(eps)
+        self.weight_decay = float(weight_decay)
+
+    def init(self, params: Union[Var, List[Var]]) -> "Adam":
+        """Set the parameters, determine the dtype, and construct the initial state for the
+        optimizer.
+
+        The state of Adam is
+
+        .. code-block:: python
+            (
+                num_steps,
+                beta_0_prod, # beta0 ** num_steps
+                beta_1_prod, # beta1 ** num_steps
+                first_momentum_of_param_0, ..., first_momentum_of_param_n-1,
+                second_momentum_of_param_0, ..., second_momentum_of_param_n-1
+            )
+
+        Parameters
+        ----------
+        params : Union[Var, List[Var]]
+            The parameter or the list of parameters to optimize.
+
+            Parameters should all be Vars of floating point Tensors, including float32, float64,
+            float16, etc. Currently, all parameters should have the same dtype, and that dtype
+            will be used as the dtype of the optimizer states.
+
+        Returns
+        -------
+        self : Adam
+            The Adam optimizer itself.
+        """
+        if not isinstance(params, list):
+            params = [params]
+        self._set_params_and_dtype(params)
+        self.state = (
+            # num_steps, beta_0_prod, beta_1_prod
+            tvm.nd.array(np.zeros((), "int64")),
+            tvm.nd.array(np.ones((), self.dtype)),
+            tvm.nd.array(np.ones((), self.dtype)),
+            # first_momentum
+            *(
+                tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
+                for p in self.param_list
+            ),
+            # second_momentum
+            *(
+                tvm.nd.array(np.zeros(_get_shape_as_int_list(p), p.struct_info.dtype))
+                for p in self.param_list
+            ),
+        )
+        return self
+
+    def get_function(self) -> Function:
+        """Use blockbuilder to construct an optimizer function that executes updates of the
+        parameters and the optimizer state. `init()` should be called before `get_function()`.
+
+        Returns
+        -------
+        func : Function
+            The optimizer function.
+        """
+        self._check_init()
+        plist = self.param_list
+        len_param = len(plist)
+        dtype = self.dtype
+
+        # input variables
+        param_var = Var("params", TupleStructInfo([p.struct_info for p in plist]))
+        grad_var = Var("gradients", TupleStructInfo([p.struct_info for p in plist]))
+        state_var = Var(
+            "optim_states",
+            TupleStructInfo(
+                [
+                    TensorStructInfo((), "int64"),
+                    TensorStructInfo((), dtype),
+                    TensorStructInfo((), dtype),
+                    *(p.struct_info for p in plist),
+                    *(p.struct_info for p in plist),
+                ]
+            ),
+        )
+
+        # constants
+        lr = const(self.lr, dtype)
+        beta1 = const(self.beta1, dtype)
+        beta2 = const(self.beta2, dtype)
+        beta1_inv = const(_high_precision_subtract(1, self.beta1), dtype)
+        beta2_inv = const(_high_precision_subtract(1, self.beta2), dtype)
+        eps = const(self.eps, dtype)
+        weight_decay = const(self.weight_decay, dtype)
+        one_int = const(1, "int64")
+        one_float = const(1, dtype)
+
+        builder = BlockBuilder()
+        with builder.function(self.name, [param_var, grad_var, state_var]):
+            with builder.dataflow():
+                param_list_new = []
+                state_list_new = [None] * (len_param * 2 + 3)  # type: List[Optional[Var]]
+
+                # handle num_steps
+                num_steps = builder.emit(TupleGetItem(state_var, 0), "num_steps")
+                num_steps_new = builder.emit(add(num_steps, one_int), "num_steps_new")
+                state_list_new[0] = num_steps_new
+                beta1_prod = builder.emit(multiply(TupleGetItem(state_var, 1), beta1), "beta1_prod")
+                beta2_prod = builder.emit(multiply(TupleGetItem(state_var, 2), beta2), "beta2_prod")
+                state_list_new[1] = beta1_prod
+                state_list_new[2] = beta2_prod
+
+                # computation logics
+                for i in range(len_param):
+                    name = self.param_list[i].name_hint
+                    p = builder.emit(TupleGetItem(param_var, i), name)
+                    g = builder.emit(TupleGetItem(grad_var, i), name + "_grad")
+                    m = builder.emit(TupleGetItem(state_var, i + 3), name + "_m")
+                    v = builder.emit(TupleGetItem(state_var, i + 3 + len_param), name + "_v")
+                    if self.weight_decay:
+                        g = builder.emit(add(multiply(weight_decay, p), g), name + "_grad_new")
+                    m_new = builder.emit(
+                        add(multiply(beta1, m), multiply(beta1_inv, g)), name + "_m_new"
+                    )
+                    v_new = builder.emit(
+                        add(multiply(beta2, v), multiply(beta2_inv, multiply(g, g))),
+                        name + "_v_new",
+                    )
+                    m_hat = builder.emit(
+                        divide(m_new, subtract(one_float, state_list_new[1])), name + "_m_hat"
+                    )
+                    v_hat = builder.emit(
+                        divide(v_new, subtract(one_float, state_list_new[2])), name + "_v_hat"
+                    )
+                    p_new = builder.emit(
+                        subtract(p, multiply(lr, divide(m_hat, add(sqrt(v_hat), eps)))),
+                        name + "_new",
+                    )
+                    param_list_new.append(p_new)
+                    state_list_new[i + 3] = m_new
+                    state_list_new[i + 3 + len_param] = v_new
+
+                # handle return values
+                params_new = builder.emit_output(RxTuple(param_list_new), "params_new")
+                optim_states_new = builder.emit_output(RxTuple(state_list_new), "optim_states_new")
+            builder.emit_func_output((params_new, optim_states_new))
+        return builder.get()[self.name]

--- a/python/tvm/relax/training/optimizer.py
+++ b/python/tvm/relax/training/optimizer.py
@@ -85,8 +85,8 @@ class Optimizer:
 
         # Legalize and build mod
         lowered_mod = LegalizeOps()(mod)
-        ex = relax.vm.build(lowered_mod, target="llvm")
-        vm = relax.VirtualMachine(ex, tvm.cpu())
+        ex = build(lowered_mod, target="llvm")
+        vm = VirtualMachine(ex, tvm.cpu())
 
         # Optimization process
         # param_tuple is a runtime tuple of parameters

--- a/python/tvm/relax/training/setup_trainer.py
+++ b/python/tvm/relax/training/setup_trainer.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=not-callable, unused-argument
+"""Setup Trainer Pass."""
+from typing import List
+
+import tvm
+from tvm.ir.module import IRModule
+
+from ..transform import LegalizeOps, Gradient
+from .loss import Loss
+from .utils import append_loss
+from .optimizer import Optimizer
+from ..struct_info import TensorStructInfo
+from ..analysis import well_formed
+
+
+@tvm.transform.module_pass(opt_level=0, name="SetupTrainer")
+class SetupTrainer:
+    """Transform a NN backbone module to a complete, legalized trainer module.
+
+    The transformed module will contains the following functions:
+    - `predict`: Predicts the result. It is provided in the input module.
+    - `loss`: Calculates the specified loss between the prediction results and the ground truth.
+    - `loss_adjoint`: Calculates the loss and the adjoints of parameters.
+    - `update_params`: Takes the parameters, the adjoints of parameters and the optimizer state as
+    the inputs and returns updated parameters and new optimizer state. It contains a func attr named
+    `optim_state` which is the initial state of the specified optimizer.
+
+    Parameters
+    ----------
+    loss : Loss
+        The loss function. It will be appended to the backbone function using
+        relax.training.utils.append_loss.
+
+    optimizer : Optimizer
+        The optimizer. It will be put as the `update_params` function of the transformed module. The
+        initial state will be put in the func attr `optim_state` of this function.
+
+    loss_args : List[TensorStructInfo]
+        The arguments to call the loss function.
+
+    Notes
+    -----
+    This transform requires the input module to have the following properties:
+    - The module should contain a function named `predict`.
+    - This prediction function should only return a single Tensor which is the prediction
+    result of the backbone.
+    - This prediction function should have a func attr `params_num`, which indicates that
+    the first `params_num` inputs are the parameters (which will be gradiented and trained)
+    of the NN module.
+    """
+
+    PREDICT_FUNC_NAME: str = "predict"
+    LOSS_FUNC_NAME: str = "loss"
+    ADJOINT_FUNC_NAME: str = "loss_adjoint"
+    UPDATE_PARAMS_FUNC_NAME: str = "update_params"
+
+    PARAMS_NUM_ATTR_KEY: str = "params_num"
+    OPTIM_STATE_ATTR_KEY: str = "optim_state"
+
+    def __init__(self, loss: Loss, optimizer: Optimizer, loss_args: List[TensorStructInfo]):
+        self._loss = loss
+        self._optimizer = optimizer
+        self._loss_args = loss_args
+
+    @classmethod
+    def _check_backbone_validity(cls, mod: IRModule):
+        if not well_formed(mod):
+            raise ValueError("Backbone Invalid: The backbone is not well formed.")
+        ret_sinfo = mod[cls.PREDICT_FUNC_NAME].struct_info.ret
+        if not isinstance(ret_sinfo, TensorStructInfo):
+            raise ValueError(
+                "Backbone Invalid: The predict function is expected to have a single Tensor "
+                "return value, which serves as the prediction result of the module. But got ",
+                ret_sinfo,
+            )
+
+    def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
+        """Setup the trainer in 3 steps.
+        1. Prepare Loss.
+        2. Gradient pass.
+        3. Add Optimizer function.
+        4. Legalize operators.
+        """
+
+        self._check_backbone_validity(mod)
+        # Step 1: Prepare Loss.
+        predict_with_loss = append_loss(
+            mod[self.PREDICT_FUNC_NAME],
+            self._loss(*self._loss_args),  # type: ignore
+        )
+        mod[self.LOSS_FUNC_NAME] = predict_with_loss
+
+        # Step 2: Gradient pass.
+        params_num = int(mod[self.PREDICT_FUNC_NAME].attrs[self.PARAMS_NUM_ATTR_KEY])
+        require_grads = mod[self.LOSS_FUNC_NAME].params[:params_num]
+        mod = Gradient(self.LOSS_FUNC_NAME, require_grads=require_grads)(mod)
+
+        # Step 3: Build Optimizer.
+        self._optimizer.init(list(mod[self.ADJOINT_FUNC_NAME].params)[:params_num])
+        mod[self.UPDATE_PARAMS_FUNC_NAME] = self._optimizer.get_function().with_attr(
+            self.OPTIM_STATE_ATTR_KEY, self._optimizer.state
+        )
+
+        # Step 4: Legalize operators.
+        return LegalizeOps()(mod)  # type: ignore

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -1,0 +1,256 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Unified Trainer API for relax training."""
+
+from typing import Union, List, Optional, Dict
+import numpy as np  # type: ignore
+
+import tvm
+from tvm import TVMError
+from tvm.ir.module import IRModule
+from tvm.runtime.ndarray import NDArray
+
+from .setup_trainer import SetupTrainer
+from ..vm import VirtualMachine, build
+
+
+class Trainer:
+    r"""Unified wrapper for relax training. It uses SetupTrainer to setup the backbone and
+    then compiles/builds/runs the module. Also it maintains the parameters internally.
+
+    Parameters
+    ----------
+    backbone : IRModule
+        Backbone of the module to be trained. It should be a relax module with a function
+        which has name `predict` and returns a single Tensor.
+
+    params_num : int,
+        The numer of parameters. The first `params_num` inputs of the prediction function
+        will be regarded as the parameters. It will be annotated into the prediction function
+        as the value of func attr `update_params`.
+
+    setup_trainer_pass : SetupTrainer
+        The configured SetupTrainer pass.
+
+    Examples
+    --------
+    >>> setup_trainer = setup_trainer = SetupTrainer(
+    ...     MSELoss(reduction="sum"),
+    ...     SGD(0.001),
+    ...     [pred_sinfo, pred_sinfo],
+    ... )
+
+    >>> trainer = Trainer(MLP, 2, setup_trainer)
+    >>> trainer.build(target="llvm")
+    >>> trainer.xaiver_uniform_init_params()
+    >>> trainer.predict(*predict_inputs)
+    >>> trainer.update_params(*update_params_inputs)
+
+    Notes
+    -----
+    The user should first build it then execute it.
+    """
+
+    def __init__(
+        self,
+        backbone: IRModule,
+        params_num: int,
+        setup_trainer_pass: SetupTrainer,
+    ) -> None:
+        # Function Names
+        self._predict_fn = setup_trainer_pass.PREDICT_FUNC_NAME
+        self._adjoint_fn = setup_trainer_pass.ADJOINT_FUNC_NAME
+        self._update_params_fn = setup_trainer_pass.UPDATE_PARAMS_FUNC_NAME
+
+        # Compile & Build
+        backbone[self._predict_fn] = backbone[self._predict_fn].with_attr(
+            setup_trainer_pass.PARAMS_NUM_ATTR_KEY, params_num
+        )
+        self._mod = setup_trainer_pass(backbone)  # type: ignore
+        self._vm: Optional[VirtualMachine] = None
+        self._optim_state = self._mod[self._update_params_fn].attrs[
+            setup_trainer_pass.OPTIM_STATE_ATTR_KEY
+        ]
+
+        # Allocate Parameters
+        self._parameters_buffer: List[NDArray] = []
+        self._parameters_name_to_pos: Dict[str, int] = {}
+
+        def _convert_from_tvm_shape(tvm_shape):
+            return [int(dim) for dim in tvm_shape]
+
+        self._parameters_buffer = []
+        for i, param in enumerate(self._mod[setup_trainer_pass.ADJOINT_FUNC_NAME].params):
+            if i < params_num:
+                self._parameters_buffer.append(
+                    tvm.nd.array(
+                        np.zeros(
+                            shape=_convert_from_tvm_shape(param.struct_info.shape),
+                            dtype=np.dtype(param.struct_info.dtype),
+                        )
+                    )
+                )
+                self._parameters_name_to_pos[param.name_hint] = i
+
+    def build(
+        self,
+        target: Union[str, tvm.target.Target],
+        device: Union[tvm.runtime.Device, List[tvm.runtime.Device]] = tvm.cpu(0),
+        memory_cfg: Optional[str] = None,
+    ):
+        """Build and compile the module.
+
+        Parameters
+        ----------
+        target : Union[str, tvm.target.Target]
+            The target to run all modules on.
+
+        device : Union[Device, List[Device]]
+            The device, or devices on which to execute the VM code.
+
+        memory_cfg : Optional[str]
+            The allocator behavior to use for the VM.
+        """
+        ex = build(self._mod, target=target)
+        self._vm = VirtualMachine(ex, device=device, memory_cfg=memory_cfg)
+
+    def _check_build(self):
+        if self._vm is None:
+            raise TVMError("Please build the trainer first. Use `trainer.build(...)`.")
+
+    @property
+    def mod(self) -> IRModule:
+        """Return the IRModule transformed by the setup trainer pass.
+
+        Returns
+        -------
+        ret : IRModule
+            The IRModule transformed by the setup trainer pass.
+        """
+        return self._mod
+
+    @property
+    def vm(self) -> VirtualMachine:
+        """Return the relax virtual machine of the module. Should first build the trainer.
+
+        Returns
+        -------
+        ret : VirtualMachine
+            The relax virtual machine.
+        """
+        self._check_build()
+        return self._vm
+
+    def xaiver_uniform_init_params(self):
+        """Randomly initialize parameters using the method described in `Understanding the
+        difficulty of training deep feedforward neural networks` - Glorot, X. & Bengio, Y.
+        (2010)."""
+        self._parameters_buffer = [
+            tvm.nd.array(
+                np.sqrt(6.0 / np.sum(v.shape))
+                * np.random.uniform(-1.0, 1.0, v.shape).astype(np.dtype(v.dtype))
+            )
+            for v in self._parameters_buffer
+        ]
+
+    def load_params(self, extern_param_dict: Dict[str, Union[np.ndarray, NDArray]]):
+        """Load parameters from a dict.
+        The key of the dict should be the same with the parameter name in backbone.
+
+        Parameters
+        ----------
+        extern_param_dict : Dict[str, Union[np.ndarray, NDArray]]
+            The external parameters dict: param_name -> param_value. The param name should
+            be the same as the name hint of corresponding relax Var.
+        """
+        for key, val in extern_param_dict.items():
+            self._parameters_buffer[self._parameters_name_to_pos[key]] = tvm.nd.array(val)
+
+    def export_params(self) -> Dict[str, NDArray]:
+        """Export parameters to a dict (parameter name -> NDArray).
+
+        Returns
+        -------
+        exported_dict : Dict[str, NDArray]
+            The exported dictionary of parameters.
+        """
+        ret: Dict[str, NDArray] = {}
+        for key, pos in self._parameters_name_to_pos.items():
+            ret[key] = self._parameters_buffer[pos]
+        return ret
+
+    def _prepare_inputs(self, func_name, inputs):
+        input_len = len(self._mod[func_name].params)
+        param_len = len(self._parameters_buffer)
+        assert len(inputs) + param_len == input_len
+        to_vm = []
+        for i in range(param_len):
+            to_vm.append(self._parameters_buffer[i])
+        for i in range(input_len - param_len):
+            to_vm.append(tvm.nd.array(inputs[i]))
+        return to_vm
+
+    def predict(self, *inputs: Union[np.ndarray, NDArray]) -> NDArray:
+        """Call the `predict` function and return the prediction result of the backbone.
+
+        Parameters
+        ----------
+        *inputs : Union[np.ndarray, NDArray]
+            The necessary inputs of the module.
+
+        Returns
+        -------
+        output : NDArray
+            The output result of the forward process. Only support single return value now.
+
+        Notes
+        -----
+        You don't need to provide parameters of the module in `inputs`. Instead, the trainer
+        will maintain them interally. The inputs should be given in the order of the function
+        argument list with skipping all parameters.
+        """
+        self._check_build()
+        return self._vm[self._predict_fn](*self._prepare_inputs(self._predict_fn, inputs))
+
+    def update_params(self, *inputs: Union[np.ndarray, NDArray]) -> NDArray:
+        """Calculate loss and update parameters. It will calculate the gradients of parameters
+        and update them using `update_params` function.
+
+        Parameters
+        ----------
+        *inputs : Union[np.ndarray, NDArray]
+            The necessary inputs of the module.
+
+        Returns
+        -------
+        loss : NDArray
+            The loss stored in Numpy array.
+
+        Notes
+        -----
+        You don't need to provide parameters of the module in `inputs`. Instead, the trainer
+        will maintain them interally. The inputs should be given in the order of the function
+        argument list with skipping all parameters.
+        """
+        self._check_build()
+        loss, grads = self._vm[self._adjoint_fn](*self._prepare_inputs(self._adjoint_fn, inputs))
+        new_params, self._optim_state = self._vm[self._update_params_fn](
+            self._parameters_buffer, grads, self._optim_state
+        )
+        self._parameters_buffer = [new_params[i] for i in range(len(new_params))]
+        return loss

--- a/python/tvm/relax/training/trainer.py
+++ b/python/tvm/relax/training/trainer.py
@@ -23,10 +23,11 @@ import numpy as np  # type: ignore
 import tvm
 from tvm import TVMError
 from tvm.ir.module import IRModule
+from tvm.runtime.relax_vm import VirtualMachine
 from tvm.runtime.ndarray import NDArray
 
 from .setup_trainer import SetupTrainer
-from ..vm import VirtualMachine, build
+from ..vm_build import build
 
 
 class Trainer:

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utility functions for relax training."""
+
+from ..expr import Function
+from . import _ffi_api
+
+
+def append_loss(orig_func: Function, loss_func: Function) -> Function:
+    """Local helper to append a specified loss function after the original function.
+
+    In detail, the result function has the arguments list of orig_func and the combination
+    of their body, which passes the return values of orig_func as the arguments of loss_func. For
+    those arguments of loss_func which are not mapped to some return values, they will be lifted
+    and appended to the argument list of result function.
+
+    Parameters
+    ----------
+    orig_func : Function
+        The function to be appended to.
+
+    loss_func : Function
+        The loss function.
+
+    Returns
+    -------
+    ret : Function
+        The result function.
+
+    Examples
+    --------
+    >>> @R.function
+    ... def orig(x: R.Tensor((2, 4), "float32"), y: R.Tensor((2, 4), "float32")):
+    ...     with R.dataflow():
+    ...         out = R.add(x, y)
+    ...         R.output(out)
+    ...     return out
+
+    >>> @R.function
+    ... def loss(predictions: R.Tensor((2, 4), "float32"), labels: R.Tensor((2, 4), "float32")):
+    ...     with R.dataflow():
+    ...         lv = R.subtract(predictions, labels)
+    ...         lv1 = R.multiply(lv, lv)
+    ...         gv = R.sum(lv1)
+    ...         R.output(gv)
+    ...     return gv
+
+    >>> expected = append_loss(orig, loss)
+    >>> print(expected)
+
+    Will get
+
+    >>> @R.function
+    ... def expected(x: R.Tensor((2, 4), "float32"), y: R.Tensor((2, 4), "float32"),
+    ...             labels: R.Tensor((2, 4), "float32")) -> R.Tensor((), "float32"):
+    ...     with R.dataflow():
+    ...         out: R.Tensor((2, 4), "float32") = R.add(x, y)
+    ...         lv: R.Tensor((2, 4), "float32") = R.subtract(out, labels)
+    ...         lv1: R.Tensor((2, 4), "float32") = R.multiply(lv, lv)
+    ...         gv: R.Tensor((), "float32") = R.sum(lv1)
+    ...         R.output(gv)
+    ...     return gv
+
+    Notes
+    -----
+    1. This util is dedicated to loss functions, not for general purposes.
+    2. This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in
+    some sense.
+    """
+    return _ffi_api.AppendLoss(orig_func, loss_func)  # type: ignore

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -899,9 +899,10 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderEndBlock")
 TVM_REGISTER_GLOBAL("relax.BlockBuilderNormalize")
     .set_body_method<BlockBuilder>(&BlockBuilderNode::Normalize);
 
-TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit").set_body_typed([](BlockBuilder builder, Expr expr) {
-  return builder->Emit(expr);
-});
+TVM_REGISTER_GLOBAL("relax.BlockBuilderEmit")
+    .set_body_typed([](BlockBuilder builder, Expr expr, String name_hint) {
+      return builder->Emit(expr, name_hint);
+    });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchCast")
     .set_body_typed([](BlockBuilder builder, Expr value, StructInfo struct_info) {
@@ -909,8 +910,8 @@ TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitMatchCast")
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitOutput")
-    .set_body_typed([](BlockBuilder builder, const Expr& output) {
-      return builder->EmitOutput(output);
+    .set_body_typed([](BlockBuilder builder, const Expr& output, String name_hint) {
+      return builder->EmitOutput(output, name_hint);
     });
 
 TVM_REGISTER_GLOBAL("relax.BlockBuilderEmitNormalized")

--- a/src/relax/training/utils.cc
+++ b/src/relax/training/utils.cc
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "utils.h"
+
+namespace tvm {
+namespace relax {
+
+/*! \brief Helper to implement append loss.*/
+class AppendLossMutator : public ExprMutator {
+ public:
+  explicit AppendLossMutator(const SeqExpr& loss_body) : loss_body_(loss_body) {}
+
+  Expr VisitExpr_(const SeqExprNode* seq_expr) final {
+    // mutate only the last block.
+    Array<BindingBlock> blocks;
+    for (int i = 0; i < static_cast<int>(seq_expr->blocks.size()); ++i) {
+      CHECK(seq_expr->blocks[i].as<DataflowBlockNode>())
+          << "All blocks in original functions should be Dataflow Block.";
+      if (i < static_cast<int>(seq_expr->blocks.size()) - 1) {
+        blocks.push_back(seq_expr->blocks[i]);
+      } else {
+        BindingBlock new_block = this->VisitBindingBlock(seq_expr->blocks[i]);
+        if (!new_block->bindings.empty()) {
+          blocks.push_back(new_block);
+        }
+      }
+    }
+    return SeqExpr(blocks, loss_body_->body);
+  }
+
+  BindingBlock VisitBindingBlock_(const DataflowBlockNode* block) final {
+    builder_->BeginDataflowBlock();
+    // emit original bindings.
+    for (const auto& binding : block->bindings) {
+      this->VisitBinding(binding);
+    }
+
+    ICHECK(orig_rets_var_.size() == orig_rets.size());
+    for (int i = 0; i < static_cast<int>(orig_rets_var_.size()); ++i) {
+      if (orig_rets_var_[i].defined()) {
+        builder_->EmitNormalized(VarBinding(orig_rets_var_[i].value(), orig_rets[i]));
+      }
+    }
+
+    // emit blocks for loss function part.
+    for (const BindingBlock& block : loss_body_->blocks) {
+      CHECK(block.as<DataflowBlockNode>())
+          << "All blocks in loss functions should be Dataflow Block.";
+      for (const Binding& binding : block->bindings) {
+        this->VisitBinding(binding);
+      }
+    }
+
+    return builder_->EndBlock();
+  }
+
+  // Remap the def site var using VisitExpr.
+  Var VisitVarDef(const Var& var) final { return Downcast<Var>(this->VisitExpr(var)); }
+
+  // Remap original dataflow var.
+  // TODO(chaofan): a better way to check whether new_ret_var should be dataflow
+  void RemapToDataflow(SeqExpr body) {
+    const auto& block = body->blocks.back();
+    for (const Binding& binding : block->bindings) {
+      const auto* binding_node = binding.as<VarBindingNode>();
+      if (binding_node && !binding_node->var->IsInstance<DataflowVarNode>()) {
+        Var new_binding_var = DataflowVar(binding_node->var->vid, GetStructInfo(binding_node->var),
+                                          binding_node->var->span);
+        this->var_remap_[binding_node->var->vid] = new_binding_var;
+      }
+    }
+  }
+
+  Array<Var> RemapLossParams(const Array<Var>& loss_func_params, Array<Var> new_params) {
+    for (int i = 0; i < static_cast<int>(loss_func_params.size()); ++i) {
+      Var loss_param = loss_func_params[i];
+      auto loss_param_sinfo = GetStructInfo(loss_param);
+
+      if (i < static_cast<int>(orig_rets.size())) {  // map return value to loss param
+        auto orig_ret_sinfo = GetStructInfo(orig_rets[i]);
+        ICHECK(structural_equal_(orig_ret_sinfo, loss_param_sinfo))
+            << "The struct info of the " << i
+            << "-th return value of orig func is: " << orig_ret_sinfo
+            << " while the corresponding struct info of parameter of loss function is "
+            << loss_param_sinfo << ", which is different.";
+
+        if (const auto* var_node = orig_rets[i].as<VarNode>()) {
+          ICHECK(orig_rets[i].as<DataflowVarNode>());
+          orig_rets_var_.push_back(NullOpt);
+          this->var_remap_[loss_param->vid] = GetRef<Var>(var_node);
+        } else {
+          Var new_ret_var = DataflowVar(/*name_hint=*/"ret_" + std::to_string(i), orig_ret_sinfo);
+          orig_rets_var_.push_back(new_ret_var);
+          this->var_remap_[loss_param->vid] = new_ret_var;
+        }
+      } else {  // append to the param list
+        Var new_loss_param = Var(loss_param->vid, loss_param_sinfo, loss_param->span);
+        this->var_remap_[loss_param->vid] = new_loss_param;
+        new_params.push_back(new_loss_param);
+      }
+    }
+    return new_params;
+  }
+
+  /*! \brief The original unpacked rets. */
+  Array<Expr> orig_rets;
+
+ private:
+  /*! \brief The body of the loss function */
+  SeqExpr loss_body_;
+  /*! \brief The var created for original rets. NullOpt if the original ret is already a var. */
+  Array<Optional<Var>> orig_rets_var_;
+  /*! \brief The structural equality checker */
+  StructuralEqual structural_equal_;
+};
+
+/*!
+ * \brief Local helper to append a specified loss function after the original function.
+ * \param orig_func The function to be appended to.
+ * \param loss_func The loss function.
+ * \return The result function after appended.
+ */
+Function AppendLoss(Function orig_func, Function loss_func) {
+  CHECK(orig_func->body->IsInstance<SeqExprNode>())
+      << "The body of the original function is expected to be a SeqExpr, but got"
+      << orig_func->body->GetTypeKey();
+  CHECK(loss_func->body->IsInstance<SeqExprNode>())
+      << "The body of the loss function is expected to be a SeqExpr, but got"
+      << loss_func->body->GetTypeKey();
+
+  Function param_copied_func = CopyWithNewVars(orig_func);
+  auto seq_expr = Downcast<SeqExpr>(param_copied_func->body);
+
+  AppendLossMutator mutator(Downcast<SeqExpr>(loss_func->body));
+  mutator.RemapToDataflow(seq_expr);
+  // Get the original rets. If it is a Tuple, unpack it.
+  if (orig_func->ret_struct_info.as<TupleStructInfoNode>()) {
+    const auto* tuple_node = seq_expr->body.as<TupleNode>();
+    ICHECK(tuple_node != nullptr);
+    for (const Expr& field : tuple_node->fields) {
+      mutator.orig_rets.push_back(mutator.VisitExpr(field));
+    }
+  } else {
+    mutator.orig_rets.push_back(mutator.VisitExpr(seq_expr->body));
+  }
+
+  CHECK(loss_func->params.size() >= mutator.orig_rets.size())
+      << "The number of return values of original functions should be greater than the number of "
+         "parameters of loss function. Got "
+      << mutator.orig_rets.size() << " > " << loss_func->params.size();
+
+  Array<Var> new_params = mutator.RemapLossParams(loss_func->params, param_copied_func->params);
+  Expr new_body = mutator.VisitExpr(seq_expr);
+  return Function(std::move(new_params), std::move(new_body), loss_func->ret_struct_info,
+                  param_copied_func->attrs);
+}
+
+TVM_REGISTER_GLOBAL("relax.training.AppendLoss").set_body_typed(AppendLoss);
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/training/utils.h
+++ b/src/relax/training/utils.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relax/training/utils.h
+ * \brief Utility classes and functions for relax training.
+ */
+#ifndef TVM_RELAX_TRAINING_UTILS_H_
+#define TVM_RELAX_TRAINING_UTILS_H_
+
+#include <tvm/relax/expr.h>
+#include <tvm/relax/expr_functor.h>
+
+#include <utility>
+
+namespace tvm {
+namespace relax {
+
+/*!
+ * \brief Local helper to append a specified loss function after the original function.
+ * \note
+ * 1. This uitl is dedicated to loss functions, not for general purposes.
+ * 2. This util can be replaced if we have Inline pass. It is equivalent to inline a tail call in
+ * some sense.
+ * \param orig_func The function to be appended to.
+ * \param loss_func The loss function.
+ * \return The result function after appended.
+ */
+Function AppendLoss(Function orig_func, Function loss_func);
+
+}  // namespace relax
+}  // namespace tvm
+
+#endif  // TVM_RELAX_TRAINING_UTILS_H_

--- a/tests/python/relax/test_training_loss.py
+++ b/tests/python/relax/test_training_loss.py
@@ -1,0 +1,206 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm.testing
+from tvm import relax
+from tvm.ir.base import assert_structural_equal
+from tvm.script import relax as R
+
+
+@R.function
+def forward(
+    x: R.Tensor((2, 4), "float32"),
+    w: R.Tensor((4, 4), "float32"),
+    b: R.Tensor((2, 4), "float32"),
+) -> R.Tensor((2, 4), "float32"):
+    with R.dataflow():
+        lv: R.Tensor((2, 4), "float32") = R.matmul(x, w)
+        out: R.Tensor((2, 4), "float32") = R.add(lv, b)
+        R.output(out)
+    return out
+
+
+def test_l1_loss():
+    N = 3
+    C = 5
+    predictions = relax.TensorStructInfo((N, C), "float32")
+    targets = relax.TensorStructInfo((N, C), "float32")
+    l1_loss = relax.training.loss.L1Loss()
+
+    @R.function
+    def expected(
+        predictions: R.Tensor((3, 5), "float32"), targets: R.Tensor((3, 5), "float32")
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((3, 5), "float32") = R.subtract(predictions, targets)
+            lv1: R.Tensor((3, 5), "float32") = R.abs(lv)
+            gv: R.Tensor((), "float32") = R.mean(lv1, axis=None, keepdims=False)
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(l1_loss(predictions, targets), expected)
+
+
+def test_l1_loss_append():
+    s = forward.ret_struct_info
+    l1_loss = relax.training.loss.L1Loss(reduction="sum")
+    forward_with_loss = relax.training.utils.append_loss(forward, l1_loss(s, s))
+
+    @R.function
+    def expected(
+        x: R.Tensor((2, 4), "float32"),
+        w: R.Tensor((4, 4), "float32"),
+        b: R.Tensor((2, 4), "float32"),
+        targets: R.Tensor((2, 4), "float32"),
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w, out_dtype="")
+            out: R.Tensor((2, 4), "float32") = R.add(lv, b)
+            lv1: R.Tensor((2, 4), "float32") = R.subtract(out, targets)
+            lv11: R.Tensor((2, 4), "float32") = R.abs(lv1)
+            gv: R.Tensor((), "float32") = R.sum(lv11, axis=None, keepdims=False)
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(forward_with_loss, expected)
+
+
+def test_mse_loss():
+    N = 3
+    C = 5
+    predictions = relax.TensorStructInfo((N, C), "float32")
+    targets = relax.TensorStructInfo((N, C), "float32")
+    mse_loss = relax.training.loss.MSELoss()
+
+    @R.function
+    def expected(
+        predictions: R.Tensor((3, 5), "float32"), targets: R.Tensor((3, 5), "float32")
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((3, 5), "float32") = R.subtract(predictions, targets)
+            lv1: R.Tensor((3, 5), "float32") = R.multiply(lv, lv)
+            gv: R.Tensor((), "float32") = R.mean(lv1, axis=None, keepdims=False)
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(mse_loss(predictions, targets), expected)
+
+
+def test_mse_loss_append():
+    s = forward.ret_struct_info
+    mse_loss = relax.training.loss.MSELoss(reduction="sum")
+    forward_with_loss = relax.training.utils.append_loss(forward, mse_loss(s, s))
+
+    @R.function
+    def expected(
+        x: R.Tensor((2, 4), "float32"),
+        w: R.Tensor((4, 4), "float32"),
+        b: R.Tensor((2, 4), "float32"),
+        targets: R.Tensor((2, 4), "float32"),
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w, out_dtype="")
+            out: R.Tensor((2, 4), "float32") = R.add(lv, b)
+            lv1: R.Tensor((2, 4), "float32") = R.subtract(out, targets)
+            lv11: R.Tensor((2, 4), "float32") = R.multiply(lv1, lv1)
+            gv: R.Tensor((), "float32") = R.sum(lv11, axis=None, keepdims=False)
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(forward_with_loss, expected)
+
+
+def test_cross_entropy_loss():
+    N = 3
+    C = 5
+    predictions = relax.TensorStructInfo((N, C), "float32")
+    targets = relax.TensorStructInfo((N,), "int64")
+    weights = relax.TensorStructInfo((C,), "float32")
+    cross_entropy_loss = relax.training.loss.CrossEntropyLoss(reduction="sum", ignore_index=1)
+
+    @R.function
+    def expected(
+        predictions: R.Tensor((3, 5), "float32"),
+        targets: R.Tensor((3,), "int64"),
+        weights: R.Tensor((5,), "float32"),
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((3, 5), "float32") = R.nn.log_softmax(predictions, axis=-1)
+            gv: R.Tensor((), "float32") = R.nn.nll_loss(
+                lv, targets, weights, reduction="sum", ignore_index=1
+            )
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(cross_entropy_loss(predictions, targets, weights), expected)
+
+
+def test_cross_entropy_loss_without_weights():
+    N = 3
+    C = 5
+    predictions = relax.TensorStructInfo((N, C), "float32")
+    targets = relax.TensorStructInfo((N,), "int64")
+    cross_entropy_loss = relax.training.loss.CrossEntropyLoss()
+
+    @R.function
+    def expected(
+        predictions: R.Tensor((3, 5), "float32"), targets: R.Tensor((3,), "int64")
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((3, 5), "float32") = R.nn.log_softmax(predictions, axis=-1)
+            gv: R.Tensor((), "float32") = R.nn.nll_loss(
+                lv, targets, reduction="mean", ignore_index=-100
+            )
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(cross_entropy_loss(predictions, targets), expected)
+
+
+def test_cross_entropy_loss_append():
+    s = forward.ret_struct_info
+    N = s.shape[0]
+    C = s.shape[1]
+    targets = relax.TensorStructInfo((N,), "int64")
+    weights = relax.TensorStructInfo((C,), "float32")
+    cross_entropy_loss = relax.training.loss.CrossEntropyLoss(reduction="sum", ignore_index=1)
+    forward_with_loss = relax.training.utils.append_loss(
+        forward, cross_entropy_loss(s, targets, weights)
+    )
+
+    @R.function
+    def expected(
+        x: R.Tensor((2, 4), "float32"),
+        w: R.Tensor((4, 4), "float32"),
+        b: R.Tensor((2, 4), "float32"),
+        targets: R.Tensor((2,), "int64"),
+        weights: R.Tensor((4,), "float32"),
+    ) -> R.Tensor((), "float32"):
+        with R.dataflow():
+            lv: R.Tensor((2, 4), "float32") = R.matmul(x, w, out_dtype="")
+            out: R.Tensor((2, 4), "float32") = R.add(lv, b)
+            lv1: R.Tensor((2, 4), "float32") = R.nn.log_softmax(out, axis=-1)
+            gv: R.Tensor((), "float32") = R.nn.nll_loss(
+                lv1, targets, weights, reduction="sum", ignore_index=1
+            )
+            R.output(gv)
+        return gv
+
+    assert_structural_equal(forward_with_loss, expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_training_optimizer.py
+++ b/tests/python/relax/test_training_optimizer.py
@@ -1,0 +1,594 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for relax optimizer APIs."""
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.ir.base import assert_structural_equal
+from tvm.relax.training.optimizer import SGD, MomentumSGD, Adam
+from tvm.script.parser import relax as R
+
+
+def test_optimizer_error():
+    x1 = relax.Var("x1", R.Tensor((3, 3), "float32"))
+    x2 = relax.Var("x2", R.Tensor((3, 3), "float64"))
+    x3 = relax.Var("x3", R.Tuple([R.Tensor((3, 3), "float32")]))
+    x4 = relax.Var("x4", R.Tensor((3, 3), "int64"))
+    x5 = relax.Tuple([x1])
+
+    # fine cases
+    SGD(0.01).init(x1)
+    SGD(0.01).init([x1])
+    assert SGD(0.01).init([x2]).dtype == "float64"
+
+    with pytest.raises(ValueError):
+        SGD(0.01).init([x1, x1])
+    with pytest.raises(ValueError):
+        SGD(0.01).init([x1, x2])
+    with pytest.raises(ValueError):
+        SGD(0.01).init(x3)
+    with pytest.raises(ValueError):
+        SGD(0.01).init(x4)
+    with pytest.raises(ValueError):
+        SGD(0.01).init(x5)
+    with pytest.raises(
+        RuntimeError,
+        match="Please call init\\(\\) for the optimizer before calling get_function\\(\\)",
+    ):
+        SGD(0.01).get_function()
+
+
+def test_sgd_simple():
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    sgd = SGD(0.01).init([x, y]).get_function()
+
+    @R.function
+    def sgd_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(R.Tensor((), "int64")),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(R.Tensor((), "int64")),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            lv: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), x_grad)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            lv1: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), y_grad)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv1)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(R.Tensor((), "int64")) = (num_steps_new,)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(sgd, sgd_expected)
+
+
+def test_sgd_complex():
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    sgd = SGD(0.01, 0.02).init([x, y]).get_function()
+
+    @R.function
+    def sgd_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(R.Tensor((), "int64")),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(R.Tensor((), "int64")),
+    ):
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            lv: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.02, "float32"), x)
+            x_grad_new: R.Tensor((3, 3), "float32") = R.add(lv, x_grad)
+            lv1: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), x_grad_new)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv1)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            lv2: R.Tensor((3,), "float32") = R.multiply(R.const(0.02, "float32"), y)
+            y_grad_new: R.Tensor((3,), "float32") = R.add(lv2, y_grad)
+            lv3: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), y_grad_new)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv3)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(R.Tensor((), "int64")) = (num_steps_new,)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(sgd, sgd_expected)
+
+
+def test_momentum_sgd_simple():
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    msgd = MomentumSGD(0.01, 0.9).init([x, y]).get_function()
+
+    @R.function
+    def msgd_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(
+            R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")
+        ),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            x_v: R.Tensor((3, 3), "float32") = optim_states[1]
+            lv: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.9, "float32"), x_v)
+            x_v_new: R.Tensor((3, 3), "float32") = R.add(lv, x_grad)
+            lv1: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), x_v_new)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv1)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            y_v: R.Tensor((3,), "float32") = optim_states[2]
+            lv2: R.Tensor((3,), "float32") = R.multiply(R.const(0.9, "float32"), y_v)
+            y_v_new: R.Tensor((3,), "float32") = R.add(lv2, y_grad)
+            lv3: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), y_v_new)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv3)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(
+                R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")
+            ) = (num_steps_new, x_v_new, y_v_new)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(msgd, msgd_expected)
+
+
+def test_momentum_sgd_complex():
+    lr, mom, damp, wd, nest = 0.01, 0.9, 0.85, 0.02, False
+
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    msgd = MomentumSGD(lr, mom, damp, wd, nest).init([x, y]).get_function()
+
+    @R.function
+    def msgd_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(
+            R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")
+        ),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            x_v: R.Tensor((3, 3), "float32") = optim_states[1]
+            lv: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.02, "float32"), x)
+            x_grad_new: R.Tensor((3, 3), "float32") = R.add(lv, x_grad)
+            lv1: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.9, "float32"), x_v)
+            lv2: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.15, "float32"), x_grad_new)
+            x_v_new: R.Tensor((3, 3), "float32") = R.add(lv1, lv2)
+            lv3: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), x_v_new)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv3)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            y_v: R.Tensor((3,), "float32") = optim_states[2]
+            lv4: R.Tensor((3,), "float32") = R.multiply(R.const(0.02, "float32"), y)
+            y_grad_new: R.Tensor((3,), "float32") = R.add(lv4, y_grad)
+            lv5: R.Tensor((3,), "float32") = R.multiply(R.const(0.9, "float32"), y_v)
+            lv6: R.Tensor((3,), "float32") = R.multiply(R.const(0.15, "float32"), y_grad_new)
+            y_v_new: R.Tensor((3,), "float32") = R.add(lv5, lv6)
+            lv7: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), y_v_new)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv7)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(
+                R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")
+            ) = (num_steps_new, x_v_new, y_v_new)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(msgd, msgd_expected)
+
+
+def test_momentum_sgd_nesterov():
+    lr, mom, damp, wd, nest = 0.01, 0.9, 0.85, 0.02, True
+
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    msgd = MomentumSGD(lr, mom, damp, wd, nest).init([x, y]).get_function()
+
+    @R.function
+    def msgd_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(
+            R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")
+        ),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            x_v: R.Tensor((3, 3), "float32") = optim_states[1]
+            lv: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.02, "float32"), x)
+            x_grad_new: R.Tensor((3, 3), "float32") = R.add(lv, x_grad)
+            lv1: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.9, "float32"), x_v)
+            lv2: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.15, "float32"), x_grad_new)
+            x_v_new: R.Tensor((3, 3), "float32") = R.add(lv1, lv2)
+            lv3: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.9, "float32"), x_v_new)
+            x_g_nest: R.Tensor((3, 3), "float32") = R.add(x_grad_new, lv3)
+            lv4: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), x_g_nest)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv4)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            y_v: R.Tensor((3,), "float32") = optim_states[2]
+            lv5: R.Tensor((3,), "float32") = R.multiply(R.const(0.02, "float32"), y)
+            y_grad_new: R.Tensor((3,), "float32") = R.add(lv5, y_grad)
+            lv6: R.Tensor((3,), "float32") = R.multiply(R.const(0.9, "float32"), y_v)
+            lv7: R.Tensor((3,), "float32") = R.multiply(R.const(0.15, "float32"), y_grad_new)
+            y_v_new: R.Tensor((3,), "float32") = R.add(lv6, lv7)
+            lv8: R.Tensor((3,), "float32") = R.multiply(R.const(0.9, "float32"), y_v_new)
+            y_g_nest: R.Tensor((3,), "float32") = R.add(y_grad_new, lv8)
+            lv9: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), y_g_nest)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv9)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(
+                R.Tensor((), "int64"), R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")
+            ) = (num_steps_new, x_v_new, y_v_new)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(msgd, msgd_expected)
+
+
+def test_adam_simple():
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    adam = Adam(0.01).init([x, y]).get_function()
+
+    @R.function
+    def adam_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(
+            R.Tensor((), "int64"),
+            R.Tensor((), "float32"),
+            R.Tensor((), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+        ),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(
+            R.Tensor((), "int64"),
+            R.Tensor((), "float32"),
+            R.Tensor((), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+        ),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            lv: R.Tensor((), "float32") = optim_states[1]
+            beta1_prod: R.Tensor((), "float32") = R.multiply(lv, R.const(0.9, "float32"))
+            lv1: R.Tensor((), "float32") = optim_states[2]
+            beta2_prod: R.Tensor((), "float32") = R.multiply(lv1, R.const(0.999, "float32"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            x_m: R.Tensor((3, 3), "float32") = optim_states[3]
+            x_v: R.Tensor((3, 3), "float32") = optim_states[5]
+            lv2: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.9, "float32"), x_m)
+            lv3: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.1, "float32"), x_grad)
+            x_m_new: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
+            lv4: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.999, "float32"), x_v)
+            lv5: R.Tensor((3, 3), "float32") = R.multiply(x_grad, x_grad)
+            lv6: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.001, "float32"), lv5)
+            x_v_new: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
+            lv7: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta1_prod)
+            x_m_hat: R.Tensor((3, 3), "float32") = R.divide(x_m_new, lv7)
+            lv8: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta2_prod)
+            x_v_hat: R.Tensor((3, 3), "float32") = R.divide(x_v_new, lv8)
+            lv9: R.Tensor((3, 3), "float32") = R.sqrt(x_v_hat)
+            lv10: R.Tensor((3, 3), "float32") = R.add(lv9, R.const(1e-08, "float32"))
+            lv11: R.Tensor((3, 3), "float32") = R.divide(x_m_hat, lv10)
+            lv12: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), lv11)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv12)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            y_m: R.Tensor((3,), "float32") = optim_states[4]
+            y_v: R.Tensor((3,), "float32") = optim_states[6]
+            lv13: R.Tensor((3,), "float32") = R.multiply(R.const(0.9, "float32"), y_m)
+            lv14: R.Tensor((3,), "float32") = R.multiply(R.const(0.1, "float32"), y_grad)
+            y_m_new: R.Tensor((3,), "float32") = R.add(lv13, lv14)
+            lv15: R.Tensor((3,), "float32") = R.multiply(R.const(0.999, "float32"), y_v)
+            lv16: R.Tensor((3,), "float32") = R.multiply(y_grad, y_grad)
+            lv17: R.Tensor((3,), "float32") = R.multiply(R.const(0.001, "float32"), lv16)
+            y_v_new: R.Tensor((3,), "float32") = R.add(lv15, lv17)
+            lv18: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta1_prod)
+            y_m_hat: R.Tensor((3,), "float32") = R.divide(y_m_new, lv18)
+            lv19: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta2_prod)
+            y_v_hat: R.Tensor((3,), "float32") = R.divide(y_v_new, lv19)
+            lv20: R.Tensor((3,), "float32") = R.sqrt(y_v_hat)
+            lv21: R.Tensor((3,), "float32") = R.add(lv20, R.const(1e-08, "float32"))
+            lv22: R.Tensor((3,), "float32") = R.divide(y_m_hat, lv21)
+            lv23: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), lv22)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv23)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(
+                R.Tensor((), "int64"),
+                R.Tensor((), "float32"),
+                R.Tensor((), "float32"),
+                R.Tensor((3, 3), "float32"),
+                R.Tensor((3,), "float32"),
+                R.Tensor((3, 3), "float32"),
+                R.Tensor((3,), "float32"),
+            ) = (num_steps_new, beta1_prod, beta2_prod, x_m_new, y_m_new, x_v_new, y_v_new)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(adam, adam_expected)
+
+
+def test_adam_complex():
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    adam = Adam(0.01, (0.8, 0.85), 1e-7, 0.1).init([x, y]).get_function()
+
+    @R.function
+    def adam_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        optim_states: R.Tuple(
+            R.Tensor((), "int64"),
+            R.Tensor((), "float32"),
+            R.Tensor((), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+        ),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")),
+        R.Tuple(
+            R.Tensor((), "int64"),
+            R.Tensor((), "float32"),
+            R.Tensor((), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+            R.Tensor((3, 3), "float32"),
+            R.Tensor((3,), "float32"),
+        ),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            lv: R.Tensor((), "float32") = optim_states[1]
+            beta1_prod: R.Tensor((), "float32") = R.multiply(lv, R.const(0.8, "float32"))
+            lv1: R.Tensor((), "float32") = optim_states[2]
+            beta2_prod: R.Tensor((), "float32") = R.multiply(lv1, R.const(0.85, "float32"))
+            x: R.Tensor((3, 3), "float32") = params[0]
+            x_grad: R.Tensor((3, 3), "float32") = gradients[0]
+            x_m: R.Tensor((3, 3), "float32") = optim_states[3]
+            x_v: R.Tensor((3, 3), "float32") = optim_states[5]
+            lv2: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.1, "float32"), x)
+            x_grad_new: R.Tensor((3, 3), "float32") = R.add(lv2, x_grad)
+            lv3: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.8, "float32"), x_m)
+            lv4: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.2, "float32"), x_grad_new)
+            x_m_new: R.Tensor((3, 3), "float32") = R.add(lv3, lv4)
+            lv5: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.85, "float32"), x_v)
+            lv6: R.Tensor((3, 3), "float32") = R.multiply(x_grad_new, x_grad_new)
+            lv7: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.15, "float32"), lv6)
+            x_v_new: R.Tensor((3, 3), "float32") = R.add(lv5, lv7)
+            lv8: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta1_prod)
+            x_m_hat: R.Tensor((3, 3), "float32") = R.divide(x_m_new, lv8)
+            lv9: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta2_prod)
+            x_v_hat: R.Tensor((3, 3), "float32") = R.divide(x_v_new, lv9)
+            lv10: R.Tensor((3, 3), "float32") = R.sqrt(x_v_hat)
+            lv11: R.Tensor((3, 3), "float32") = R.add(lv10, R.const(1e-07, "float32"))
+            lv12: R.Tensor((3, 3), "float32") = R.divide(x_m_hat, lv11)
+            lv13: R.Tensor((3, 3), "float32") = R.multiply(R.const(0.01, "float32"), lv12)
+            x_new: R.Tensor((3, 3), "float32") = R.subtract(x, lv13)
+            y: R.Tensor((3,), "float32") = params[1]
+            y_grad: R.Tensor((3,), "float32") = gradients[1]
+            y_m: R.Tensor((3,), "float32") = optim_states[4]
+            y_v: R.Tensor((3,), "float32") = optim_states[6]
+            lv14: R.Tensor((3,), "float32") = R.multiply(R.const(0.1, "float32"), y)
+            y_grad_new: R.Tensor((3,), "float32") = R.add(lv14, y_grad)
+            lv15: R.Tensor((3,), "float32") = R.multiply(R.const(0.8, "float32"), y_m)
+            lv16: R.Tensor((3,), "float32") = R.multiply(R.const(0.2, "float32"), y_grad_new)
+            y_m_new: R.Tensor((3,), "float32") = R.add(lv15, lv16)
+            lv17: R.Tensor((3,), "float32") = R.multiply(R.const(0.85, "float32"), y_v)
+            lv18: R.Tensor((3,), "float32") = R.multiply(y_grad_new, y_grad_new)
+            lv19: R.Tensor((3,), "float32") = R.multiply(R.const(0.15, "float32"), lv18)
+            y_v_new: R.Tensor((3,), "float32") = R.add(lv17, lv19)
+            lv20: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta1_prod)
+            y_m_hat: R.Tensor((3,), "float32") = R.divide(y_m_new, lv20)
+            lv21: R.Tensor((), "float32") = R.subtract(R.const(1, "float32"), beta2_prod)
+            y_v_hat: R.Tensor((3,), "float32") = R.divide(y_v_new, lv21)
+            lv22: R.Tensor((3,), "float32") = R.sqrt(y_v_hat)
+            lv23: R.Tensor((3,), "float32") = R.add(lv22, R.const(1e-07, "float32"))
+            lv24: R.Tensor((3,), "float32") = R.divide(y_m_hat, lv23)
+            lv25: R.Tensor((3,), "float32") = R.multiply(R.const(0.01, "float32"), lv24)
+            y_new: R.Tensor((3,), "float32") = R.subtract(y, lv25)
+            params_new: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3,), "float32")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(
+                R.Tensor((), "int64"),
+                R.Tensor((), "float32"),
+                R.Tensor((), "float32"),
+                R.Tensor((3, 3), "float32"),
+                R.Tensor((3,), "float32"),
+                R.Tensor((3, 3), "float32"),
+                R.Tensor((3,), "float32"),
+            ) = (num_steps_new, beta1_prod, beta2_prod, x_m_new, y_m_new, x_v_new, y_v_new)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(adam, adam_expected)
+
+
+def test_adam_float64():
+    x = relax.Var("x", R.Tensor((3, 3), "float64"))
+    y = relax.Var("y", R.Tensor((3,), "float64"))
+    adam = Adam(0.01, (0.8, 0.85), 1e-7, 0.1).init([x, y]).get_function()
+
+    @R.function
+    def adam_expected(
+        params: R.Tuple(R.Tensor((3, 3), "float64"), R.Tensor((3,), "float64")),
+        gradients: R.Tuple(R.Tensor((3, 3), "float64"), R.Tensor((3,), "float64")),
+        optim_states: R.Tuple(
+            R.Tensor((), "int64"),
+            R.Tensor((), "float64"),
+            R.Tensor((), "float64"),
+            R.Tensor((3, 3), "float64"),
+            R.Tensor((3,), "float64"),
+            R.Tensor((3, 3), "float64"),
+            R.Tensor((3,), "float64"),
+        ),
+    ) -> R.Tuple(
+        R.Tuple(R.Tensor((3, 3), "float64"), R.Tensor((3,), "float64")),
+        R.Tuple(
+            R.Tensor((), "int64"),
+            R.Tensor((), "float64"),
+            R.Tensor((), "float64"),
+            R.Tensor((3, 3), "float64"),
+            R.Tensor((3,), "float64"),
+            R.Tensor((3, 3), "float64"),
+            R.Tensor((3,), "float64"),
+        ),
+    ):
+        # block 0
+        with R.dataflow():
+            num_steps: R.Tensor((), "int64") = optim_states[0]
+            num_steps_new: R.Tensor((), "int64") = R.add(num_steps, R.const(1, "int64"))
+            lv: R.Tensor((), "float64") = optim_states[1]
+            beta1_prod: R.Tensor((), "float64") = R.multiply(lv, R.const(0.8, "float64"))
+            lv1: R.Tensor((), "float64") = optim_states[2]
+            beta2_prod: R.Tensor((), "float64") = R.multiply(lv1, R.const(0.85, "float64"))
+            x: R.Tensor((3, 3), "float64") = params[0]
+            x_grad: R.Tensor((3, 3), "float64") = gradients[0]
+            x_m: R.Tensor((3, 3), "float64") = optim_states[3]
+            x_v: R.Tensor((3, 3), "float64") = optim_states[5]
+            lv2: R.Tensor((3, 3), "float64") = R.multiply(R.const(0.1, "float64"), x)
+            x_grad_new: R.Tensor((3, 3), "float64") = R.add(lv2, x_grad)
+            lv3: R.Tensor((3, 3), "float64") = R.multiply(R.const(0.8, "float64"), x_m)
+            lv4: R.Tensor((3, 3), "float64") = R.multiply(R.const(0.2, "float64"), x_grad_new)
+            x_m_new: R.Tensor((3, 3), "float64") = R.add(lv3, lv4)
+            lv5: R.Tensor((3, 3), "float64") = R.multiply(R.const(0.85, "float64"), x_v)
+            lv6: R.Tensor((3, 3), "float64") = R.multiply(x_grad_new, x_grad_new)
+            lv7: R.Tensor((3, 3), "float64") = R.multiply(R.const(0.15, "float64"), lv6)
+            x_v_new: R.Tensor((3, 3), "float64") = R.add(lv5, lv7)
+            lv8: R.Tensor((), "float64") = R.subtract(R.const(1, "float64"), beta1_prod)
+            x_m_hat: R.Tensor((3, 3), "float64") = R.divide(x_m_new, lv8)
+            lv9: R.Tensor((), "float64") = R.subtract(R.const(1, "float64"), beta2_prod)
+            x_v_hat: R.Tensor((3, 3), "float64") = R.divide(x_v_new, lv9)
+            lv10: R.Tensor((3, 3), "float64") = R.sqrt(x_v_hat)
+            lv11: R.Tensor((3, 3), "float64") = R.add(lv10, R.const(1e-07, "float64"))
+            lv12: R.Tensor((3, 3), "float64") = R.divide(x_m_hat, lv11)
+            lv13: R.Tensor((3, 3), "float64") = R.multiply(R.const(0.01, "float64"), lv12)
+            x_new: R.Tensor((3, 3), "float64") = R.subtract(x, lv13)
+            y: R.Tensor((3,), "float64") = params[1]
+            y_grad: R.Tensor((3,), "float64") = gradients[1]
+            y_m: R.Tensor((3,), "float64") = optim_states[4]
+            y_v: R.Tensor((3,), "float64") = optim_states[6]
+            lv14: R.Tensor((3,), "float64") = R.multiply(R.const(0.1, "float64"), y)
+            y_grad_new: R.Tensor((3,), "float64") = R.add(lv14, y_grad)
+            lv15: R.Tensor((3,), "float64") = R.multiply(R.const(0.8, "float64"), y_m)
+            lv16: R.Tensor((3,), "float64") = R.multiply(R.const(0.2, "float64"), y_grad_new)
+            y_m_new: R.Tensor((3,), "float64") = R.add(lv15, lv16)
+            lv17: R.Tensor((3,), "float64") = R.multiply(R.const(0.85, "float64"), y_v)
+            lv18: R.Tensor((3,), "float64") = R.multiply(y_grad_new, y_grad_new)
+            lv19: R.Tensor((3,), "float64") = R.multiply(R.const(0.15, "float64"), lv18)
+            y_v_new: R.Tensor((3,), "float64") = R.add(lv17, lv19)
+            lv20: R.Tensor((), "float64") = R.subtract(R.const(1, "float64"), beta1_prod)
+            y_m_hat: R.Tensor((3,), "float64") = R.divide(y_m_new, lv20)
+            lv21: R.Tensor((), "float64") = R.subtract(R.const(1, "float64"), beta2_prod)
+            y_v_hat: R.Tensor((3,), "float64") = R.divide(y_v_new, lv21)
+            lv22: R.Tensor((3,), "float64") = R.sqrt(y_v_hat)
+            lv23: R.Tensor((3,), "float64") = R.add(lv22, R.const(1e-07, "float64"))
+            lv24: R.Tensor((3,), "float64") = R.divide(y_m_hat, lv23)
+            lv25: R.Tensor((3,), "float64") = R.multiply(R.const(0.01, "float64"), lv24)
+            y_new: R.Tensor((3,), "float64") = R.subtract(y, lv25)
+            params_new: R.Tuple(R.Tensor((3, 3), "float64"), R.Tensor((3,), "float64")) = (
+                x_new,
+                y_new,
+            )
+            optim_states_new: R.Tuple(
+                R.Tensor((), "int64"),
+                R.Tensor((), "float64"),
+                R.Tensor((), "float64"),
+                R.Tensor((3, 3), "float64"),
+                R.Tensor((3,), "float64"),
+                R.Tensor((3, 3), "float64"),
+                R.Tensor((3,), "float64"),
+            ) = (num_steps_new, beta1_prod, beta2_prod, x_m_new, y_m_new, x_v_new, y_v_new)
+            R.output(params_new, optim_states_new)
+        return (params_new, optim_states_new)
+
+    assert_structural_equal(adam, adam_expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_training_optimizer_numeric.py
+++ b/tests/python/relax/test_training_optimizer_numeric.py
@@ -25,13 +25,14 @@ from tvm import IRModule
 from tvm.relax.training.optimizer import Adam, SGD, MomentumSGD
 from tvm.relax.transform import LegalizeOps
 from tvm.script.parser import relax as R
+from tvm.runtime.relax_vm import VirtualMachine
 from tvm.testing import assert_allclose
 
 
 def _legalize_and_build(mod: IRModule, target, dev):
     lowered_mod = LegalizeOps()(mod)
-    ex = relax.vm.build(lowered_mod, target)
-    vm = relax.VirtualMachine(ex, dev)
+    ex = relax.build(lowered_mod, target)
+    vm = VirtualMachine(ex, dev)
     return vm
 
 

--- a/tests/python/relax/test_training_optimizer_numeric.py
+++ b/tests/python/relax/test_training_optimizer_numeric.py
@@ -1,0 +1,175 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Numeric tests for relax optimizer APIs."""
+from typing import Callable, List
+
+import numpy as np
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm import IRModule
+from tvm.relax.training.optimizer import Adam, SGD, MomentumSGD
+from tvm.relax.transform import LegalizeOps
+from tvm.script.parser import relax as R
+from tvm.testing import assert_allclose
+
+
+def _legalize_and_build(mod: IRModule, target, dev):
+    lowered_mod = LegalizeOps()(mod)
+    ex = relax.vm.build(lowered_mod, target)
+    vm = relax.VirtualMachine(ex, dev)
+    return vm
+
+
+def _numpy_to_tvm(data):
+    if isinstance(data, (list, tuple)):
+        return [_numpy_to_tvm(_data) for _data in data]
+    return tvm.nd.array(data)
+
+
+def _tvm_to_numpy(data):
+    if isinstance(data, (list, tuple, tvm.ir.Array)):
+        return [_tvm_to_numpy(_data) for _data in data]
+    return data.numpy()
+
+
+def _assert_allclose_nested(data1, data2):
+    if isinstance(data1, (list, tuple)):
+        assert isinstance(data2, (list, tuple))
+        assert len(data1) == len(data2)
+        for x, y in zip(data1, data2):
+            _assert_allclose_nested(x, y)
+    else:
+        assert_allclose(data1, data2)
+
+
+def _assert_run_result_same(tvm_func: Callable, np_func: Callable, np_inputs: List):
+    result = _tvm_to_numpy(tvm_func(*[_numpy_to_tvm(i) for i in np_inputs]))
+    expected = np_func(*np_inputs)
+    _assert_allclose_nested(result, expected)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
+    x = relax.Var("x", R.Tensor((3, 3), "float32"))
+    y = relax.Var("y", R.Tensor((3,), "float32"))
+    opt = opt_type(*args, **kwargs).init([x, y])
+    mod = IRModule.from_expr(opt.get_function())
+    tvm_func = _legalize_and_build(mod, target, dev)["main"]
+
+    param_arr = [np.random.rand(3, 3).astype(np.float32), np.random.rand(3).astype(np.float32)]
+    grad_arr = [np.random.rand(3, 3).astype(np.float32), np.random.rand(3).astype(np.float32)]
+    state_arr = _tvm_to_numpy(opt.state)
+
+    _assert_run_result_same(tvm_func, np_func, [param_arr, grad_arr, state_arr])
+
+
+lr, weight_decay = tvm.testing.parameters(
+    (0.01, 0),
+    (0.01, 0.02),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_sgd(target, dev, lr, weight_decay):
+    def np_func(param_tuple, grad_tuple, state_tuple):
+        num_steps = state_tuple[0]
+        param_tuple_new, state_tuple_new = [], []
+        state_tuple_new.append(num_steps + 1)
+        for i in range(len(param_tuple)):
+            param = param_tuple[i]
+            grad = grad_tuple[i]
+            param_tuple_new.append(param - lr * (grad + weight_decay * param))
+        return param_tuple_new, state_tuple_new
+
+    _test_optimizer(target, dev, np_func, SGD, lr, weight_decay)
+
+
+lr, momentum, dampening, weight_decay, nesterov = tvm.testing.parameters(
+    (0.01, 0.9, 0, 0, False),
+    (0.01, 0.9, 0.85, 0.02, False),
+    (0.01, 0.9, 0.85, 0.02, True),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_momentum_sgd(target, dev, lr, momentum, dampening, weight_decay, nesterov):
+    def np_func(param_tuple, grad_tuple, state_tuple):
+        num_steps = state_tuple[0]
+        param_tuple_new, state_tuple_new = [], []
+        state_tuple_new.append(num_steps + 1)
+
+        for i in range(len(param_tuple)):
+            param = param_tuple[i]
+            grad = grad_tuple[i]
+            velocity = state_tuple[i + 1]
+            grad = param * weight_decay + grad
+            velocity = momentum * velocity + grad * (1 - dampening)
+            if nesterov:
+                param = param - (grad + momentum * velocity) * lr
+            else:
+                param = param - velocity * lr
+            param_tuple_new.append(param)
+            state_tuple_new.append(velocity)
+
+        return param_tuple_new, state_tuple_new
+
+    _test_optimizer(
+        target, dev, np_func, MomentumSGD, lr, momentum, dampening, weight_decay, nesterov
+    )
+
+
+lr, betas, eps, weight_decay = tvm.testing.parameters(
+    (0.01, (0.9, 0.999), 1e-08, 0),
+    (0.01, (0.8, 0.85), 1e-07, 0.1),
+)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_adam(target, dev, lr, betas, eps, weight_decay):
+    def np_func(param_tuple, grad_tuple, state_tuple):
+        num_steps = state_tuple[0]
+        num_steps_new = num_steps + 1
+
+        param_tuple_new = []
+        state_tuple_new = [None] * len(state_tuple)  # type: ignore
+        state_tuple_new[0] = num_steps_new
+        state_tuple_new[1] = state_tuple[1] * betas[0]
+        state_tuple_new[2] = state_tuple[2] * betas[1]
+
+        for i in range(len(param_tuple)):
+            param = param_tuple[i]
+            grad = grad_tuple[i]
+            m = state_tuple[i + 3]
+            v = state_tuple[i + 3 + len(param_tuple)]
+            grad = grad + weight_decay * param
+            m = betas[0] * m + (1 - betas[0]) * grad
+            v = betas[1] * v + (1 - betas[1]) * grad * grad
+            m_hat = m / (1 - betas[0] ** num_steps_new)
+            v_hat = v / (1 - betas[1] ** num_steps_new)
+            param = param - lr * m_hat / (np.sqrt(v_hat) + eps)
+            param_tuple_new.append(param)
+            state_tuple_new[i + 3] = m
+            state_tuple_new[i + 3 + len(param_tuple)] = v
+
+        return param_tuple_new, state_tuple_new
+
+    _test_optimizer(target, dev, np_func, Adam, lr, betas, eps, weight_decay)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_training_trainer.py
+++ b/tests/python/relax/test_training_trainer.py
@@ -1,0 +1,183 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+import tvm.testing
+import numpy as np
+
+from tvm import relax, TVMError
+from tvm.ir.base import assert_structural_equal
+from tvm.script.parser import ir as I, relax as R, tir as T
+from tvm.relax.training import SetupTrainer
+from tvm.relax.training.optimizer import SGD
+from tvm.relax.training.loss import MSELoss
+from tvm.relax.training.trainer import Trainer
+
+
+def _get_backbone():
+    @I.ir_module
+    class MLP:
+        @R.function
+        def predict(
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.add(lv0, b0)
+                out = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+    return MLP, 2
+
+
+def _make_dataset():
+    N = 100
+    return [
+        [
+            np.random.uniform(size=(1, 10)).astype(np.float32),
+            np.array([[0, 0, 1, 0, 0]]).astype(np.float32),
+        ]
+        for _ in range(N)
+    ]
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_execute(target, dev):
+    backbone, params_num = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    trainer = Trainer(backbone, params_num, setup_trainer)
+    trainer.build(target, dev)
+    trainer.xaiver_uniform_init_params()
+
+    dataset = _make_dataset()
+    last_loss = np.inf
+    for epoch in range(5):
+        for i, data in enumerate(dataset):
+            loss = trainer.update_params(data[0], data[1])
+    trainer.predict(dataset[0][0])
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_load_export_params(target, dev):
+    backbone, params_num = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    trainer = Trainer(backbone, params_num, setup_trainer)
+    trainer.build(target, dev)
+    trainer.xaiver_uniform_init_params()
+
+    dataset = _make_dataset()
+    for i, data in enumerate(dataset):
+        trainer.update_params(data[0], data[1])
+
+    param_dict = trainer.export_params()
+    assert "w0" in param_dict
+    assert "b0" in param_dict
+
+    trainer1 = Trainer(backbone, params_num, setup_trainer)
+    trainer1.build(target, dev)
+    trainer1.load_params(param_dict)
+
+    x_sample = dataset[np.random.randint(len(dataset))][0]
+    tvm.testing.assert_allclose(
+        trainer.predict(x_sample).numpy(), trainer1.predict(x_sample).numpy()
+    )
+
+
+def test_setting_error():
+    backbone, params_num = _get_backbone()
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
+    trainer = Trainer(backbone, params_num, setup_trainer)
+
+    with pytest.raises(TVMError):
+        trainer.vm
+    dataset = _make_dataset()
+    with pytest.raises(TVMError):
+        trainer.predict(dataset[0][0])
+    with pytest.raises(TVMError):
+        trainer.update_params(dataset[0][0], dataset[0][1])
+
+
+def test_invalid_mod():
+    @I.ir_module
+    class NotReturnSingleTensor:
+        @R.function
+        def predict(
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
+        ):
+            R.func_attr({"params_num": 2})
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                gv = R.add(lv0, b0)
+                out = R.nn.relu(gv)
+                R.output(gv, out)
+            return gv, out
+
+    pred_sinfo = relax.TensorStructInfo((1, 5), "float32")
+    setup_trainer = SetupTrainer(
+        MSELoss(reduction="sum"),
+        SGD(0.001),
+        [pred_sinfo, pred_sinfo],
+    )
+
+    with pytest.raises(ValueError):
+        setup_trainer(NotReturnSingleTensor)
+
+    @I.ir_module
+    class NoParamsNumAttr:
+        @R.function
+        def predict(
+            w0: R.Tensor((10, 5), "float32"),
+            b0: R.Tensor((5,), "float32"),
+            x: R.Tensor((1, 10), "float32"),
+        ):
+            with R.dataflow():
+                lv0 = R.matmul(x, w0)
+                lv1 = R.add(lv0, b0)
+                out = R.nn.relu(lv1)
+                R.output(out)
+            return out
+
+    with pytest.raises(TypeError):
+        setup_trainer(NoParamsNumAttr)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/relax/test_training_utils.py
+++ b/tests/python/relax/test_training_utils.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+import tvm.testing
+from tvm import relax, TVMError
+from tvm.ir.base import assert_structural_equal
+from tvm.script import relax as R
+
+
+def test_append_loss_basic_extend():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.sum(x)
+            gv1 = R.sum(y)
+            R.output(gv0, gv1)
+        return gv0, gv1
+
+    @R.function
+    def loss(arg1: R.Tensor((), dtype="float32"), arg2: R.Tensor((), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.add(arg1, arg2)
+            R.output(gv0)
+        return gv0
+
+    @R.function
+    def expected(
+        x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=0):
+        # block 0
+        with R.dataflow():
+            gv0: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+            gv1: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+            gv01: R.Tensor((), dtype="float32") = R.add(gv0, gv1)
+            R.output(gv01)
+        return gv01
+
+    after = relax.training.utils.append_loss(orig, loss)
+    assert_structural_equal(after, expected)
+
+
+def test_append_loss_extra_params():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.sum(x)
+            gv1 = R.add(x, x)
+            R.output(gv0, gv1)
+        return gv0, gv1
+
+    @R.function
+    def loss(
+        arg1: R.Tensor((), dtype="float32"),
+        arg2: R.Tensor((3, 3), dtype="float32"),
+        arg3: R.Tensor((3, 3), dtype="float32"),
+    ):
+        with R.dataflow():
+            gv0 = R.add(arg2, arg3)
+            R.output(gv0)
+        return gv0
+
+    @R.function
+    def expected(
+        x: R.Tensor((3, 3), dtype="float32"), arg3: R.Tensor((3, 3), dtype="float32")
+    ) -> R.Tensor(None, dtype="float32", ndim=2):
+        with R.dataflow():
+            gv0: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+            gv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+            gv01: R.Tensor((3, 3), dtype="float32") = R.add(gv1, arg3)
+            R.output(gv01)
+        return gv01
+
+    after = relax.training.utils.append_loss(orig, loss)
+    assert_structural_equal(after, expected)
+
+
+def test_append_loss_nested_tuple():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.add(x, x)
+            gv1 = R.sum(y)
+            gv2 = R.add(x, y)
+            R.output(gv0, gv1, gv2)
+        return (gv0, gv1), gv2
+
+    @R.function
+    def loss(
+        arg1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32")),
+        arg2: R.Tensor((3, 3), dtype="float32"),
+    ):
+        with R.dataflow():
+            arg10 = arg1[0]
+            gv0 = R.add(arg10, arg2)
+            R.output(gv0)
+        return gv0
+
+    @R.function
+    def expected(
+        x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")
+    ) -> R.Tensor((3, 3), dtype="float32"):
+        # block 0
+        with R.dataflow():
+            gv0: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+            gv1: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+            gv2: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+            ret_0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32")) = (
+                gv0,
+                gv1,
+            )
+            arg10: R.Tensor((3, 3), dtype="float32") = ret_0[0]
+            gv01: R.Tensor((3, 3), dtype="float32") = R.add(arg10, gv2)
+            R.output(gv01)
+        return gv01
+
+    after = relax.training.utils.append_loss(orig, loss)
+    assert_structural_equal(after, expected)
+
+
+def test_append_loss_wrong_struct_info():
+    @R.function
+    def orig(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")):
+        with R.dataflow():
+            gv0 = R.sum(x)
+            gv1 = R.sum(y)
+            R.output(gv0, gv1)
+        return gv0, gv1
+
+    @R.function
+    def loss(arg1: R.Tensor((), dtype="float64"), arg2: R.Tensor((), dtype="float64")):
+        with R.dataflow():
+            gv0 = R.add(arg1, arg2)
+            R.output(gv0)
+        return gv0
+
+    with pytest.raises(TVMError):
+        after = relax.training.utils.append_loss(orig, loss)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR contains a relax training suite to achieve minimum training in Relax including:
- Loss functions
- Optimizers
- Trainer API

It also contains a API fix for Relax block builder, adding argument `name_hint: str` for `emit` and `emit_output`.

Co-authored-by: Yixin Dong <ubospica@gmail.com>