### PR TITLE
[Training] Bind TE Gradient Func to TIR Name

### DIFF
--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -22,6 +22,7 @@ from typing import Optional, Callable
 import tvm
 from tvm import TVMError
 from tvm.ir import IRModule
+from tvm.error import TVMError
 
 from ..expr import Function
 from . import _ffi_api
@@ -192,7 +193,7 @@ def bind_te_grad_func(mod: IRModule, func_name: str, te_grad_func: Callable):
     if previous_grad_dict is None:
         return mod.with_attr(attr_key, {func_name: wrap_func})
 
-    assert type(previous_grad_dict) == dict
+    assert isinstance(previous_grad_dict, dict)
     if func_name in previous_grad_dict:
         raise TVMError(f"Grad func has already been bound to the function {func_name}")
     previous_grad_dict[func_name] = wrap_func

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -163,7 +163,7 @@ def bind_te_grad_func(mod: IRModule, func_name: str, te_grad_func: Callable):
 
     Parameters
     ----------
-    bb : BlockBuilder
+    builder : BlockBuilder
         The block builder.
 
     func_name : str
@@ -182,9 +182,9 @@ def bind_te_grad_func(mod: IRModule, func_name: str, te_grad_func: Callable):
 
     attr_key = "te_grad_bind_handler"
 
-    def wrap_func(bb, output_grad_var, relax_call):
+    def wrap_func(builder, output_grad_var, relax_call):
         args = relax_call.args[1]
