### PR TITLE
[Cherry-Pick][TOPI] Symbolic shape support for `collapse_sum`

### DIFF
--- a/tests/python/relax/test_transform_legalize_ops_manipulate.py
+++ b/tests/python/relax/test_transform_legalize_ops_manipulate.py
@@ -1013,7 +1013,6 @@ def test_collapse_sum_like():
     tvm.ir.assert_structural_equal(mod, Expected)
 
 
-# @pytest.mark.skip("TOPI collapse_sum not support symbolic now")
 def test_collapse_sum_like_symbolic():
     # fmt: off
     @tvm.script.ir_module


### PR DESCRIPTION
This PR lets the `topi::collapse_sum` support symbolic shape cases. And as a result, in high-level op legalization, we can now legalize `R.collapse_sum_like / R.collapse_sum_to` with symbolic shapes.

Cherry Pick from https://github.com/apache/tvm/pull/14535