### PR TITLE
[OP] Add an operator for fused multi head attention

### DIFF
--- a/include/tvm/relax/attrs/nn.h
+++ b/include/tvm/relax/attrs/nn.h
@@ -197,6 +197,15 @@ struct NLLLossAttrs : public tvm::AttrsNode<NLLLossAttrs> {
   }
 };  // struct NLLLossAttrs
 
+/*! \brief Attributes used in fuse multi head attention operator */
+struct AttentionAttrs : public tvm::AttrsNode<AttentionAttrs> {
+  DataType out_dtype;
+
+  TVM_DECLARE_ATTRS(AttentionAttrs, "relax.attrs.AttentionAttrs") {
+    TVM_ATTR_FIELD(out_dtype).describe("The data type of the output tensor");
+  }
+};  // struct AttentionAttrs
+
 }  // namespace relax
 }  // namespace tvm
 

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-wildcard-import, wildcard-import
+"""Generator for CUTLASS attention kernels."""
+from .library import *
+
+
+def instantiate_attention_template(attrs, func_args):
+    """Return CUTLASS host code for fused multi head attention
+    based on a template and the provided attribute map."""
+
+    template = """
+  using T = cutlass::half_t;
+
+  CHECK(${arg0}->ndim == 4); // B, S, N, H
+  CHECK(${arg1}->ndim == 4); // B, S', N, H
+  CHECK(${arg2}->ndim == 4); // B, S', N, H'
+  CHECK(out0->ndim == 4); // B, S, N, H'
+
+  using Attention =
+      AttentionKernel<T,
+                      /*ArchTag=*/${arch}, 
+                      /*is_aligned=*/true,
+                      /*queries_per_block=*/${kQueriesPerBlock},
+                      /*keys_per_block=*/${kKeysPerBlock},
+                      /*single_value_iteration=*/${kSingleValueIteration}
+      >;
+
+  typename Attention::Params p;
+
+  p.query_ptr = reinterpret_cast<T *>(${arg0}->data);
+  p.key_ptr = reinterpret_cast<T *>(${arg1}->data);
+  p.value_ptr = reinterpret_cast<T *>(${arg2}->data);
+  p.logsumexp_ptr = nullptr;
+  p.output_ptr = reinterpret_cast<T *>(out0->data);
+  static_assert(!Attention::kNeedsOutputAccumulatorBuffer);
+  p.output_accum_ptr = nullptr;
+
+  p.num_heads = ${num_heads}; // N
+  p.num_batches = ${num_batches}; // B
+  p.head_dim = ${head_dim}; // H
+  p.head_dim_value = ${head_dim_value}; // H'
+  p.num_queries = ${num_queries}; // S
+  p.num_keys = ${num_keys}; // S'
+  p.scale = 1.0f / sqrt(float(${head_dim}));
+  // p.causal = false;
+
+  // stride for N
+  p.q_strideH = p.head_dim; // H
+  p.k_strideH = p.head_dim; // H
+  p.v_strideH = p.head_dim_value; // H'
+  // p.o_strideH = p.head_dim_value; // H'
+
+  // stride for S
+  p.q_strideM = p.q_strideH * p.num_heads; // H * N
+  p.k_strideM = p.k_strideH * p.num_heads; // H * N
+  p.v_strideM = p.v_strideH * p.num_heads; // H' * N
+  p.o_strideM = p.head_dim_value * p.num_heads; // H' * N
+
+  // stride for B
+  p.q_strideB = p.q_strideM * p.num_queries; // H * N * S
+  p.k_strideB = p.k_strideM * p.num_keys; // H * N * S'
+  p.v_strideB = p.v_strideM * p.num_keys; // H'* N * S'
+  // p.o_strideB = p.o_strideM * p.num_queries; // H'* N * S
+
+  constexpr auto kernel_fn = attention_kernel_batched_impl<Attention>;
+  int smem_bytes = sizeof(typename Attention::SharedStorage);
+  if (smem_bytes > 0xc000) {
+    static bool once = [&]() {
+      cudaFuncSetAttribute(
+          kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+      return true;
+    }();
+  }
+
+  CHECK(Attention::check_supported(p));
+  kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(),
+              smem_bytes /*cuda stream?*/>>>(p);
+"""
+    for i, arg in enumerate(func_args):
+        attrs["arg{}".format(i)] = arg
+    return substitute_template(template, attrs)

