### PR TITLE
[Op][Gradient] Refactor op gradients and tests

### DIFF
--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -220,9 +220,7 @@ class BlockBuilder(Object):
         ret: FunctionScope
             A FunctionScope for building a Relax function node.
         """
-        if not params:
-            params = None
-        elif isinstance(params, rx.Var):
+        if isinstance(params, rx.Var):
             params = [params]
         elif isinstance(params, (list, tuple)):
             for param in params:

--- a/python/tvm/relax/transform/legalize_ops/statistical.py
+++ b/python/tvm/relax/transform/legalize_ops/statistical.py
@@ -45,7 +45,7 @@ def _te_mean(x: te.Tensor, axis: List[tir.IntImm], keepdims: bool) -> te.Tensor:
 
 
 def _te_variance(x: te.Tensor, axis: List[tir.IntImm], keepdims: bool) -> te.Tensor:
-    dev = x - _te_mean(x, axis, keepdims)
+    dev = x - _te_mean(x, axis, True)
     return _te_mean(dev * dev, axis, keepdims)
 
 


### PR DESCRIPTION
This PR refactors `tests/python/relax/test_op_gradient_numeric.py`, especially the checker function `relax_check_gradients` to simplify the logic and remove some unnecessary parameters, and added several documents. 

That can make it easier to extend gradient tests.