### PR TITLE
[Quantization] Int4 Quantization Pass

### DIFF
--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -983,6 +983,8 @@ constexpr const char* kCodegen = "Codegen";
 constexpr const char* kComposite = "Composite";
 /*! \brief Indicate the function was created by the Pattern Partitioning Pass. */
 constexpr const char* kPartitionedFromPattern = "PartitionedFromPattern";
+/*! \brief Indicate the function cannot be lifted to transform_params*/
+constexpr const char* kStopLifting = "StopLifting";
 }  // namespace attr
 
 /*! \brief The extern function, which can represent packed function. */

--- a/python/tvm/relax/transform/__init__.py
+++ b/python/tvm/relax/transform/__init__.py
@@ -21,3 +21,5 @@ from .transform import *
 
 # Import to register the legalization functions.
 from . import legalize_ops
+
+from .quantization import GroupQuantize

--- a/python/tvm/relax/transform/quantization.py
+++ b/python/tvm/relax/transform/quantization.py
@@ -1,4 +1,3 @@
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/python/tvm/relax/transform/quantization.py
+++ b/python/tvm/relax/transform/quantization.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name
+# pylint: disable=abstract-method,invalid-name,missing-class-docstring,missing-function-docstring,missing-module-docstring,unused-argument
 """Relax quantization passes."""
 import tvm
 from tvm import topi, relax
@@ -27,6 +27,7 @@ from tvm.tir import IntImm
 
 
 def te_encode_i4(x, group_size=64):