-        return bb.emit_te(
+        return builder.emit_te(
             te_grad_func, output_grad_var, *args, primfunc_name_hint=func_name + "_grad"
         )
 

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -20,7 +20,6 @@
 from typing import Optional, Callable
 
 import tvm
-from tvm import TVMError
 from tvm.ir import IRModule
 from tvm.error import TVMError
 

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -111,19 +111,34 @@ class BackwardBindingGenerator : private ExprVisitor {
 
     Var adjoint_var = adjoint_var_map_[binding->var];
     const Op& call_op = Downcast<Op>(call->op);
-    const Array<Expr>& partials =
-        gradient_op_map[call_op](binding->var, GetRef<Call>(call), adjoint_var, builder_);
-    ICHECK(partials.size() == call->args.size()) << "partials number != inputs number";
+    Array<Expr> partials;
 
-    for (size_t i = 0; i < partials.size(); ++i) {
-      Expr partial = partials[i];
-      if (IsCallNoGrad(partial)) {  // no grad: don't update
-        continue;
+    Optional<Map<String, PackedFunc>> te_grad_bind_map_ =
+        builder_->GetContextIRModule()->GetAttr<Map<String, PackedFunc>>("te_grad_bind_handler");
+
+    if (call_op == Op::Get("relax.call_tir") && te_grad_bind_map_.defined()) {
+      GlobalVar call_gvar = Downcast<GlobalVar>(call->args[0]);
+      auto handler = te_grad_bind_map_.value()[call_gvar->name_hint];
+      Var result_var = handler(builder_, adjoint_var, GetRef<Call>(call));
+      Tuple args = Downcast<Tuple>(call->args[1]);
+      for (int i = 0; i < static_cast<int>(args->fields.size()); ++i) {
+        Expr partial = TupleGetItem(result_var, i);
+        UpdateStructInfo(partial, GetStructInfo(args->fields[i]));
+        partials.push_back(partial);
+        UpdateAdjoint(args->fields[i], partial);
       }
-      if (!partial->struct_info_.defined()) {
-        UpdateStructInfo(partial, GetStructInfo(call->args[i]));
+    } else {
+      partials = gradient_op_map[call_op](binding->var, GetRef<Call>(call), adjoint_var, builder_);
+      ICHECK(partials.size() == call->args.size()) << "partials number != inputs number";
+      for (size_t i = 0; i < partials.size(); ++i) {
+        if (IsCallNoGrad(partials[i])) {  // no grad: don't update
+          continue;
+        }
+        if (!partials[i]->struct_info_.defined()) {
+          UpdateStructInfo(partials[i], GetStructInfo(call->args[i]));
+        }
+        UpdateAdjoint(call->args[i], partials[i]);
       }
-      UpdateAdjoint(call->args[i], partial);
     }
   }
 
@@ -335,7 +350,7 @@ class GradientMutator : private ExprMutator {
     GradientMutator mutator(mod, require_grads_value, target_index);
     Function new_func_transformed = Downcast<Function>(mutator.VisitExpr(new_func));
 
-    IRModule new_module = GetRef<IRModule>(mod.CopyOnWrite());
+    IRModule new_module = std::move(mutator.GetContextIRModule());
     new_module->Add(GlobalVar(func_name + "_adjoint"), new_func_transformed);
     return new_module;
   }
@@ -343,6 +358,8 @@ class GradientMutator : private ExprMutator {
  private:
   GradientMutator(const IRModule& module, const Array<Var>& require_grads, int target_index)
       : ExprMutator(module), require_grads_(require_grads), target_index_(target_index) {}
+
+  IRModule GetContextIRModule() const { return builder_->GetContextIRModule(); }
 
   Expr VisitExpr_(const FunctionNode* func) final {
     CHECK(func->body->IsInstance<SeqExprNode>()) << "The body of the function must be SeqExpr.";

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -118,6 +118,9 @@ class BackwardBindingGenerator : private ExprVisitor {
 
     if (call_op == Op::Get("relax.call_tir") && te_grad_bind_map_.defined()) {
       GlobalVar call_gvar = Downcast<GlobalVar>(call->args[0]);
+      CHECK(te_grad_bind_map_.value().count(call_gvar->name_hint))
+          << "The TIR prim func name: " << call_gvar->name_hint
+          << " has not TE gradient handler bound.";
       auto handler = te_grad_bind_map_.value()[call_gvar->name_hint];
       Var result_var = handler(builder_, adjoint_var, GetRef<Call>(call));
       Tuple args = Downcast<Tuple>(call->args[1]);

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -350,7 +350,8 @@ class GradientMutator : private ExprMutator {
     GradientMutator mutator(mod, require_grads_value, target_index);
     Function new_func_transformed = Downcast<Function>(mutator.VisitExpr(new_func));
 
-    IRModule new_module = std::move(mutator.GetContextIRModule());
+    IRModule new_module = mutator.GetContextIRModule();
+    new_module.CopyOnWrite();
     new_module->Add(GlobalVar(func_name + "_adjoint"), new_func_transformed);
     return new_module;
   }

--- a/tests/python/relax/test_training_utils.py
+++ b/tests/python/relax/test_training_utils.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for relax training utils."""
-import pytest
 import tvm
 import tvm.testing
 from tvm import relax
@@ -136,7 +135,8 @@ def test_bind_tir_grad_func():
 
     mod = bb.get()
     mod = bind_te_grad_func(mod, "f_mul", f_mul_grad)
-    After = Gradient("main")(mod)
+    with tvm.transform.PassContext():
+        After = Gradient("main")(mod)
 
     # remove the module attr to pass the assert structrual equal
     After = After.without_attr("te_grad_bind_handler")

--- a/tests/python/relax/test_training_utils.py
+++ b/tests/python/relax/test_training_utils.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for relax training utils."""
+import pytest
+import tvm
+import tvm.testing
+from tvm import relax
+from tvm.ir.base import assert_structural_equal
+from tvm.script.parser import relax as R, tir as T, ir as I
+
+from tvm.relax.training.utils import bind_te_grad_func
+from tvm.relax.transform import Gradient
+
+
+def test_bind_tir_grad_func():
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def f_mul(
+            A: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+            B: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+            f_mul_1: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i0, i1 in T.grid(T.int64(5), T.int64(5)):
+                with T.block("f_mul"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(A[v_i0, v_i1], B[v_i0, v_i1])
+                    T.writes(f_mul_1[v_i0, v_i1])
+                    f_mul_1[v_i0, v_i1] = A[v_i0, v_i1] * B[v_i0, v_i1]
+
+        @T.prim_func
+        def f_mul_grad(
+            A: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+            B: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+            C: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+            f_mul_grad_1: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+            f_mul_grad_2: T.Buffer((T.int64(5), T.int64(5)), "float32"),
+        ):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i0, i1 in T.grid(T.int64(5), T.int64(5)):
+                with T.block("f_mul_grad_1"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(C[v_i0, v_i1], A[v_i0, v_i1])
+                    T.writes(f_mul_grad_1[v_i0, v_i1])
+                    f_mul_grad_1[v_i0, v_i1] = C[v_i0, v_i1] * A[v_i0, v_i1]
+            for i0, i1 in T.grid(T.int64(5), T.int64(5)):
+                with T.block("f_mul_grad_2"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(B[v_i0, v_i1], A[v_i0, v_i1])
+                    T.writes(f_mul_grad_2[v_i0, v_i1])
+                    f_mul_grad_2[v_i0, v_i1] = B[v_i0, v_i1] * A[v_i0, v_i1]
+
+        @R.function
+        def main_adjoint(
+            a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")
+        ) -> R.Tuple(
+            R.Tensor((), dtype="float32"),
+            R.Tuple(R.Tensor((5, 5), dtype="float32"), R.Tensor((5, 5), dtype="float32")),
+        ):
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv_adjoint: R.Tensor((5, 5), dtype="float32") = R.broadcast_to(
+                    gv_adjoint, R.shape([5, 5])
+                )
+                lv_1 = R.call_tir(
+                    cls.f_mul_grad,
+                    (lv_adjoint, a, b),
+                    out_sinfo=[
+                        R.Tensor((5, 5), dtype="float32"),
+                        R.Tensor((5, 5), dtype="float32"),
+                    ],
+                )
+                a_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[0]
+                b_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[1]
+                R.output(gv, a_adjoint, b_adjoint)
+            return (gv, (a_adjoint, b_adjoint))
+
+        @R.function
+        def main(
+            a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")
+        ) -> R.Tensor((), dtype="float32"):
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+
+    def f_mul(src1, src2):
+        def mul(*idx):
+            return src1[idx] * src2[idx]
+
+        return tvm.te.compute(src1.shape, mul, name="f_mul")
+
+    def f_mul_grad(output_grad, src1, src2):
+        def mul_grad_1(*idx):
+            return src2[idx] * output_grad[idx]
+
+        def mul_grad_2(*idx):
+            return src1[idx] * output_grad[idx]
+
+        return [
+            tvm.te.compute(output_grad.shape, mul_grad_1, name="f_mul_grad_1"),
+            tvm.te.compute(output_grad.shape, mul_grad_2, name="f_mul_grad_2"),
+        ]
+
+    a = relax.Var("a", relax.TensorStructInfo([5, 5], "float32"))
+    b = relax.Var("b", relax.TensorStructInfo([5, 5], "float32"))
+
+    bb = relax.BlockBuilder()
+    with bb.function("main", [a, b]):
+        with bb.dataflow():
+            d = bb.emit_te(f_mul, a, b, primfunc_name_hint="f_mul")
+            out = bb.emit_output(R.sum(d))
+        bb.emit_func_output(out)
+
+    mod = bb.get()
+    mod = bind_te_grad_func(mod, "f_mul", f_mul_grad)
+    After = Gradient("main")(mod)
+
+    # remove the module attr to pass the assert structrual equal
+    After = After.without_attr("te_grad_bind_handler")
+
+    assert_structural_equal(After, Expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
This PR provides an interface to let user bind a manually written TE gradient function to a TIR function name. This binding information will be stored as an attribute of the module (with attr key `te_grad_bind_handler`).
When the gradient pass meet a `call_tir`, it will try to search whether there is a TE gradient function bound to this name. If so, it will call the handler (i.e. A wrapped function to execute `bb.emit_te(te_grad_func, ...)`) and get the emitted var. Then the partials will be set to `var[0], var[1], ...` and we can do the adjoints propagation.