### PR TITLE
[Fix][TVMScript] Print truncdiv for int div

### DIFF
--- a/src/script/printer/tir/expr.cc
+++ b/src/script/printer/tir/expr.cc
@@ -305,8 +305,8 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
       if (IsNumber(a) && IsNumber(b)) {
         return TIR(d, "Div")->Call({a, b});
       }
-      if ((node->a->dtype.is_int() || node->a->dtype.is_uint()) && node->b->dtype.is_int() ||
-          node->b->dtype.is_uint()) {
+      if ((node->a->dtype.is_int() || node->a->dtype.is_uint()) &&
+          (node->b->dtype.is_int() || node->b->dtype.is_uint())) {
         return TIR(d, "truncdiv")->Call({a, b});
       }
       return OperationDoc(OperationDocNode::Kind::kDiv, {a, b});

--- a/src/script/printer/tir/expr.cc
+++ b/src/script/printer/tir/expr.cc
@@ -298,6 +298,20 @@ bool IsNumber(const ExprDoc& e) {
   return false;
 }
 
+TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
+    .set_dispatch<tir::Div>("", [](tir::Div node, ObjectPath p, IRDocsifier d) -> Doc {
+      ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));
+      ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));
+      if (IsNumber(a) && IsNumber(b)) {
+        return TIR(d, "Div")->Call({a, b});
+      }
+      if ((node->a->dtype.is_int() || node->a->dtype.is_uint()) && node->b->dtype.is_int() ||
+          node->b->dtype.is_uint()) {
+        return TIR(d, "truncdiv")->Call({a, b});
+      }
+      return OperationDoc(OperationDocNode::Kind::kDiv, {a, b});
+    });
+
 #define TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(NodeType, OpString, OpKind)                      \
   TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)                                                      \
       .set_dispatch<tir::NodeType>("",                                                            \
@@ -313,7 +327,6 @@ bool IsNumber(const ExprDoc& e) {
 TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Add, "Add", kAdd);
 TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Sub, "Sub", kSub);
 TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Mul, "Mul", kMult);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Div, "Div", kDiv);
 TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(FloorDiv, "FloorDiv", kFloorDiv);
 TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(FloorMod, "FloorMod", kMod);
 TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(LT, "LT", kLt);

--- a/tests/python/unittest/test_tvmscript_printer_tir.py
+++ b/tests/python/unittest/test_tvmscript_printer_tir.py
@@ -536,6 +536,19 @@ a {} b""".format(
         _assert_print(obj, expected)
 
 
+def test_int_div():
+    a = tir.Var("a", "int32")
+    b = tir.Var("b", "int32")
+    _assert_print(
+        tir.Div(a, b),
+        """
+a = T.int32()
+b = T.int32()
+T.truncdiv(a, b)
+""",
+    )
+
+
 def test_logical():
     a = tir.Var("a", "bool")
     b = tir.Var("b", "bool")


### PR DESCRIPTION
This PR fixes the output for `T.Div(int, int)`. It will print `T.truncdiv(int, int)`, instead of `int / int`, to avoid the integer division ambiguity in parser.