### PR TITLE
[Fix][TVMScript] Sync TVMScript parser binop impl

### DIFF
--- a/python/tvm/script/parser/tir/operation.py
+++ b/python/tvm/script/parser/tir/operation.py
@@ -46,12 +46,12 @@ def _register_expr_op(ty: Type):  # pylint: disable=invalid-name
 
     for i in [0, 1]:
         # Case 1. binop
-        r(doc.Add, i, lambda a, b: a + b)
-        r(doc.Sub, i, lambda a, b: a - b)
-        r(doc.Mult, i, lambda a, b: a * b)
-        r(doc.Div, i, lambda a, b: a / b)
-        r(doc.FloorDiv, i, lambda a, b: a // b)
-        r(doc.Mod, i, lambda a, b: a % b)
+        r(doc.Add, i, tir.Add)
+        r(doc.Sub, i, tir.Sub)
+        r(doc.Mult, i, tir.Mul)
+        r(doc.Div, i, tir.Div)
+        r(doc.FloorDiv, i, tir.FloorDiv)
+        r(doc.Mod, i, tir.FloorMod)
         r(doc.LShift, i, lambda a, b: a << b)
         r(doc.RShift, i, lambda a, b: a >> b)
         r(doc.BitOr, i, lambda a, b: a | b)


### PR DESCRIPTION
This PR synchronizes the TVMScript parser binary operation implementation, to avoid the issues like integer division ambiguity. The difference might have been brought when rebasing.