### PR TITLE
[UX] Suppress warnings passes

### DIFF
--- a/src/relax/transform/legalize_ops.cc
+++ b/src/relax/transform/legalize_ops.cc
@@ -106,10 +106,6 @@ class LegalizeMutator : public ExprMutator {
       return legalize_map[op](this->builder_, visited_call);
     }
 
-    // No legalization.
-    if (op != call_tir_op && op != call_dps_packed_op) {
-      LOG(WARNING) << "No legalization func for " << op->name << " is found.";
-    }
     return visited_call;
   }
 

--- a/src/relax/transform/meta_schedule.cc
+++ b/src/relax/transform/meta_schedule.cc
@@ -123,8 +123,6 @@ Pass MetaScheduleApplyDatabase(Optional<String> work_dir) {
           new_prim_func = WithAttr(std::move(new_prim_func), tir::attr::kIsScheduled, Bool(true));
           result.Set(gv, new_prim_func);
           continue;
-        } else {
-          LOG(WARNING) << "Tuning record is not found for primfunc: " << gv->name_hint;
         }
       }
       result.Set(gv, base_func);


### PR DESCRIPTION
This PR suppress the warnings of MetaSchedule database application and the relax operator legalization.