--- a/python/tvm/contrib/cutlass/attention_operation.py
+++ b/python/tvm/contrib/cutlass/attention_operation.py
@@ -33,7 +33,7 @@ def instantiate_attention_template(attrs, func_args):
 
   using Attention =
       AttentionKernel<T,
-                      /*ArchTag=*/${arch}, 
+                      /*ArchTag=*/${arch},
                       /*is_aligned=*/true,
                       /*queries_per_block=*/${kQueriesPerBlock},
                       /*keys_per_block=*/${kKeysPerBlock},
@@ -88,8 +88,7 @@ def instantiate_attention_template(attrs, func_args):
   }
 
   CHECK(Attention::check_supported(p));
-  kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(),
-              smem_bytes /*cuda stream?*/>>>(p);
+  kernel_fn<<<p.getBlocksGrid(), p.getThreadsGrid(), smem_bytes>>>(p);
 """
     for i, arg in enumerate(func_args):
         attrs["arg{}".format(i)] = arg

--- a/python/tvm/contrib/cutlass/build.py
+++ b/python/tvm/contrib/cutlass/build.py
@@ -54,6 +54,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
     cutlass_root = _get_cutlass_path()
     cutlass_include = os.path.join(cutlass_root, "include")
     cutlass_util_include = os.path.join(cutlass_root, "tools/util/include")
+    cutlass_attention_include = os.path.join(cutlass_root, "examples/41_fused_multi_head_attention")
 
     kwargs = {}
     kwargs["cc"] = "nvcc"
@@ -68,6 +69,7 @@ def _get_cutlass_compile_options(sm, threads, use_fast_math=False):
         "-std=c++17",
         "-I" + cutlass_include,
         "-I" + cutlass_util_include,
+        "-I" + cutlass_attention_include,
     ]
     if use_fast_math:
         kwargs["options"].append("-DCUTLASS_USE_TANH_FOR_SIGMOID")
@@ -709,6 +711,43 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             }
         )
 
+    def handle_attention(self, f, op_type):
+        """Tune and annotate a dense op."""
+        signature = _extract_relax_function_signature(f)
+
+        q_shape = signature["arg0_shape"]
+        k_shape = signature["arg1_shape"]
+        v_shape = signature["arg2_shape"]
+        out_shape = signature["ret_shape"]
+        q_dtype = signature["arg0_dtype"]
+        k_dtype = signature["arg1_dtype"]
+        v_dtype = signature["arg2_dtype"]
+        out_dtype = signature["ret_dtype"]
+        num_batches, num_queries, num_heads, head_dim = q_shape
+        _, num_keys, _, _ = k_shape
+        _, _, _, head_dim_value = v_shape
+
+        return f.with_attrs(
+            {
+                "op_type": op_type,
+                "arg0_dtype": q_dtype,
+                "arg1_dtype": k_dtype,
+                "arg2_dtype": v_dtype,
+                "ret_dtype": out_dtype,
+                "arg0_shape": q_shape,
+                "arg1_shape": k_shape,
+                "arg2_shape": v_shape,
+                "ret_shape": out_shape,
+                "num_batches": num_batches,
+                "num_queries": num_queries,
+                "num_keys": num_keys,
+                "num_heads": num_heads,
+                "head_dim": head_dim,
+                "head_dim_value": head_dim_value,
+                "arch": self.options["sm"],
+            }
+        )
+
     def visit_function_(self, f):
         if "Composite" not in f.attrs:
             body = super().visit_expr(f.body)
@@ -720,6 +759,8 @@ class CutlassRelaxFunctionAnnotator(relax.PyExprMutator):
             return self.handle_conv2d(f, op_type)
         elif "matmul" in op_type:
             return self.handle_matmul(f, op_type)
+        elif "attention" in op_type:
+            return self.handle_attention(f, op_type)
 
         raise ValueError("Unsupported composite {}".format(op_type))
 

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -30,6 +30,7 @@ from tvm.tir import IntImm
 from . import _ffi_api as ffi
 from .conv2d_operation import instantiate_conv2d_template
 from .gemm_operation import instantiate_gemm_template
+from .attention_operation import instantiate_attention_template
 from .library import (
     DataType,
     DataTypeTag,
@@ -650,6 +651,27 @@ def instantiate_template(func_name, annotations, func_args):
             attrs["split_k_slices"] = "1"
 
         code = instantiate_conv2d_template(attrs, func_args)
+        return CodegenResult(code, headers)
+        
+    elif "attention" in func_name:
+        headers.append("kernel_forward.h")
+        attrs["num_batches"] = str(int(annotations["num_batches"]))
+        attrs["num_queries"] = str(int(annotations["num_queries"]))
+        attrs["num_keys"] = str(int(annotations["num_keys"]))
+        attrs["num_heads"] = str(int(annotations["num_heads"]))
+        attrs["head_dim"] = str(int(annotations["head_dim"]))
+        h_v = int(annotations["head_dim_value"])
+        attrs["head_dim_value"] = str(h_v)
+        if h_v > 64:
+            attrs["kQueriesPerBlock"] = "32"
+            attrs["kKeysPerBlock"] = "128"
+            attrs["kSingleValueIteration"] = "true" if h_v <= 128 else "false"
+        else:
+            attrs["kQueriesPerBlock"] = "64"
+            attrs["kKeysPerBlock"] = "64"
+            attrs["kSingleValueIteration"] = "true"
+        attrs["arch"] = "cutlass::arch::Sm{}".format(annotations["arch"])
+        code = instantiate_attention_template(attrs, func_args)
         return CodegenResult(code, headers)
 
     raise ValueError("Do not have a template for {}".format(func_name))

--- a/python/tvm/contrib/cutlass/gen_tensor_op.py
+++ b/python/tvm/contrib/cutlass/gen_tensor_op.py
@@ -652,7 +652,7 @@ def instantiate_template(func_name, annotations, func_args):
 
         code = instantiate_conv2d_template(attrs, func_args)
         return CodegenResult(code, headers)
-        
+
     elif "attention" in func_name:
         headers.append("kernel_forward.h")
         attrs["num_batches"] = str(int(annotations["num_batches"]))

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -20,7 +20,7 @@
 from tvm.relax import transform
 
 from ..pattern_registry import get_patterns_with_prefix, register_patterns
-from ..patterns import make_fused_bias_activation_pattern, make_matmul_pattern
+from ..patterns import make_fused_bias_activation_pattern, make_matmul_pattern, make_attention_pattern
 
 register_patterns(
     [
@@ -95,6 +95,10 @@ register_patterns(
                 activation="relax.nn.gelu",
                 transposed_rhs=True,
             ),
+        ),
+        (
+            "cutlass.attention",
+            make_attention_pattern(),
         ),
     ]
 )

--- a/python/tvm/relax/backend/contrib/cutlass.py
+++ b/python/tvm/relax/backend/contrib/cutlass.py
@@ -20,7 +20,11 @@
 from tvm.relax import transform
 
 from ..pattern_registry import get_patterns_with_prefix, register_patterns
-from ..patterns import make_fused_bias_activation_pattern, make_matmul_pattern, make_attention_pattern
+from ..patterns import (
+    make_fused_bias_activation_pattern,
+    make_matmul_pattern,
+    make_attention_pattern,
+)
 
 register_patterns(
     [

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -113,3 +113,24 @@ def make_matmul_pattern(
     out = is_op("relax.matmul")(lhs, rhs)
 
     return _with_bias_activation_pattern(out, args, with_bias, activation)
+
+
+def make_attention_pattern():
+    """
+    Create pattern for fused multi head attention.
+
+    Returns
+    -------
+    pattern: DFPattern
+        The resulting pattern describing a fused multi head attention.
+
+    args: Mapping[str, DFPattern]
+        The mapping from arg name to its pattern. It can be used to extract
+        arg expression from match result.
+    """
+    q = wildcard()
+    k = wildcard()
+    v = wildcard()
+    out = is_op("relax.nn.attention")(q, k, v)
+
+    return out

--- a/python/tvm/relax/backend/patterns.py
+++ b/python/tvm/relax/backend/patterns.py
@@ -128,9 +128,9 @@ def make_attention_pattern():
         The mapping from arg name to its pattern. It can be used to extract
         arg expression from match result.
     """