+    """topi implementation of int4 quantization encoding"""
     assert len(x.shape) == 2
     assert x.shape[1] % group_size == 0
     x_reshape = topi.reshape(x, (x.shape[0], x.shape[1] // group_size, group_size))
@@ -46,6 +47,7 @@ def te_encode_i4(x, group_size=64):
 
 
 def te_decode_i4(x, x_max, x_min):
+    """topi implementation of int4 quantization decoding"""
     assert len(x.shape) == 3
     assert len(x_max.shape) == 3
     assert len(x_min.shape) == 3
@@ -66,7 +68,19 @@ def te_decode_i4(x, x_max, x_min):
 
 @tvm.transform.module_pass(opt_level=3, name="GroupQuantize")
 class GroupQuantize:
+    """
+    A pass that quantize the input tensor to int4 by group.
+    """
+
     def __init__(self, group_size: int = 64) -> None:
+        """
+        Parameters
+        ----------
+
+        group_size: int
+            The size of the group for quantization.
+
+        """
         self.group_size = group_size
 
     def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
@@ -126,7 +140,7 @@ class GroupQuantize:
                 else:
                     return args, False
 
-            def visit_call_(self, call):
+            def visit_call_(self, call):  # pylint: disable=arguments-differ
                 call = self.visit_expr_post_order(call)
                 new_args, updated = self.process_args(call.args)
                 if not updated:

--- a/python/tvm/relax/transform/quantization.py
+++ b/python/tvm/relax/transform/quantization.py
@@ -1,0 +1,138 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Relax quantization passes."""
+import tvm
+from tvm import topi, relax
+from tvm.ir.module import IRModule
+from tvm.relax.expr_functor import mutator, PyExprMutator
+from tvm.relax.analysis import remove_all_unused
+from tvm.ir import Array
+from tvm.relax import Tuple
+from tvm.tir import IntImm
+
+
+def te_encode_i4(x, group_size=64):
+    assert len(x.shape) == 2
+    assert x.shape[1] % group_size == 0
+    x_reshape = topi.reshape(x, (x.shape[0], x.shape[1] // group_size, group_size))
+    x_max = topi.max(x_reshape, axis=2, keepdims=True)
+    x_min = topi.min(x_reshape, axis=2, keepdims=True)
+    dtype_bits = 4
+    x_scaled = topi.round((2**dtype_bits - 1) * (x_reshape - x_min) / (x_max - x_min))
+    x_int = topi.cast(x_scaled, "uint8")
+    x_first_half = topi.strided_slice(x_int, (0,), (x_int.shape[2] // 2,), (1,), axes=(2,))
+    x_second_half = topi.strided_slice(
+        x_int, (x_int.shape[2] // 2,), (x_int.shape[2],), (1,), axes=(2,)
+    )
+    x_first_half = topi.left_shift(x_first_half, IntImm(dtype="uint8", value=dtype_bits))
+    x_masked = topi.bitwise_or(x_first_half, x_second_half)
+
+    return (x_masked, x_max, x_min)
+
+
+def te_decode_i4(x, x_max, x_min):
+    assert len(x.shape) == 3
+    assert len(x_max.shape) == 3
+    assert len(x_min.shape) == 3
+    assert x.shape[0] == x_max.shape[0] and x_min.shape[0] == x_max.shape[0]
+    assert x.shape[1] == x_max.shape[1] and x_min.shape[1] == x_max.shape[1]
+
+    dtype_bits = 4
+    x_first_half = topi.right_shift(x, IntImm(dtype="uint8", value=dtype_bits))
+    x_second_half = topi.bitwise_and(x, IntImm(dtype="uint8", value=2**dtype_bits - 1))
+    x_concat = topi.concatenate([x_first_half, x_second_half], axis=2)
+    x_float = topi.cast(x_concat, "float32")
+    x_rescaled = x_float * (x_max - x_min) / (2**dtype_bits - 1) + x_min
+    x_reshaped = topi.reshape(
+        x_rescaled, (x_rescaled.shape[0], x_rescaled.shape[1] * x_rescaled.shape[2])
+    )
+    return x_reshaped
+
+
+@tvm.transform.module_pass(opt_level=3, name="GroupQuantize")
+class GroupQuantize:
+    def __init__(self, group_size: int = 64) -> None:
+        self.group_size = group_size
+
+    def transform_module(self, mod: IRModule, ctx: tvm.transform.PassContext) -> IRModule:
+        @mutator
+        class QuantizeMutator(PyExprMutator):
+            def __init__(self, mod: IRModule, group_size: int):
+                super().__init__(mod)
+                self.mod = mod
+                self._params = set()
+                self.group_size = group_size
+
+            def emit_te_encode_decode(self, x):
+                encoded_data = self.builder_.emit_te(
+                    te_encode_i4, x, group_size=self.group_size, primfunc_name_hint="encode"
+                )
+                data = self.builder_.emit(relax.TupleGetItem(encoded_data, 0))
+                data_max = self.builder_.emit(relax.TupleGetItem(encoded_data, 1))
+                data_min = self.builder_.emit(relax.TupleGetItem(encoded_data, 2))
+                decoded_data = self.builder_.emit_te(
+                    te_decode_i4,
+                    data,
+                    data_max,
+                    data_min,
+                    primfunc_name_hint="decode",
+                    primfunc_attrs={"StopLifting": True},
+                )
+                return decoded_data
+
+            def transform(self) -> IRModule:
+                for global_var, func in self.mod.functions.items():
+                    if not isinstance(func, relax.Function):
+                        continue
+                    if not "num_input" in func.attrs:
+                        continue
+                    num_inputs = func.attrs["num_input"]
+                    for i in range(int(num_inputs), len(func.params)):
+                        self._params.add(func.params[i])
+                    updated_func = self.visit_expr(func)
+                    updated_func = remove_all_unused(updated_func)
+                    self.builder_.update_func(global_var, updated_func)
+                return self.builder_.get()
+
+            def process_args(self, args):
+                if isinstance(args, (Array, Tuple)):
+                    updated = False
+                    new_args = []
+                    for arg in args:
+                        new_arg, arg_updated = self.process_args(arg)
+                        new_args.append(new_arg)
+                        updated = updated or arg_updated
+                    return (Tuple(new_args) if isinstance(args, Tuple) else new_args), updated
+                elif isinstance(args, relax.Var):
+                    if args in self._params:
+                        return self.emit_te_encode_decode(args), True
+                    else:
+                        return args, False
+                else:
+                    return args, False
+
+            def visit_call_(self, call):
+                call = self.visit_expr_post_order(call)
+                new_args, updated = self.process_args(call.args)
+                if not updated:
+                    return call
+                new_call = relax.Call(call.op, new_args, call.attrs, call.sinfo_args, call.span)
+                return new_call
+
+        return QuantizeMutator(mod, self.group_size).transform()

--- a/tests/python/relax/test_transform_quantization.py
+++ b/tests/python/relax/test_transform_quantization.py
@@ -1,0 +1,337 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.script import ir as I
+from tvm.script import tir as T
+from tvm.script import relax as R
+import numpy as np
+import tvm.topi.testing
+
+
+def test_simple():
+    @tvm.script.ir_module
+    class Before:
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), "float32"),
+            w1: R.Tensor((256, 256), "float32"),
+        ) -> R.Tensor((256, 256), "float32"):
+            R.func_attr({"num_input": 1})
+            with R.dataflow():
+                w1_t = R.permute_dims(w1, [1, 0])
+                y = R.matmul(x, w1_t)
+                R.output(y)
+            return y
+
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def decode(
+            rxplaceholder: T.Buffer((T.int64(256), T.int64(4), T.int64(32)), "uint8"),
+            rxplaceholder_1: T.Buffer((T.int64(256), T.int64(4), T.int64(1)), "float32"),
+            rxplaceholder_2: T.Buffer((T.int64(256), T.int64(4), T.int64(1)), "float32"),
+            T_reshape: T.Buffer((T.int64(256), T.int64(256)), "float32"),
+        ):
+            T.func_attr({"StopLifting": True, "tir.noalias": True})
+            # with T.block("root"):
+            T_bitwise_and = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(32)), "uint8")
+            T_right_shift = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(32)), "uint8")
+            T_concat = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)), "uint8")
+            compute = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            T_subtract = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(1)))
+            T_multiply = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            T_divide = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            T_add = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(32)):
+                with T.block("T_bitwise_and"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_bitwise_and[v_ax0, v_ax1, v_ax2])
+                    T_bitwise_and[v_ax0, v_ax1, v_ax2] = T.bitwise_and(
+                        rxplaceholder[v_ax0, v_ax1, v_ax2], T.uint8(15)
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(32)):
+                with T.block("T_right_shift"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(rxplaceholder[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_right_shift[v_ax0, v_ax1, v_ax2])
+                    T_right_shift[v_ax0, v_ax1, v_ax2] = T.shift_right(
+                        rxplaceholder[v_ax0, v_ax1, v_ax2], T.uint8(4)
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_concat"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        T_bitwise_and[v_ax0, v_ax1, v_ax2 - T.int64(32)],
+                        T_right_shift[v_ax0, v_ax1, v_ax2],
+                    )
+                    T.writes(T_concat[v_ax0, v_ax1, v_ax2])
+                    T_concat[v_ax0, v_ax1, v_ax2] = T.if_then_else(
+                        T.int64(32) <= v_ax2,
+                        T_bitwise_and[v_ax0, v_ax1, v_ax2 - T.int64(32)],
+                        T_right_shift[v_ax0, v_ax1, v_ax2],
+                    )
+            for i0, i1, i2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("compute"):
+                    v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+                    T.reads(T_concat[v_i0, v_i1, v_i2])
+                    T.writes(compute[v_i0, v_i1, v_i2])
+                    compute[v_i0, v_i1, v_i2] = T.Cast("float32", T_concat[v_i0, v_i1, v_i2])
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(1)):
+                with T.block("T_subtract"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        rxplaceholder_1[v_ax0, v_ax1, v_ax2], rxplaceholder_2[v_ax0, v_ax1, v_ax2]
+                    )
+                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2])
+                    T_subtract[v_ax0, v_ax1, v_ax2] = (
+                        rxplaceholder_1[v_ax0, v_ax1, v_ax2] - rxplaceholder_2[v_ax0, v_ax1, v_ax2]
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(compute[v_ax0, v_ax1, v_ax2], T_subtract[v_ax0, v_ax1, T.int64(0)])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2])
+                    T_multiply[v_ax0, v_ax1, v_ax2] = (
+                        compute[v_ax0, v_ax1, v_ax2] * T_subtract[v_ax0, v_ax1, T.int64(0)]
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_divide"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_multiply[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_divide[v_ax0, v_ax1, v_ax2])
+                    T_divide[v_ax0, v_ax1, v_ax2] = T_multiply[v_ax0, v_ax1, v_ax2] * T.float32(
+                        0.066666666666666666
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_add"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        T_divide[v_ax0, v_ax1, v_ax2], rxplaceholder_2[v_ax0, v_ax1, T.int64(0)]
+                    )
+                    T.writes(T_add[v_ax0, v_ax1, v_ax2])
+                    T_add[v_ax0, v_ax1, v_ax2] = (
+                        T_divide[v_ax0, v_ax1, v_ax2] + rxplaceholder_2[v_ax0, v_ax1, T.int64(0)]
+                    )
+            for ax0, ax1 in T.grid(T.int64(256), T.int64(256)):
+                with T.block("T_reshape"):
+                    v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+                    T.reads(
+                        T_add[
+                            (v_ax1 // T.int64(256) + v_ax0) % T.int64(256),
+                            v_ax1 % T.int64(256) // T.int64(64),
+                            v_ax1 % T.int64(64),
+                        ]
+                    )
+                    T.writes(T_reshape[v_ax0, v_ax1])
+                    T_reshape[v_ax0, v_ax1] = T_add[
+                        (v_ax1 // T.int64(256) + v_ax0) % T.int64(256),
+                        v_ax1 % T.int64(256) // T.int64(64),
+                        v_ax1 % T.int64(64),
+                    ]
+
+        @T.prim_func
+        def encode(
+            rxplaceholder: T.Buffer((T.int64(256), T.int64(256)), "float32"),
+            T_bitwise_or: T.Buffer((T.int64(256), T.int64(4), T.int64(32)), "uint8"),
+            T_reshape_red: T.Buffer((T.int64(256), T.int64(4), T.int64(1)), "float32"),
+            T_reshape_red_1: T.Buffer((T.int64(256), T.int64(4), T.int64(1)), "float32"),
+        ):
+            T.func_attr({"tir.noalias": True})
+            # with T.block("root"):
+            T_reshape = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            T_subtract = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            T_multiply = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            T_subtract_1 = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(1)))
+            T_divide = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            compute = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)))
+            compute_1 = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(64)), "uint8")
+            T_strided_slice_with_axes = T.alloc_buffer(
+                (T.int64(256), T.int64(4), T.int64(32)), "uint8"
+            )
+            T_left_shift = T.alloc_buffer((T.int64(256), T.int64(4), T.int64(32)), "uint8")
+            T_strided_slice_with_axes_1 = T.alloc_buffer(
+                (T.int64(256), T.int64(4), T.int64(32)), "uint8"
+            )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_reshape"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        rxplaceholder[
+                            ((v_ax1 * T.int64(64) + v_ax2) // T.int64(256) + v_ax0) % T.int64(256),
+                            (v_ax1 * T.int64(64) + v_ax2) % T.int64(256),
+                        ]
+                    )
+                    T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+                    T_reshape[v_ax0, v_ax1, v_ax2] = rxplaceholder[
+                        ((v_ax1 * T.int64(64) + v_ax2) // T.int64(256) + v_ax0) % T.int64(256),
+                        (v_ax1 * T.int64(64) + v_ax2) % T.int64(256),
+                    ]
+            for ax0, ax1, ax2, k2 in T.grid(T.int64(256), T.int64(4), T.int64(1), T.int64(64)):
+                with T.block("T_reshape_red"):
+                    v_ax0, v_ax1, v_ax2, v_k2 = T.axis.remap("SSSR", [ax0, ax1, ax2, k2])
+                    T.reads(T_reshape[v_ax0, v_ax1, v_k2])
+                    T.writes(T_reshape_red_1[v_ax0, v_ax1, v_ax2])
+                    with T.init():
+                        T_reshape_red_1[v_ax0, v_ax1, v_ax2] = T.float32(3.4028234663852886e38)
+                    T_reshape_red_1[v_ax0, v_ax1, v_ax2] = T.min(
+                        T_reshape_red_1[v_ax0, v_ax1, v_ax2], T_reshape[v_ax0, v_ax1, v_k2]
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_subtract"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        T_reshape[v_ax0, v_ax1, v_ax2], T_reshape_red_1[v_ax0, v_ax1, T.int64(0)]
+                    )
+                    T.writes(T_subtract[v_ax0, v_ax1, v_ax2])
+                    T_subtract[v_ax0, v_ax1, v_ax2] = (
+                        T_reshape[v_ax0, v_ax1, v_ax2] - T_reshape_red_1[v_ax0, v_ax1, T.int64(0)]
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_multiply"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_subtract[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_multiply[v_ax0, v_ax1, v_ax2])
+                    T_multiply[v_ax0, v_ax1, v_ax2] = (
+                        T.float32(15) * T_subtract[v_ax0, v_ax1, v_ax2]
+                    )
+            for ax0, ax1, ax2, k2 in T.grid(T.int64(256), T.int64(4), T.int64(1), T.int64(64)):
+                with T.block("T_reshape_red_1"):
+                    v_ax0, v_ax1, v_ax2, v_k2 = T.axis.remap("SSSR", [ax0, ax1, ax2, k2])
+                    T.reads(T_reshape[v_ax0, v_ax1, v_k2])
+                    T.writes(T_reshape_red[v_ax0, v_ax1, v_ax2])
+                    with T.init():
+                        T_reshape_red[v_ax0, v_ax1, v_ax2] = T.float32(-3.4028234663852886e38)
+                    T_reshape_red[v_ax0, v_ax1, v_ax2] = T.max(
+                        T_reshape_red[v_ax0, v_ax1, v_ax2], T_reshape[v_ax0, v_ax1, v_k2]
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(1)):
+                with T.block("T_subtract_1"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        T_reshape_red[v_ax0, v_ax1, v_ax2], T_reshape_red_1[v_ax0, v_ax1, v_ax2]
+                    )
+                    T.writes(T_subtract_1[v_ax0, v_ax1, v_ax2])
+                    T_subtract_1[v_ax0, v_ax1, v_ax2] = (
+                        T_reshape_red[v_ax0, v_ax1, v_ax2] - T_reshape_red_1[v_ax0, v_ax1, v_ax2]
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("T_divide"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_multiply[v_ax0, v_ax1, v_ax2], T_subtract_1[v_ax0, v_ax1, T.int64(0)])
+                    T.writes(T_divide[v_ax0, v_ax1, v_ax2])
+                    T_divide[v_ax0, v_ax1, v_ax2] = (
+                        T_multiply[v_ax0, v_ax1, v_ax2] / T_subtract_1[v_ax0, v_ax1, T.int64(0)]
+                    )
+            for i0, i1, i2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("compute"):
+                    v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+                    T.reads(T_divide[v_i0, v_i1, v_i2])
+                    T.writes(compute[v_i0, v_i1, v_i2])
+                    compute[v_i0, v_i1, v_i2] = T.round(T_divide[v_i0, v_i1, v_i2])
+            for i0, i1, i2 in T.grid(T.int64(256), T.int64(4), T.int64(64)):
+                with T.block("compute_1"):
+                    v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+                    T.reads(compute[v_i0, v_i1, v_i2])
+                    T.writes(compute_1[v_i0, v_i1, v_i2])
+                    compute_1[v_i0, v_i1, v_i2] = T.Cast("uint8", compute[v_i0, v_i1, v_i2])
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(32)):
+                with T.block("T_strided_slice_with_axes"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(compute_1[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_strided_slice_with_axes[v_ax0, v_ax1, v_ax2])
+                    T_strided_slice_with_axes[v_ax0, v_ax1, v_ax2] = compute_1[v_ax0, v_ax1, v_ax2]
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(32)):
+                with T.block("T_left_shift"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(T_strided_slice_with_axes[v_ax0, v_ax1, v_ax2])
+                    T.writes(T_left_shift[v_ax0, v_ax1, v_ax2])
+                    T_left_shift[v_ax0, v_ax1, v_ax2] = T.shift_left(
+                        T_strided_slice_with_axes[v_ax0, v_ax1, v_ax2], T.uint8(4)
+                    )
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(32)):
+                with T.block("T_strided_slice_with_axes_1"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(compute_1[v_ax0, v_ax1, v_ax2 + T.int64(32)])
+                    T.writes(T_strided_slice_with_axes_1[v_ax0, v_ax1, v_ax2])
+                    T_strided_slice_with_axes_1[v_ax0, v_ax1, v_ax2] = compute_1[
+                        v_ax0, v_ax1, v_ax2 + T.int64(32)
+                    ]
+            for ax0, ax1, ax2 in T.grid(T.int64(256), T.int64(4), T.int64(32)):
+                with T.block("T_bitwise_or"):
+                    v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+                    T.reads(
+                        T_left_shift[v_ax0, v_ax1, v_ax2],
+                        T_strided_slice_with_axes_1[v_ax0, v_ax1, v_ax2],
+                    )
+                    T.writes(T_bitwise_or[v_ax0, v_ax1, v_ax2])
+                    T_bitwise_or[v_ax0, v_ax1, v_ax2] = T.bitwise_or(
+                        T_left_shift[v_ax0, v_ax1, v_ax2],
+                        T_strided_slice_with_axes_1[v_ax0, v_ax1, v_ax2],
+                    )
+
+        @R.function
+        def func1(
+            x: R.Tensor((256, 256), dtype="float32"), w1: R.Tensor((256, 256), dtype="float32")
+        ) -> R.Tensor((256, 256), dtype="float32"):
+            R.func_attr({"num_input": 1})
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(
+                    cls.encode,
+                    (w1,),
+                    out_sinfo=[
+                        R.Tensor((256, 4, 32), dtype="uint8"),
+                        R.Tensor((256, 4, 1), dtype="float32"),
+                        R.Tensor((256, 4, 1), dtype="float32"),
+                    ],
+                )
+                lv1: R.Tensor((256, 4, 32), dtype="uint8") = lv[0]
+                lv2: R.Tensor((256, 4, 1), dtype="float32") = lv[1]
+                lv3: R.Tensor((256, 4, 1), dtype="float32") = lv[2]
+                lv4 = R.call_tir(
+                    cls.decode, (lv1, lv2, lv3), out_sinfo=R.Tensor((256, 256), dtype="float32")
+                )
+                w1_t: R.Tensor((256, 256), dtype="float32") = R.permute_dims(lv4, axes=[1, 0])
+                y: R.Tensor((256, 256), dtype="float32") = R.matmul(x, w1_t, out_dtype="void")
+                R.output(y)
+            return y
+
+    mod = Before
+    after = relax.transform.GroupQuantize()(Before)
+    tvm.ir.assert_structural_equal(after, Expected)
+
+    mod = relax.transform.LegalizeOps()(mod)
+    ex_before = relax.build(mod, target="llvm")
+    vm_before = relax.VirtualMachine(ex_before, tvm.cpu())
+    data_nd = tvm.nd.array(np.random.rand(256, 256).astype("float32"))
+    weight_nd = tvm.nd.array(np.random.rand(256, 256).astype("float32"))
+    res_before = vm_before["func1"](data_nd, weight_nd)
+
+    after = relax.transform.LegalizeOps()(after)
+    ex_after = relax.build(after, target="llvm")
+    vm_after = relax.VirtualMachine(ex_after, tvm.cpu())
+    res_after = vm_after["func1"](data_nd, weight_nd)
+
+    tvm.testing.assert_allclose(res_before.numpy(), res_after.numpy(), rtol=0.05)
+
+
+if __name__ == "__main__":
+    test_simple()


### PR DESCRIPTION
1. add a pass called GroupQuantize, which does int4 quantization. 
Given a tensor, we group along the continuous dimension and calcuate the min and max of the group elements. Then we quantize  element x into 4-bit integers by xquant = round((2**4-1)*(x-min)/(max-min))
As int4 is not natively supported, we store 2 int4 into an uint8.

2. Add an attribute "StopLifting" which disables lifting the call_tir into transform_params. We mark the attribute on decoding function of int4 quantization.
cc: @tqchen @vinx13 @MasterJH5574 