### PR TITLE
[Op] Refactor reshape operator

### DIFF
--- a/python/tvm/relax/transform/legalize_ops/manipulate.py
+++ b/python/tvm/relax/transform/legalize_ops/manipulate.py
@@ -29,8 +29,7 @@ def _reshape(
     te_func: TEFunc, primfunc_name: str, is_collapse_sum_like: bool = False
 ) -> LegalizeFunc:
     def reshape_call_te(bb: BlockBuilder, call: Call):
-        tgt_shape = call.args[1].struct_info.shape if is_collapse_sum_like else call.args[1]
-        return bb.call_te(te_func, call.args[0], tgt_shape, primfunc_name_hint=primfunc_name)
+        return bb.call_te(te_func, call.args[0], call.struct_info.shape, primfunc_name_hint=primfunc_name)
 
     return reshape_call_te
 

--- a/python/tvm/relax/transform/legalize_ops/manipulate.py
+++ b/python/tvm/relax/transform/legalize_ops/manipulate.py
@@ -29,7 +29,9 @@ def _reshape(
     te_func: TEFunc, primfunc_name: str, is_collapse_sum_like: bool = False
 ) -> LegalizeFunc:
     def reshape_call_te(bb: BlockBuilder, call: Call):
-        return bb.call_te(te_func, call.args[0], call.struct_info.shape, primfunc_name_hint=primfunc_name)
+        return bb.call_te(
+            te_func, call.args[0], call.struct_info.shape, primfunc_name_hint=primfunc_name
+        )
 
     return reshape_call_te
 

--- a/python/tvm/relax/transform/legalize_ops/manipulate.py
+++ b/python/tvm/relax/transform/legalize_ops/manipulate.py
@@ -25,9 +25,7 @@ from ...expr import Call, Expr, Var, Tuple, TupleGetItem
 from .common import TEFunc, LegalizeFunc, register_legalize
 
 
-def _reshape(
-    te_func: TEFunc, primfunc_name: str, is_collapse_sum_like: bool = False
-) -> LegalizeFunc:
+def _reshape(te_func: TEFunc, primfunc_name: str) -> LegalizeFunc:
     def reshape_call_te(bb: BlockBuilder, call: Call):
         return bb.call_te(
             te_func, call.args[0], call.struct_info.shape, primfunc_name_hint=primfunc_name
@@ -38,10 +36,7 @@ def _reshape(
 
 register_legalize("relax.broadcast_to", _reshape(topi.broadcast_to, "broadcast_to"))
 register_legalize("relax.reshape", _reshape(topi.reshape, "reshape"))
-register_legalize(
-    "relax.collapse_sum_like",
-    _reshape(topi.collapse_sum, "collapse_sum", is_collapse_sum_like=True),
-)
+register_legalize("relax.collapse_sum_like", _reshape(topi.collapse_sum, "collapse_sum"))
 register_legalize("relax.collapse_sum_to", _reshape(topi.collapse_sum, "collapse_sum"))
 
 


### PR DESCRIPTION
Now `relax.reshape(x, shape)` checks the shape parameter and infers the unknown dimension (-1 dimension) during constructing the operator. In the InferStructInfo and the Legalization stage, it just uses the inferred shape.

The problem of this is that it requires `x` have `struct_info` before constructing the op. But for expressions like `reshape(negative(x))`, `negative(x)` does not have `struct_info` until normalization. So this expression will report error.

This PR fixes this problem by refactoring the reshape op. `relax.reshape(x, shape)` will directly transform shape into `ShapeExpr` , which may contain `-1`, after simple checks. In the InferStructInfo stage, it checks the validity of the input ShapeExpr, and infers the unknown dim. In the Legalization stage, it uses the **output shape** as the shape parameter of `topi.reshape`.