-    q = wildcard()
-    k = wildcard()
-    v = wildcard()
-    out = is_op("relax.nn.attention")(q, k, v)
+    query = wildcard()
+    key = wildcard()
+    value = wildcard()
+    out = is_op("relax.nn.attention")(query, key, value)
 
     return out

--- a/python/tvm/relax/op/nn/nn.py
+++ b/python/tvm/relax/op/nn/nn.py
@@ -622,3 +622,43 @@ def nll_loss(
       The computed result.
     """
     return _ffi_api.nll_loss(predictions, targets, weights, reduction, ignore_index)  # type: ignore
+
+
+def attention(
+    query: Expr, key: Expr, value: Expr, out_dtype: Optional[Union[str, DataType]] = None
+) -> Expr:
+    r"""Computes fused multi head attention.
+
+    All input tensors are of 4-D tensors with BSNH layout.
+
+    .. math::
+        FMA(Q, K, V) = \text{Softmax}(Q @ K^T) @ V
+
+    .. note::
+        The input tensor is required to have float16 dtype
+
+    Parameters
+    ----------
+    query: relax.Expr
+        The input query to the operator. The layout of the input query should be
+        (batch_size, seq_len, num_head, head_dim).
+
+    key: relax.Expr
+        The input key to the operator. The layout of the input key should be
+        (batch_size, seq_len_kv, num_head, head_dim).
+
+    value: relax.Expr
+        The input value to the operator. The layout of the input value should be
+        (batch_size, seq_len_kv, num_head, head_dim_v).
+
+    out_dtype: Optional[Union[str, DataType]]
+        The data type of the attention result.
+        When it is not specified, the output dtype will be the the same as input dtype.
+
+    Returns
+    -------
+    result : relax.Expr
+        The computed result. The layout of the output should be
+        (batch_size, seq_len, num_head, head_dim_v).
+    """
+    return _ffi_api.attention(query, key, value, out_dtype)  # type: ignore

--- a/src/relax/op/nn/attention.cc
+++ b/src/relax/op/nn/attention.cc
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "attention.h"
+
+#include <utility>
+#include <vector>
+
+namespace tvm {
+namespace relax {
+
+/* relax.nn.attention */
+TVM_REGISTER_NODE_TYPE(AttentionAttrs);
+
+Expr attention(Expr query, Expr key, Expr value, DataType out_dtype) {
+  ObjectPtr<AttentionAttrs> attrs = make_object<AttentionAttrs>();
+  attrs->out_dtype = out_dtype;
+  static const Op& op = Op::Get("relax.nn.attention");
+  return Call(op, {std::move(query), std::move(key), std::move(value)}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_GLOBAL("relax.op.nn.attention").set_body_typed(attention);
+
+StructInfo InferStructInfoAttention(const Call& call, const BlockBuilder& ctx) {
+  Array<TensorStructInfo> input_sinfo = GetInputTensorStructInfo(call, ctx);
+  TensorStructInfo q_sinfo = input_sinfo[0];
+  TensorStructInfo k_sinfo = input_sinfo[1];
+  TensorStructInfo v_sinfo = input_sinfo[2];
+  auto diag_dim = [&](TensorStructInfo sinfo, String name) {
+    if (sinfo->ndim != 4) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << "The " << name << " should have 4 dimension, namely "
+                       << "[batch size, sequence length, number of heads, dimension of heads].");
+    }
+  };
+  diag_dim(q_sinfo, "query");
+  diag_dim(k_sinfo, "key");
+  diag_dim(v_sinfo, "value");
+  const auto* attrs = call->attrs.as<AttentionAttrs>();
+  DataType out_dtype = attrs->out_dtype.is_void()
+                           ? InferBinaryArithOpOutDtype(call, ctx, q_sinfo, k_sinfo)
+                           : attrs->out_dtype;
+  const ShapeExprNode* q_shape = q_sinfo->shape.as<ShapeExprNode>();
+  const ShapeExprNode* k_shape = k_sinfo->shape.as<ShapeExprNode>();
+  const ShapeExprNode* v_shape = v_sinfo->shape.as<ShapeExprNode>();
+  PrimExpr num_batches = q_shape->values[0];
+  PrimExpr num_queries = q_shape->values[1];
+  PrimExpr num_heads = q_shape->values[2];
+  PrimExpr head_dim = q_shape->values[3];
+  PrimExpr num_keys = k_shape->values[1];
+  PrimExpr head_dim_value = v_shape->values[3];
+  arith::Analyzer* analyzer = ctx->GetAnalyzer();
+  auto diag_equal = [&](PrimExpr v1, PrimExpr v2, String m1, String m2, String dim) {
+    if (analyzer->CanProve(v1 != v2)) {
+      ctx->ReportFatal(Diagnostic::Error(call)
+                       << "The " << m1 << " " << dim << " and the " << m2 << " " << dim
+                       << " should be the same. However, the " << dim << " of " << m1 << " is "
+                       << v1 << " while the " << dim << " of " << m2 << " is " << v2);
+    }
+  };
+  diag_equal(num_batches, k_shape->values[0], "query", "key", "batch size");
+  diag_equal(num_batches, v_shape->values[0], "query", "value", "batch size");
+  diag_equal(num_heads, k_shape->values[2], "query", "key", "number of heads");
+  diag_equal(num_heads, v_shape->values[2], "query", "value", "number of heads");
+  diag_equal(k_shape->values[1], v_shape->values[1], "key", "value", "sequence length");
+  diag_equal(head_dim, k_shape->values[3], "query", "key", "dimension of heads");
+
+  Array<PrimExpr> output_shape = {num_batches, num_queries, num_heads, head_dim_value};
+  return TensorStructInfo(ShapeExpr(output_shape), out_dtype);
+}
+
+TVM_REGISTER_OP("relax.nn.attention")
+    .set_num_inputs(3)
+    .add_argument("query", "Tensor", "The input queries tensor.")
+    .add_argument("key", "Tensor", "The input keys tensor.")
+    .add_argument("value", "Tensor", "The input values tensor.")
+    .set_attrs_type<AttentionAttrs>()
+    .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoAttention);
+
+}  // namespace relax
+}  // namespace tvm

--- a/src/relax/op/nn/attention.h
+++ b/src/relax/op/nn/attention.h
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file attention.h
+ * \brief The functions to make Relax attention operator calls.
+ */
+
+#ifndef TVM_RELAX_OP_NN_ATTENTION_H_
+#define TVM_RELAX_OP_NN_ATTENTION_H_
+
+#include <tvm/relax/attrs/nn.h>
+
+#include "../op_common.h"
+
+namespace tvm {
+namespace relax {
+
+/*! \brief fused multi head attention */
+Expr attention(Expr query, Expr key, Expr value, DataType out_dtype);
+
+}  // namespace relax
+}  // namespace tvm
+
+#endif  // TVM_RELAX_OP_NN_ATTENTION_H_


### PR DESCRIPTION
This PR introduces the new relax operator `R.nn.attention` for fused multi head attention, and the support of fused multi head attention to relax cutlass BYOC. The input of the operator are query, key and value tensor, with `BSNH` layout, namely `[batch size, sequence length, number of heads, dimension of heads]`. And the output shares the same layout with all input tensor.