### PR TITLE
[Unity][Pass] Checkpointing for Gradient pass

### DIFF
--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -200,5 +200,6 @@ def register_te_gradient(te_grad_name: str, te_grad_func: Callable = None):
             )
 
         register_func(func_prefix + te_grad_name, handler)
+        return func
 
     return register(te_grad_func) if te_grad_func else register

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -75,6 +75,22 @@ def Gradient(
                 R.output(original_outputs, grad_1, grad_2, ...)
             return (original_return_value, (grad_1, grad_2, ...))
 
+    This AD pass also supports checkpointing as described in
+    "Training deep nets with sublinear memory cost." - Chen, Tianqi, et al. (2016).
+    You can add a checkpoint attribute, whose value
+    is a list of intermediate Vars in the function, to the given function to specify which Vars
+    should be checkpointed. E.g.
+
+    ```
+    func: relax.Function
+    func_with_checkpoint_attr: relax.Function = func.with_attr("checkpoint", [b, c, d])
+    ```
+
+    The uncheckpointed Vars in the function will be computed again from the checkpointed Vars. The
+    input of the function is unconditionally checkpointed (and does not need to be specified in the
+    attribute). By default, ALL intermediate results are checkpointed (meaning they will not be
+    computed again).
+
     Parameters
     ----------
     func_name : str

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -77,19 +77,18 @@ def Gradient(
 
     This AD pass also supports checkpointing as described in
     "Training deep nets with sublinear memory cost." - Chen, Tianqi, et al. (2016).
-    You can add a checkpoint attribute, whose value
-    is a list of intermediate Vars in the function, to the given function to specify which Vars
-    should be checkpointed. E.g.
+    You can add a checkpoint attribute, whose value is a list of intermediate Vars in the function,
+    to the given function to specify which Vars should be checkpointed. E.g.
 
     ```
     func: relax.Function
     func_with_checkpoint_attr: relax.Function = func.with_attr("checkpoint", [b, c, d])
     ```
 
-    The uncheckpointed Vars in the function will be computed again from the checkpointed Vars. The
-    input of the function is unconditionally checkpointed (and does not need to be specified in the
-    attribute). By default, ALL intermediate results are checkpointed (meaning they will not be
-    computed again).
+    The uncheckpointed Vars in the function will be computed again from the checkpointed Vars in the
+    backward process. The input of the function is unconditionally checkpointed (and does not need
+    to be specified in the attribute). By default, ALL intermediate results are checkpointed
+    (meaning they will not be computed again in the backward process).
 
     Parameters
     ----------

--- a/python/tvm/relax/transform/transform.py
+++ b/python/tvm/relax/transform/transform.py
@@ -86,7 +86,7 @@ def Gradient(
     ```
 
     The uncheckpointed Vars in the function will be computed again from the checkpointed Vars in the
-    backward process. The input of the function is unconditionally checkpointed (and does not need
+    backward process. The inputs of the function are unconditionally checkpointed (and do not need
     to be specified in the attribute). By default, ALL intermediate results are checkpointed
     (meaning they will not be computed again in the backward process).
 

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -25,6 +25,7 @@
  * with respect to the only return value of the function, which needs to be scalar.
  */
 
+#include <tvm/relax/analysis.h>
 #include <tvm/relax/attrs/op.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/nested_msg.h>
@@ -40,10 +41,103 @@
 namespace tvm {
 namespace relax {
 
+// We will use NestedMsg<Expr> to handle adjoint updates involving tuple handling
 using AdjointMsg = NestedMsg<Expr>;
 
-// A tool class for GradientMutator
-// Visit the forward bindings and generate the backward bindings
+/*!
+ * \brief A tool class for BackwardBindingGenerator
+ * Generate the checkpoint bindings. To be specific, in the backward process, we need to use vars
+ * computed in the forward process. Those vars contained in the given checkpoint array, and the
+ * inputs of the function, will be used as is; other vars will be computed again (this will
+ * generate bindings) using the checkpoint vars.
+ */
+class CheckpointGenerator : private ExprMutator {
+ public:
+  /*!
+   * \brief Generate the checkpoint bindings for BackwardBindingGenerator
+   *
+   * \param builder The BlockBuilder of BackwardBindingGenerator, used to generate bindings
+   * \param orig_params The parameters of the forward function
+   * \param forward_block The forward DataflowBlock
+   * \param checkpoint The checkpointed vars. If it is NullOpt, all vars will be checkpointed.
+   */
+  CheckpointGenerator(const BlockBuilder& builder, const Array<Var>& orig_params,
+                      const DataflowBlock& forward_block, const Optional<Array<Var>>& checkpoint)
+      : builder_(builder) {
+    std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> checkpoint_set;
+    if (checkpoint) {
+      checkpoint_set.insert(checkpoint.value().begin(), checkpoint.value().end());
+    }
+
+    // func params will always be checkpointed
+    for (auto var : orig_params) {
+      checkpoint_map_.Set(var, var);
+    }
+
+    for (auto binding : forward_block->bindings) {
+      auto* var_binding = binding.as<VarBindingNode>();
+      CHECK(var_binding) << "Now only support VarBindingNode";
+      auto var = var_binding->var;
+      binding_map_.Set(var, var_binding->value);
+      if (!checkpoint || checkpoint_set.count(var)) {
+        checkpoint_map_.Set(var, var);
+      }
+    }
+  }
+
+  // Receives the forward binding var and value, returns the checkpointed binding var and value.
+  std::pair<Var, Expr> UpdateBinding(const Var& var, const Expr& value) {
+    Expr new_value = VisitExpr(value);
+    auto it = checkpoint_map_.find(var);
+    if (it != checkpoint_map_.end()) {
+      return std::make_pair((*it).second, new_value);
+    }
+    auto new_var = builder_->Emit(new_value, var->name_hint() + "_cp");
+    checkpoint_map_.Set(var, new_var);
+    return std::make_pair(new_var, new_value);
+  }
+
+ private:
+  // Visit the use-site of a defined Var
+  Expr VisitExpr_(const VarNode* op) final { return VisitVar(GetRef<Var>(op)); }
+
+  // Visit the use-site of a defined DataflowVar
+  Expr VisitExpr_(const DataflowVarNode* op) final { return VisitVar(GetRef<Var>(op)); }
+
+  Expr VisitVar(const Var& var) {
+    auto it = checkpoint_map_.find(var);
+    if (it != checkpoint_map_.end()) {
+      return (*it).second;
+    }
+    Var new_var = builder_->Emit(VisitExpr(binding_map_[var]), var->name_hint() + "_cp");
+    checkpoint_map_.Set(var, new_var);
+    return new_var;
+  }
+
+  // Create a new binding for Call node. The purpose for that is to pass the structural equal check.
+  Expr VisitExpr_(const CallNode* call_node) {
+    Expr new_op = this->VisitExpr(call_node->op);
+
+    tvm::Array<Expr> call_args;
+    for (Expr arg : call_node->args) {
+      Expr new_arg = this->VisitExpr(arg);
+      call_args.push_back(new_arg);
+    }
+
+    return Call(new_op, call_args, call_node->attrs, call_node->sinfo_args, call_node->span);
+  }
+
+  BlockBuilder builder_;
+  // The mapping from the forward vars to the checkpoint vars.
+  Map<Var, Var> checkpoint_map_;
+  // The mapping from the forward vars to their bindings, used to generate checkpoint bindings
+  Map<Var, Expr> binding_map_;
+};
+
+/*!
+ * \brief A tool class for GradientMutator
+ * Visit the forward bindings and generate the backward bindings
+ */
 class BackwardBindingGenerator : private ExprVisitor {
  public:
   /*!
@@ -52,23 +146,26 @@ class BackwardBindingGenerator : private ExprVisitor {
    * \param builder The BlockBuilder of GradientMutator, used to generate bindings
    * \param forward_block The forward DataflowBlock
    * \param require_grads The Var list to differentiate w.r.t.
+   * \param orig_params The params of the forward function. Used for checkpointing
    * \param target_var The target Var to differentiate
    * \param orig_return_value The original return value of the function. The new return value is a
-   * 2-tuple, containing the original return value, and a tuple of the adjoints of parameters.
+   * 2-tuple, containing the original return value, and a tuple of the adjoints of parameters
+   * \param checkpoint The checkpointed vars. checkpoint being NullOpt means all Vars are
+   * checkpointed
    * \return The return expr of new adjoint function.
    */
   static Expr Generate(const BlockBuilder& builder, const DataflowBlock& forward_block,
                        const Array<Var>& require_grads, const Var& target_var,
-                       const Expr& orig_return_value) {
-    BackwardBindingGenerator generator(builder);
+                       const Array<Var>& orig_params, const Expr& orig_return_value,
+                       const Optional<Array<Var>>& checkpoint) {
+    CheckpointGenerator checkpoint_generator(builder, orig_params, forward_block, checkpoint);
+    BackwardBindingGenerator generator(builder, checkpoint_generator);
 
-    // Initialize the adjoint of target_var as ones op. We have already check the target.
+    // Initialize the adjoint of target_var as ones op. We have already checked the target.
     auto* target_sinfo = GetStructInfoAs<TensorStructInfoNode>(target_var);
-    const Expr& target_adjoint = ones(target_sinfo->shape.value(), target_sinfo->dtype);
-    UpdateStructInfo(target_adjoint, GetRef<StructInfo>(target_sinfo));
-    generator.adjoint_msg_map_.Set(target_var, AdjointMsg(target_adjoint));
+    generator.UpdateAdjoint(target_var, ones(target_sinfo->shape.value(), target_sinfo->dtype));
 
-    // We do reverse-mode ad, so visit bindings backwards
+    // Do reverse-mode ad, so visit bindings backwards
     for (auto it = forward_block->bindings.rbegin(); it != forward_block->bindings.rend(); ++it) {
       generator.VisitBinding(*it);
     }
@@ -77,34 +174,31 @@ class BackwardBindingGenerator : private ExprVisitor {
   }
 
  private:
-  explicit BackwardBindingGenerator(const BlockBuilder& builder) : builder_(builder) {}
+  explicit BackwardBindingGenerator(const BlockBuilder& builder,
+                                    const CheckpointGenerator& checkpoint_generator)
+      : builder_(builder), checkpoint_generator_(checkpoint_generator) {}
 
   void VisitBinding(const Binding& binding) final {
     // TODO(chaofan, yixin): support other types of bindings
-    CHECK(binding->IsInstance<VarBindingNode>()) << "now only support VarBindingNode";
+    CHECK(binding->IsInstance<VarBindingNode>()) << "Now only support VarBindingNode";
     auto* var_binding = binding.as<VarBindingNode>();
 
-    auto it = adjoint_msg_map_.find(var_binding->var);
-    if (it == adjoint_msg_map_.end()) {
-      // This var is not used in the following bindings
+    if (adjoint_var_map_.count(var_binding->var) == 0) {
+      // Optimization: this var is not used in the following bindings
       return;
     }
-
-    // Meet the definition of binding->var
-    // Create the adjoint var and bind the adjoint value to it
-    EmitAdjoint(var_binding->var, (*it).second, true);
 
     Expr value = var_binding->value;
     // TODO(chaofan, yixin): support other types of binding values
     CHECK(value->IsInstance<CallNode>() || value->IsInstance<TupleNode>() ||
           value->IsInstance<TupleGetItemNode>() || value->IsInstance<VarNode>() ||
           value->IsInstance<ConstantNode>())
-        << "now does not support the type of binding value: " << value;
+        << "Now does not support the type of binding value: " << value;
 
     ExprVisitor::VisitBinding_(var_binding);
   }
 
-  // Handle the adjoint expr of the inputs of binding
+  // The following functions will handle the adjoint expr of the inputs of binding
   // For call node, we would call the registered gradient functions
   void VisitBinding_(const VarBindingNode* binding, const CallNode* call) final {
     // Skip if it is not an Op
@@ -119,53 +213,52 @@ class BackwardBindingGenerator : private ExprVisitor {
     Var adjoint_var = adjoint_var_map_[binding->var];
     const Op& call_op = Downcast<Op>(call->op);
 
+    // Support checkpointing
+    auto [checkpoint_var, checkpoint_call] =
+        checkpoint_generator_.UpdateBinding(binding->var, GetRef<Call>(call));
+
     if (call_op == Op::Get("relax.call_tir")) {
       auto te_grad_name = call->attrs.as<CallTIRAttrs>()->te_grad_name;
       if (te_grad_name) {
-        auto func = tvm::runtime::Registry::Get(te_grad_func_prefix + te_grad_name.value());
-        CHECK(func) << "te grad function " << te_grad_name.value() << " not registered";
-        Var result_var = (*func)(builder_, adjoint_var, GetRef<Call>(call));
+        auto grad_func = tvm::runtime::Registry::Get(te_grad_func_prefix + te_grad_name.value());
+        CHECK(grad_func) << "te grad function " << te_grad_name.value() << " not registered";
+        Var result_var = (*grad_func)(builder_, adjoint_var, checkpoint_call);
         Tuple args = Downcast<Tuple>(call->args[1]);
         for (int i = 0; i < static_cast<int>(args->fields.size()); ++i) {
-          Expr partial = TupleGetItem(result_var, i);
-          UpdateStructInfo(partial, GetStructInfo(args->fields[i]));
-          UpdateAdjoint(args->fields[i], partial);
+          UpdateAdjoint(args->fields[i], TupleGetItem(result_var, i));
         }
       } else {
         LOG(FATAL) << "Differentiation of call_tir op without te_grad_name is not supported yet.";
       }
     } else {
-      Array<Expr> partials =
-          gradient_op_map[call_op](binding->var, GetRef<Call>(call), adjoint_var, builder_);
+      const Array<Expr>& partials = gradient_op_map[call_op](
+          checkpoint_var, Downcast<Call>(checkpoint_call), adjoint_var, builder_);
       ICHECK(partials.size() == call->args.size()) << "partials number != inputs number";
       for (size_t i = 0; i < partials.size(); ++i) {
-        if (IsCallNoGrad(partials[i])) {  // no grad: don't update
+        Expr partial = partials[i];
+        if (IsCallNoGrad(partial)) {  // no grad: don't update
           continue;
         }
-        if (!partials[i]->struct_info_.defined()) {
-          UpdateStructInfo(partials[i], GetStructInfo(call->args[i]));
-        }
-        UpdateAdjoint(call->args[i], partials[i]);
+        UpdateAdjoint(call->args[i], partial);
       }
     }
   }
 
   // For Tuple nodes, we would iterate over the input tuple and update adjoint exprs for each input
   // e.g.
-  // a = (b, c)
+  // a = (b, c) -->
   // b_adjoint += a_adjoint_var[0], c_adjoint += a_adjoint_var[1]
-  // a = ((b, c), d)
+  //
+  // a = ((b, c), d) -->
   // b_adjoint += a_adjoint_var[0][0], c_adjoint += a_adjoint_var[0][1],
   // d_adjoint += a_adjoint_var[1]
-  //
-  // Here we use adjoint_var to simplify calculation
   void VisitBinding_(const VarBindingNode* binding, const TupleNode* tuple) final {
     UpdateAdjoint(GetRef<Tuple>(tuple), adjoint_var_map_[binding->var]);
   }
 
   // For TupleGetItem nodes, we do a partial update
   // e.g.
-  // b = a[0]
+  // b = a[0] -->
   // a_adjoint[0] += b_adjoint_var
   // If a_adjoint does not exist, we would create a zeros tuple as a_adjoint first, and then add
   void VisitBinding_(const VarBindingNode* binding, const TupleGetItemNode* tuple_get_item) final {
@@ -175,14 +268,16 @@ class BackwardBindingGenerator : private ExprVisitor {
     ICHECK(tuple_sinfo) << "The tuple field of a TupleGetItem must has a TupleStructInfo";
 
     const Var& tuple_var = Downcast<Var>(tuple_get_item->tuple);
-    if (adjoint_msg_map_.count(tuple_var) == 0) {
-      const AdjointMsg& init = InitZerosAdjointNested(GetRef<StructInfo>(tuple_sinfo));
-      adjoint_msg_map_.Set(tuple_var, init);
+    if (adjoint_var_map_.count(tuple_var) == 0) {
+      auto nested_zeros = Downcast<Tuple>(NestedZeros(GetRef<StructInfo>(tuple_sinfo)));
+      auto tuple_fields = nested_zeros->fields;
+      tuple_fields.Set(tuple_get_item->index, adjoint_var_map_[binding->var]);
+      EmitAdjoint(tuple_var, Tuple(tuple_fields), false);
+    } else {
+      Expr updated_adjoint = AddInTuple(adjoint_var_map_[tuple_var], tuple_get_item->index,
+                                        adjoint_var_map_[binding->var]);
+      EmitAdjoint(tuple_var, updated_adjoint, false);
     }
-
-    adjoint_msg_map_.Set(tuple_var,
-                         AddInAdjointMsg(adjoint_msg_map_[tuple_var], tuple_get_item->index,
-                                         ExprToAdjointMsg(adjoint_var_map_[binding->var])));
   }
 
   // For assign nodes, we add the adjoint of output to the adjoint of input
@@ -197,16 +292,24 @@ class BackwardBindingGenerator : private ExprVisitor {
   // For constant nodes, we do not have to handle it because it does not contribute to the adjoint
   void VisitBinding_(const VarBindingNode* binding, const ConstantNode* var) final { return; }
 
-  // Add partial (Expr type) to the adjoint of expr
+  // Add partial to the adjoint of expr
+  // expr may be a argument of a func call / tuple definition. Its type can be
+  // 1) var 2) constant (in this case, the adjoint will not be updated)
+  // 3) (maybe nested) tuple of vars / constant
+  //
+  // We use NestedMsg to simplify handling (nested) tuples. That requires converting partial from
+  // expr to NestedMsg or backwards.
   void UpdateAdjoint(const Expr& expr, const Expr& partial) {
-    DecomposeNestedMsg(expr, ExprToAdjointMsg(partial), [&](Expr leaf, AdjointMsg msg) {
+    AdjointMsg partial_msg = ExprToAdjointMsg(builder_->Normalize(partial));
+    DecomposeNestedMsg(expr, partial_msg, [&](Expr leaf, AdjointMsg msg) {
       if (leaf->IsInstance<VarNode>()) {
         const Var& v = Downcast<Var>(leaf);
-        if (adjoint_msg_map_.count(v) == 0) {
-          adjoint_msg_map_.Set(v, msg);
-        } else {
-          adjoint_msg_map_.Set(v, TupleAwareAdd(adjoint_msg_map_[v], msg));
+        Expr updated_adjoint_expr = builder_->Normalize(AdjointMsgToExpr(msg));
+        auto it = adjoint_var_map_.find(v);
+        if (it != adjoint_var_map_.end()) {
+          updated_adjoint_expr = TupleAwareAdd((*it).second, updated_adjoint_expr);
         }
+        EmitAdjoint(v, updated_adjoint_expr, false);
       } else if (leaf->IsInstance<ConstantNode>()) {
         // nothing to do
       } else if (leaf->IsInstance<ShapeExprNode>()) {
@@ -219,21 +322,6 @@ class BackwardBindingGenerator : private ExprVisitor {
     });
   }
 
-  // Transform the adjoint expressed as NestedMsg<Expr> into adjoint Expr, and then emit it
-  // If the adjoint is assigned to a DataflowVar (the adjoint corresponds to a non-output binding),
-  // it would be stored in adjoint_var_map_ for future lookup
-  Var EmitAdjoint(const Var& source_var, const AdjointMsg& adjoint, bool is_dataflow_var) {
-    Var adjoint_var;
-    if (is_dataflow_var) {
-      adjoint_var = builder_->Emit(AdjointMsgToExpr(adjoint), source_var->name_hint() + "_adjoint");
-      adjoint_var_map_.Set(source_var, adjoint_var);
-    } else {
-      adjoint_var =
-          builder_->EmitOutput(AdjointMsgToExpr(adjoint), source_var->name_hint() + "_adjoint");
-    }
-    return adjoint_var;
-  }
-
   // Handle the return value of the AD function.
   // Returns the new return value, which would be like:
   // Tuple(original_return_value,
@@ -243,19 +331,29 @@ class BackwardBindingGenerator : private ExprVisitor {
     Array<Expr> out_adjoints;
 
     for (Var var : require_grads) {
-      // If the var don't have adjoint msg, it do not contribute to the target
-      // so its adjoint is zeros
-      AdjointMsg adjoint =
-          adjoint_msg_map_.Get(var).value_or(InitZerosAdjointNested(GetStructInfo(var)));
-      Var adjoint_var = EmitAdjoint(var, adjoint, false);
-      out_adjoints.push_back(adjoint_var);
+      // If the var don't have adjoint var, it do not contribute to the target. So its adjoint is
+      // zeros
+      auto it = adjoint_var_map_.find(var);
+      if (it == adjoint_var_map_.end()) {
+        UpdateAdjoint(var, NestedZeros(GetStructInfo(var)));
+      }
+      Var adjoint_output_var = EmitAdjoint(var, adjoint_var_map_[var], true);
+      out_adjoints.push_back(adjoint_output_var);
     }
 
     return Tuple({orig_return_value, Tuple(out_adjoints)});
   }
 
-  static bool IsCallZeros(const Expr& expr) {
-    return expr->IsInstance<CallNode>() && Downcast<Call>(expr)->op == Op::Get("relax.zeros");
+  // Emit the adjoint expr as the name `original_var_name` + "_adjoint"
+  Var EmitAdjoint(const Var& source_var, const Expr& adjoint, bool is_output) {
+    Var adjoint_var;
+    if (is_output) {
+      adjoint_var = builder_->EmitOutput(adjoint, source_var->name_hint() + "_adjoint_out");
+    } else {
+      adjoint_var = builder_->Emit(adjoint, source_var->name_hint() + "_adjoint");
+      adjoint_var_map_.Set(source_var, adjoint_var);
+    }
+    return adjoint_var;
   }
 
   static bool IsCallNoGrad(const Expr& expr) {
@@ -280,99 +378,126 @@ class BackwardBindingGenerator : private ExprVisitor {
     });
   }
 
-  // Create a zeros AdjointMsg with specified struct info
-  // When sinfo is TupleStructInfo, we would create a nested zeros Tuple
-  static AdjointMsg InitZerosAdjointNested(const StructInfo& sinfo) {
-    return MapToNestedMsg<Expr>(sinfo, [](StructInfo sinfo) {
+  // Create a zeros Expr with specified struct info
+  // When sinfo is TupleStructInfo, we would create a (nested) Tuple containing zeros
+  static Expr NestedZeros(const StructInfo& sinfo) {
+    AdjointMsg msg = MapToNestedMsg<Expr>(sinfo, [](StructInfo sinfo) {
       auto* tensor_sinfo = sinfo.as<TensorStructInfoNode>();
       ICHECK(tensor_sinfo) << "The leaf of adjoint should be a Tensor.";
-      ICHECK(tensor_sinfo->shape.defined()) << "Error: missing shape when building zeros tuple.";
+      ICHECK(tensor_sinfo->shape.defined()) << "Missing shape when building zeros tuple.";
       const Expr& init = zeros(tensor_sinfo->shape.value(), tensor_sinfo->dtype);
-      UpdateStructInfo(init, sinfo);
       return init;
     });
+    return AdjointMsgToExpr(msg);
   }
 
-  // Return base + increment. A tuple-aware addition.
-  static AdjointMsg TupleAwareAdd(const AdjointMsg& base, const AdjointMsg& increment) {
-    return CombineNestedMsg(base, increment, [&](Expr lhs, Expr rhs) {
-      // a small optimization: a+0=a, 0+a=a.
-      if (IsCallZeros(lhs)) {
-        return rhs;
-      } else if (IsCallZeros(rhs)) {
-        return lhs;
-      }
-      auto* sinfo = GetStructInfoAs<TensorStructInfoNode>(lhs);
-      ICHECK(sinfo) << "The leaf of adjoint should have StructInfo and be a Tensor.";
-      ICHECK(GetStructInfoAs<TensorStructInfoNode>(rhs))
-          << "The leaf of adjoint should have StructInfo and be a Tensor.";
-      Expr res = add(lhs, rhs);
-      UpdateStructInfo(res, GetRef<StructInfo>(sinfo));
-      return res;
-    });
+  // Return lhs + rhs. Requires lhs and rhs has the same StructInfo.
+  // Use NestedMsg to handle cases when lhs and rhs are tuples.
+  static Expr TupleAwareAdd(const Expr& lhs, const Expr& rhs) {
+    AdjointMsg res = CombineNestedMsg(
+        ExprToAdjointMsg(lhs), ExprToAdjointMsg(rhs), [](Expr l_leaf, Expr r_leaf) {
+          auto* sinfo = GetStructInfoAs<TensorStructInfoNode>(l_leaf);
+          ICHECK(sinfo) << "The leaf of adjoint should have StructInfo and be a Tensor.";
+          ICHECK(GetStructInfoAs<TensorStructInfoNode>(r_leaf))
+              << "The leaf of adjoint should have StructInfo and be a Tensor.";
+          Expr res = add(l_leaf, r_leaf);
+          UpdateStructInfo(res, GetRef<StructInfo>(sinfo));
+          return res;
+        });
+    return AdjointMsgToExpr(res);
   }
 
   // Perform an addition in a specified position of tuple.
-  // e.g. tuple=(a, b, c), index=1, increment=d, then return (a, b+d, c)
-  static AdjointMsg AddInAdjointMsg(const AdjointMsg& adjoint, int index,
-                                    const AdjointMsg& increment) {
-    ICHECK(adjoint.IsNested()) << "The adjoint should be nested.";
-    Array<AdjointMsg> arr = adjoint.NestedArray();
-    ICHECK(index >= 0 && index < static_cast<int>(arr.size()));
-    arr.Set(index, TupleAwareAdd(arr[index], increment));
-    return AdjointMsg(arr);
+  // tuple[index] += increment
+  // Impl:
+  // Step 1) t1 = tuple[0], t2 = tuple[1], t3 = tuple[2]
+  // Step 2）t2_new = t2 + increment (TupleAwareAdd)
+  // Step 3) tuple_new = (t1, t2_new, t3)
+  static Expr AddInTuple(const Expr& tuple, int index, const Expr& increment) {
+    auto* sinfo = GetStructInfoAs<TupleStructInfoNode>(tuple);
+    ICHECK(sinfo) << "The first argument of AddInTuple should have tuple struct info.";
+    ICHECK(index >= 0 && index < static_cast<int>(sinfo->fields.size()));
+    Array<Expr> res;
+    for (size_t i = 0; i < sinfo->fields.size(); ++i) {
+      Expr field;
+      if (const auto* expr_tuple = tuple.as<TupleNode>()) {
+        field = expr_tuple->fields[i];
+      } else {
+        field = TupleGetItem(tuple, i);
+        UpdateStructInfo(field, sinfo->fields[i]);
+      }
+      if (static_cast<int>(i) == index) {
+        field = TupleAwareAdd(field, increment);
+      }
+      res.push_back(field);
+    }
+    return Tuple(res);
   }
 
   // The block builder of the corresponding GradientMutator, to emit bindings
   BlockBuilder builder_;
   // Forward Var to its adjoint Var
   Map<Var, Var> adjoint_var_map_;
-  // Forward Var to its adjoint NestedMsg<Expr>
-  // We use NestedMsg<Expr> to save the adjoint information (equivalent to adjoint Expr)
-  // When emitting, adjoint information will be transformed into adjoint Expr
-  Map<Var, AdjointMsg> adjoint_msg_map_;
+  // The generator for checkpoint bindings
+  CheckpointGenerator checkpoint_generator_;
 };
 
 class GradientMutator : private ExprMutator {
  public:
   static IRModule Transform(IRModule mod, String func_name, Optional<Array<Var>> require_grads,
                             int target_index) {
-    auto* old_func_ptr = mod->Lookup(func_name).as<FunctionNode>();
-    CHECK(old_func_ptr) << func_name << "is not a Relax Function";
-    auto old_func = GetRef<Function>(old_func_ptr);
+    // 1. Copy function
+    auto* old_func = mod->Lookup(func_name).as<FunctionNode>();
+    CHECK(old_func) << func_name << "is not a Relax Function";
+    FunctionCopier copier;
+    Function new_func = copier.Copy(GetRef<Function>(old_func));
 
-    // when require_grads is not specified, it would be set to all params of the function
-    auto require_grads_value = require_grads.value_or(old_func->params);
-
-    CheckRequireGrads(require_grads_value, old_func->params, func_name);
-
-    Function new_func = CopyWithNewVars(old_func);
-    // map the parameter list into new params
-    for (size_t i = 0; i < require_grads_value.size(); ++i) {
-      int idx =
-          std::find(old_func->params.begin(), old_func->params.end(), require_grads_value[i]) -
-          old_func->params.begin();
-      require_grads_value.Set(i, new_func->params[idx]);
+    // 2. Handle require_grads
+    // When require_grads is not specified, it would be set to all params of the function
+    if (require_grads) {
+      CheckRequireGrads(require_grads.value(), old_func->params, func_name);
     }
+    // then map the parameter list into new params
+    auto require_grads_value = require_grads.value_or(old_func->params).Map([&copier](Var v) {
+      return copier.var_map[v];
+    });
 
-    GradientMutator mutator(mod, require_grads_value, target_index);
-    Function new_func_transformed = Downcast<Function>(mutator.VisitExpr(new_func));
+    // 3. Handle the checkpoint attribute
+    static constexpr const char* CHECKPOINT_ATTR_KEY = "checkpoint";
+    auto checkpoint = CheckAndUpdateCheckpoint(
+        new_func->attrs.GetAttr<Array<ObjectRef>>(CHECKPOINT_ATTR_KEY), copier.var_map);
 
-    IRModule new_module = mutator.GetContextIRModule();
-    new_module.CopyOnWrite();
-    new_module->Add(GlobalVar(func_name + "_adjoint"), new_func_transformed);
-    return new_module;
+    // 4. Generate the adjoint function, use RemoveAllUnused to simplify it, and then return the
+    // IRModule with the adjoint function
+    return GradientMutator(mod, require_grads_value, target_index, checkpoint)
+        .AddAdjointFunction(new_func, func_name, true);
   }
 
  private:
-  GradientMutator(const IRModule& module, const Array<Var>& require_grads, int target_index)
-      : ExprMutator(module), require_grads_(require_grads), target_index_(target_index) {}
+  GradientMutator(const IRModule& module, const Array<Var>& require_grads, int target_index,
+                  Optional<Array<Var>> checkpoint)
+      : ExprMutator(module),
+        require_grads_(require_grads),
+        checkpoint_(checkpoint),
+        target_index_(target_index) {}
+
+  // Add the adjoint function of func to the IRModule using BlockBuilder
+  IRModule AddAdjointFunction(const Function& func, const String& func_name,
+                              bool remove_all_unused = true) {
+    Function transformed_func = Downcast<Function>(VisitExpr(func));
+    if (remove_all_unused) {
+      transformed_func = RemoveAllUnused(transformed_func);
+    }
+    builder_->AddFunction(transformed_func, func_name + "_adjoint");
+    return builder_->GetContextIRModule();
+  }
 
   IRModule GetContextIRModule() const { return builder_->GetContextIRModule(); }
 
   Expr VisitExpr_(const FunctionNode* func) final {
     CHECK(func->body->IsInstance<SeqExprNode>()) << "The body of the function must be SeqExpr.";
 
+    orig_params_ = func->params;
     Expr new_body = this->VisitExpr(func->body);
 
     return Function(func->params, new_body, NullOpt, func->attrs);
@@ -390,7 +515,7 @@ class GradientMutator : private ExprMutator {
     CheckAndSetTarget(seq_expr->body, target_index_);
 
     BindingBlock new_block = this->VisitBindingBlock(seq_expr->blocks[0]);
-    return SeqExpr({new_block}, this->return_expr_);
+    return SeqExpr({new_block}, return_expr_);
   }
 
   BindingBlock VisitBindingBlock_(const DataflowBlockNode* block) final {
@@ -401,9 +526,9 @@ class GradientMutator : private ExprMutator {
     }
 
     // generate backward bindings and the return value
-    return_expr_ = BackwardBindingGenerator::Generate(this->builder_, GetRef<DataflowBlock>(block),
-                                                      this->require_grads_, this->target_var_,
-                                                      orig_return_expr_);
+    return_expr_ = BackwardBindingGenerator::Generate(builder_, GetRef<DataflowBlock>(block),
+                                                      require_grads_, target_var_, orig_params_,
+                                                      orig_return_expr_, checkpoint_);
 
     return builder_->EndBlock();
   }
@@ -464,12 +589,47 @@ class GradientMutator : private ExprMutator {
     }
   }
 
+  // checkpoint could contain:
+  // 1) Var. In this case, convert it to the Var in the copied function
+  // 2) String. In this case, convert it to the Var with this name in the copied function
+  // Also check all Vars in checkpoint occurs in the original function
+  static Optional<Array<Var>> CheckAndUpdateCheckpoint(const Optional<Array<ObjectRef>>& checkpoint,
+                                                       const Map<Var, Var>& var_map) {
+    if (!checkpoint) {
+      return NullOpt;
+    }
+    Array<Var> result;
+    for (auto var : checkpoint.value()) {
+      if (auto* ptr = var.as<VarNode>()) {
+        auto mapped_var = var_map.Get(GetRef<Var>(ptr));
+        CHECK(mapped_var) << "Var " << ptr->name_hint()
+                          << " is not found in the specified function";
+        result.push_back(mapped_var.value());
+      } else if (auto* ptr = var.as<StringObj>()) {
+        auto str = GetRef<String>(ptr);
+        auto mapped_var = std::find_if(
+            var_map.begin(), var_map.end(),
+            [&str](const std::pair<Var, Var>& pair) { return pair.first->name_hint() == str; });
+        CHECK(mapped_var != var_map.end())
+            << "Var " << GetRef<String>(ptr) << " is not found in the specified function";
+        result.push_back((*mapped_var).second);
+      } else {
+        LOG(FATAL) << "Checkpoint attribute should be an array of either Vars or strings of Var "
+                      "names";
+      }
+    }
+    return result;
+  }
+
   // differentiation sources
   Array<Var> require_grads_;
+  // checkpoint
+  Optional<Array<Var>> checkpoint_;
   // the differentiation target
   int target_index_;
   Var target_var_;
   // the return value of the original function and the differentiated function
+  Array<Var> orig_params_;
   Expr orig_return_expr_;
   Expr return_expr_;
 };

--- a/tests/python/relax/test_training_register_te_gradient.py
+++ b/tests/python/relax/test_training_register_te_gradient.py
@@ -19,7 +19,7 @@ import pytest
 
 import tvm
 import tvm.testing
-from tvm import relax, tir
+from tvm import relax
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R, tir as T, ir as I
 

--- a/tests/python/relax/test_training_setup_trainer.py
+++ b/tests/python/relax/test_training_setup_trainer.py
@@ -68,13 +68,14 @@ def test_simple():
                 gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float64") = R.ones(R.shape([]), dtype="float64")
                 lv1_adjoint: R.Tensor((2, 2), dtype="float64") = R.broadcast_to(gv_adjoint, R.shape([2, 2]))
+                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
                 lv_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv1_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.add(lv_1, lv1_1)
-                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint
+                lv_adjoint1: R.Tensor((2, 2), dtype="float64") = R.add(lv_adjoint, lv_1)
+                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint1
                 y_adjoint: R.Tensor((2, 2), dtype="float64") = x1_adjoint
-                R.output(gv, y_adjoint)
-            return (gv, (y_adjoint,))
+                y_adjoint_out: R.Tensor((2, 2), dtype="float64") = y_adjoint
+                R.output(gv, y_adjoint_out)
+            return (gv, (y_adjoint_out,))
 
         @R.function
         def optimizer(params: R.Tuple(R.Tensor((2, 2), dtype="float64")), gradients: R.Tuple(R.Tensor((2, 2), dtype="float64")), optim_states: R.Tuple(R.Tensor((), dtype="int64"))) -> R.Tuple(R.Tuple(R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((), dtype="int64"))):
@@ -142,13 +143,14 @@ def test_states():
                 gv: R.Tensor((), dtype="float64") = R.sum(lv1, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float64") = R.ones(R.shape([]), dtype="float64")
                 lv1_adjoint: R.Tensor((2, 2), dtype="float64") = R.broadcast_to(gv_adjoint, R.shape([2, 2]))
+                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
                 lv_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv1_1: R.Tensor((2, 2), dtype="float64") = R.multiply(lv1_adjoint, lv)
-                lv_adjoint: R.Tensor((2, 2), dtype="float64") = R.add(lv_1, lv1_1)
-                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint
+                lv_adjoint1: R.Tensor((2, 2), dtype="float64") = R.add(lv_adjoint, lv_1)
+                x1_adjoint: R.Tensor((2, 2), dtype="float64") = lv_adjoint1
                 y_adjoint: R.Tensor((2, 2), dtype="float64") = x1_adjoint
-                R.output(z1, gv, y_adjoint)
-            return ((gv, z1), (y_adjoint,))
+                y_adjoint_out: R.Tensor((2, 2), dtype="float64") = y_adjoint
+                R.output(z1, gv, y_adjoint_out)
+            return ((gv, z1), (y_adjoint_out,))
 
         @R.function
         def optimizer(params: R.Tuple(R.Tensor((2, 2), dtype="float64")), gradients: R.Tuple(R.Tensor((2, 2), dtype="float64")), optim_states: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64"))) -> R.Tuple(R.Tuple(R.Tensor((2, 2), dtype="float64")), R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64"))):
@@ -163,9 +165,10 @@ def test_states():
                 lv1: R.Tensor((2, 2), dtype="float64") = R.multiply(R.const(0.10000000000000001, "float64"), y_v_new)
                 y_new: R.Tensor((2, 2), dtype="float64") = R.subtract(y, lv1)
                 params_new: R.Tuple(R.Tensor((2, 2), dtype="float64")) = (y_new,)
-                optim_states_new: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64")) = (num_steps_new, y_v_new)
+                optim_states_new: R.Tuple(R.Tensor((), dtype="int64"), R.Tensor((2, 2), dtype="float64")) = num_steps_new, y_v_new
                 R.output(params_new, optim_states_new)
             return (params_new, optim_states_new)
+
     # fmt: on
 
     sinfo = relax.TensorStructInfo((2, 2), "float64")

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import tvm
+import numpy as np
 import pytest
+
+import tvm
 import tvm.testing
 from tvm import relax
+from tvm._ffi.base import TVMError
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R, tir as T, ir as I
-from tvm._ffi.base import TVMError
-import numpy as np
 
 
 def test_simple():
@@ -38,20 +39,21 @@ def test_simple():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor(None, "float32", ndim=0):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor(None, "float32", ndim=0),R.Tuple(R.Tensor(None, "float32", ndim=2)),):
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                x_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -74,27 +76,27 @@ def test_assign_binding():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((3, 3), "float32") = lv1
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((3, 3), "float32") = lv1
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -117,27 +119,29 @@ def test_multiple_uses():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv1_adjoint)
+                x_adjoint2: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint1, lv1_adjoint)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint2
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.add(lv2_adjoint, lv1_adjoint)
-                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv, lv1_adjoint)
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -149,7 +153,7 @@ def test_unused():
     @I.ir_module
     class Before:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 lv1 = R.add(x, x)
                 lv2 = R.add(lv1, x)
@@ -160,24 +164,25 @@ def test_unused():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, x)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, x)
-                gv: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                x_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, x)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, x)
+                gv: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -189,11 +194,7 @@ def test_default_require_grads():
     @I.ir_module
     class Before:
         @R.function
-        def main(
-            x: R.Tensor((3, 3), "float32"),
-            y: R.Tensor((3, 3), "float32"),
-            z: R.Tensor((3, 3), "float32"),
-        ):
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 lv1 = R.add(x, y)
                 lv2 = R.add(lv1, z)
@@ -204,33 +205,31 @@ def test_default_require_grads():
     @I.ir_module
     class Expected1:
         @R.function
-        def main(
-            x: R.Tensor((3, 3), "float32"),
-            y: R.Tensor((3, 3), "float32"),
-            z: R.Tensor((3, 3), "float32"),
-        ) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                z_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                R.output(gv, x_adjoint, y_adjoint, z_adjoint)
-            return (gv, (x_adjoint, y_adjoint, z_adjoint))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After1 = relax.transform.Gradient("main")(Before)
@@ -240,28 +239,27 @@ def test_default_require_grads():
     @I.ir_module
     class Expected2:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"))):
-            # block 0
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = R.add(lv1, z)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv2_adjoint
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.add(lv1, z)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After2 = relax.transform.Gradient("main", require_grads=Before["main"].params[0])(Before)
@@ -284,25 +282,27 @@ def test_target_index():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((), "float32"), R.Tensor((), "float32")):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32"), R.Tensor((), dtype="float32")), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                lv3: R.Tensor((), "float32") = R.sum(y, axis=None, keepdims=False)
-                R.output(lv1, lv2, lv3)
-            return (lv1, lv2, lv3)
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                lv3: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+                lv3_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(lv3_adjoint, R.shape([3, 3]))
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(lv1, lv2, lv3, x_adjoint_out, y_adjoint_out)
+            return ((lv1, lv2, lv3), (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((), "float32"), R.Tensor((), "float32")), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((), dtype="float32"), R.Tensor((), dtype="float32")):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = x
-                lv2: R.Tensor((), "float32") = R.sum(x, axis=None, keepdims=False)
-                lv3: R.Tensor((), "float32") = R.sum(y, axis=None, keepdims=False)
-                lv3_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                x_adjoint: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                y_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(lv3_adjoint, (3, 3))
-                R.output(lv1, lv2, lv3, x_adjoint, y_adjoint)
-            return ((lv1, lv2, lv3), (x_adjoint, y_adjoint))
+                lv1: R.Tensor((3, 3), dtype="float32") = x
+                lv2: R.Tensor((), dtype="float32") = R.sum(x, axis=None, keepdims=False)
+                lv3: R.Tensor((), dtype="float32") = R.sum(y, axis=None, keepdims=False)
+                R.output(lv1, lv2, lv3)
+            return (lv1, lv2, lv3)
     # fmt: on
 
     After = relax.transform.Gradient("main", target_index=2)(Before)
@@ -328,39 +328,43 @@ def test_tuple():
                 R.output(gv)
             return gv
 
+
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tensor(None, "float32", ndim=0):
+        def main_adjoint(x: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (y, z)
-                lv2: R.Tensor((3, 3), "float32") = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv1[0]
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (y, z)
+                lv2: R.Tensor((3, 3), dtype="float32") = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv1_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv)
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                x_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_adjoint, lv1_1)
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[0]
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                x_adjoint_out: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (y, z)
-                lv2: R.Tensor((3, 3), "float32") = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv1[0]
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv2, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv4, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv4_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv2_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv1_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv)
-                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                x_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv2_adjoint, lv11)
-                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[0]
-                z_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
-                R.output(gv, x_adjoint, y_adjoint, z_adjoint)
-            return (gv, (x_adjoint, y_adjoint, z_adjoint))
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (y, z)
+                lv2: R.Tensor((3, 3), dtype="float32") = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -375,57 +379,60 @@ def test_tuple_assignment():
         def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")):
             with R.dataflow():
                 lv1 = (x, y)
-                lv4 = lv1[0]
-                lv7 = R.add(lv4, x)
-                lv2 = lv1
-                lv3 = lv2[0]
-                lv5 = R.add(lv3, lv7)
-                gv = R.sum(lv5)
+                lv2 = lv1[0]
+                lv3 = R.add(lv2, x)
+                lv4 = lv1
+                lv5 = lv4[0]
+                lv6 = R.add(lv5, lv3)
+                gv = R.sum(lv6)
                 R.output(gv)
             return gv
 
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv4: R.Tensor((3, 3), "float32") = lv1[0]
-                lv7: R.Tensor((3, 3), "float32") = R.add(lv4, x)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv5: R.Tensor((3, 3), "float32") = R.add(lv3, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, x)
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[0]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv5_adjoint, lv)
+                lv1_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv4_adjoint
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
+                lv1_1: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[0]
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.add(lv1_1, lv2_adjoint)
+                lv3_1: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                lv1_adjoint1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_1, lv3_1)
+                lv4_1: R.Tensor((3, 3), dtype="float32") = lv1_adjoint1[0]
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv4_1)
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint1[1]
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
-            # block 0
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv4: R.Tensor((3, 3), "float32") = lv1[0]
-                lv7: R.Tensor((3, 3), "float32") = R.add(lv4, x)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv5: R.Tensor((3, 3), "float32") = R.add(lv3, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv5_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv5_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv)
-                lv7_adjoint: R.Tensor((3, 3), "float32") = lv5_adjoint
-                lv4_adjoint: R.Tensor((3, 3), "float32") = lv7_adjoint
-                lv11: R.Tensor((3, 3), "float32") = lv2_adjoint[0]
-                lv21: R.Tensor((3, 3), "float32") = R.add(lv11, lv4_adjoint)
-                lv31: R.Tensor((3, 3), "float32") = lv2_adjoint[1]
-                lv1_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv21, lv31)
-                lv41: R.Tensor((3, 3), "float32") = lv1_adjoint[0]
-                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv7_adjoint, lv41)
-                y_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                lv1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv1[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, x)
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[0]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv5, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -459,51 +466,66 @@ def test_tuple_nested():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = ((y, z), u)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1[0]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.add(lv3, lv5)
-                lv7: R.Tensor((3, 3), "float32") = x[1]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv6, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv8, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((y, z), u)
+                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1[0]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = x[1]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv6, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv8, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                x_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((lv, lv1_1), lv7_adjoint)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv2_1, lv5_adjoint)
+                lv3_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv1_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = (lv4_adjoint, lv3_1)
+                lv4_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv2_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_adjoint, lv4_1)
+                lv5_1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x_adjoint[0]
+                lv6_1: R.Tensor((3, 3), dtype="float32") = lv5_1[0]
+                lv7_1: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[0]
+                lv8_1: R.Tensor((3, 3), dtype="float32") = R.add(lv6_1, lv7_1)
+                lv9: R.Tensor((3, 3), dtype="float32") = lv5_1[1]
+                lv10: R.Tensor((3, 3), dtype="float32") = lv2_adjoint[1]
+                lv11: R.Tensor((3, 3), dtype="float32") = R.add(lv9, lv10)
+                lv12: R.Tensor((3, 3), dtype="float32") = x_adjoint[1]
+                x_adjoint1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((lv8_1, lv11), lv12)
+                lv13: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1_adjoint[0]
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv13[0]
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = lv13[1]
+                u_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint[1]
+                x_adjoint_out: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = x_adjoint1
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                u_adjoint_out: R.Tensor((3, 3), dtype="float32") = u_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = ((y, z), u)
-                lv2: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = x[0]
-                lv3: R.Tensor((3, 3), "float32") = lv2[0]
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1[0]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.add(lv3, lv5)
-                lv7: R.Tensor((3, 3), "float32") = x[1]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv6, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv8, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv8_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv7_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv6_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv5_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv4_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv, lv5_adjoint)
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
-                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv2_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv3_adjoint, lv11)
-                lv21: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv1_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = (lv4_adjoint, lv21)
-                x_adjoint: R.Tuple(R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")), R.Tensor((3, 3), "float32")) = (lv2_adjoint, lv7_adjoint)
-                lv31: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv1_adjoint[0]
-                y_adjoint: R.Tensor((3, 3), "float32") = lv31[0]
-                z_adjoint: R.Tensor((3, 3), "float32") = lv31[1]
-                u_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint[1]
-                R.output(gv, x_adjoint, y_adjoint, z_adjoint, u_adjoint)
-            return (gv, (x_adjoint, y_adjoint, z_adjoint, u_adjoint))
+                lv1: R.Tuple(R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")), R.Tensor((3, 3), dtype="float32")) = ((y, z), u)
+                lv2: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = x[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = lv2[0]
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv1[0]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.add(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = x[1]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv6, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv8, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -512,7 +534,6 @@ def test_tuple_nested():
 
 def test_tuple_update():
     """One tensor `x` is used in and out of tuple many times."""
-
     # fmt: off
     @I.ir_module
     class Before:
@@ -536,61 +557,66 @@ def test_tuple_update():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv0: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = lv0[0]
-                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, y)
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv1, lv3)
-                lv5: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv6: R.Tensor((3, 3), "float32") = lv5[0]
-                lv7: R.Tensor((3, 3), "float32") = lv0[0]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
-                lv9: R.Tensor((3, 3), "float32") = R.add(lv8, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, y)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv1, lv3)
+                lv5: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv6: R.Tensor((3, 3), dtype="float32") = lv5[0]
+                lv7: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv4, lv6)
+                lv9: R.Tensor((3, 3), dtype="float32") = R.add(lv8, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv9_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = lv9_adjoint
+                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = lv9_adjoint
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = lv8_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv0_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv7_adjoint, lv)
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv5_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv6_adjoint, lv1_1)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv5_adjoint[0]
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = lv5_adjoint[1]
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = lv4_adjoint
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = lv3_adjoint
+                y_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(y_adjoint, lv3_adjoint)
+                lv2_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint[0]
+                lv3_1: R.Tensor((3, 3), dtype="float32") = R.add(lv2_1, lv2_adjoint)
+                lv4_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint[1]
+                lv0_adjoint1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv3_1, lv4_1)
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv1_adjoint)
+                y_adjoint2: R.Tensor((3, 3), dtype="float32") = R.add(y_adjoint1, lv1_adjoint)
+                lv5_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint1[0]
+                x_adjoint2: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint1, lv5_1)
+                lv6_1: R.Tensor((3, 3), dtype="float32") = lv0_adjoint1[1]
+                y_adjoint3: R.Tensor((3, 3), dtype="float32") = R.add(y_adjoint2, lv6_1)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint2
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint3
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv0: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, y)
-                lv2: R.Tensor((3, 3), "float32") = lv0[0]
-                lv3: R.Tensor((3, 3), "float32") = R.add(lv2, y)
-                lv4: R.Tensor((3, 3), "float32") = R.add(lv1, lv3)
-                lv5: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (x, y)
-                lv6: R.Tensor((3, 3), "float32") = lv5[0]
-                lv7: R.Tensor((3, 3), "float32") = lv0[0]
-                lv8: R.Tensor((3, 3), "float32") = R.add(lv4, lv6)
-                lv9: R.Tensor((3, 3), "float32") = R.add(lv8, lv7)
-                gv: R.Tensor((), "float32") = R.sum(lv9, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv9_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv8_adjoint: R.Tensor((3, 3), "float32") = lv9_adjoint
-                lv7_adjoint: R.Tensor((3, 3), "float32") = lv9_adjoint
-                lv6_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv5_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv6_adjoint, lv)
-                lv4_adjoint: R.Tensor((3, 3), "float32") = lv8_adjoint
-                lv3_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv2_adjoint: R.Tensor((3, 3), "float32") = lv3_adjoint
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv4_adjoint
-                lv11: R.Tensor((3, 3), "float32") = R.add(lv7_adjoint, lv2_adjoint)
-                lv21: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv0_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv11, lv21)
-                lv31: R.Tensor((3, 3), "float32") = lv5_adjoint[0]
-                lv41: R.Tensor((3, 3), "float32") = R.add(lv31, lv1_adjoint)
-                lv51: R.Tensor((3, 3), "float32") = lv0_adjoint[0]
-                x_adjoint: R.Tensor((3, 3), "float32") = R.add(lv41, lv51)
-                lv61: R.Tensor((3, 3), "float32") = lv5_adjoint[1]
-                lv71: R.Tensor((3, 3), "float32") = R.add(lv61, lv3_adjoint)
-                lv81: R.Tensor((3, 3), "float32") = R.add(lv71, lv1_adjoint)
-                lv91: R.Tensor((3, 3), "float32") = lv0_adjoint[1]
-                y_adjoint: R.Tensor((3, 3), "float32") = R.add(lv81, lv91)
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                lv0: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv3: R.Tensor((3, 3), dtype="float32") = R.add(lv2, y)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.add(lv1, lv3)
+                lv5: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (x, y)
+                lv6: R.Tensor((3, 3), dtype="float32") = lv5[0]
+                lv7: R.Tensor((3, 3), dtype="float32") = lv0[0]
+                lv8: R.Tensor((3, 3), dtype="float32") = R.add(lv4, lv6)
+                lv9: R.Tensor((3, 3), dtype="float32") = R.add(lv8, lv7)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -613,26 +639,27 @@ def test_tuple_op_simple():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((6,), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((6,), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((6,), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(x, indices_or_sections=2, axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(x, indices_or_sections=2, axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv2_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([6]))
+                lv1_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((6,), dtype="float32") = R.concat(lv1_adjoint, axis=0)
+                x_adjoint_out: R.Tensor((6,), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((6,), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((6,), "float32"))):
+        def main(x: R.Tensor((6,), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(x, indices_or_sections=2, axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                gv: R.Tensor((), "float32") = R.sum(lv2, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv2_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv1_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                x_adjoint: R.Tensor((6,), "float32") = R.concat(lv1_adjoint, axis=0)
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(x, indices_or_sections=2, axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -659,46 +686,48 @@ def test_tuple_op_construct():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3,), "float32"), y: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32"))) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3,), dtype="float32"), y: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32"))) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")))):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = (x, x)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.concat(y, axis=0)
-                lv5: R.Tensor((6,), "float32") = R.add(lv2, lv3)
-                lv6: R.Tensor((6,), "float32") = R.add(lv5, lv4)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = (x, x)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.concat(y, axis=0)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv2, lv3)
+                lv6: R.Tensor((6,), dtype="float32") = R.add(lv5, lv4)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv6_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([6]))
+                lv5_adjoint: R.Tensor((6,), dtype="float32") = lv6_adjoint
+                lv4_adjoint: R.Tensor((6,), dtype="float32") = lv6_adjoint
+                lv2_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                lv3_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                y_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv4_adjoint, indices_or_sections=[3], axis=0)
+                lv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((3,), dtype="float32") = lv[0]
+                lv1_1: R.Tensor((3,), dtype="float32") = lv[1]
+                x_adjoint1: R.Tensor((3,), dtype="float32") = R.add(x_adjoint, lv1_1)
+                lv1_adjoint: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                lv2_1: R.Tensor((3,), dtype="float32") = lv1_adjoint[0]
+                x_adjoint2: R.Tensor((3,), dtype="float32") = R.add(x_adjoint1, lv2_1)
+                lv3_1: R.Tensor((3,), dtype="float32") = lv1_adjoint[1]
+                x_adjoint3: R.Tensor((3,), dtype="float32") = R.add(x_adjoint2, lv3_1)
+                x_adjoint_out: R.Tensor((3,), dtype="float32") = x_adjoint3
+                y_adjoint_out: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3,), "float32"), y: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32"))) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3,), "float32"), R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")))):
+        def main(x: R.Tensor((3,), dtype="float32"), y: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32"))) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = (x, x)
-                lv2: R.Tensor((6,), "float32") = R.concat(lv1, axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.concat(y, axis=0)
-                lv5: R.Tensor((6,), "float32") = R.add(lv2, lv3)
-                lv6: R.Tensor((6,), "float32") = R.add(lv5, lv4)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv6_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv5_adjoint: R.Tensor((6,), "float32") = lv6_adjoint
-                lv4_adjoint: R.Tensor((6,), "float32") = lv6_adjoint
-                lv3_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv2_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv1_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                lv: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
-                lv11: R.Tensor((3,), "float32") = lv[0]
-                lv21: R.Tensor((3,), "float32") = lv[1]
-                lv31: R.Tensor((3,), "float32") = R.add(lv11, lv21)
-                lv41: R.Tensor((3,), "float32") = lv1_adjoint[0]
-                lv51: R.Tensor((3,), "float32") = R.add(lv31, lv41)
-                lv61: R.Tensor((3,), "float32") = lv1_adjoint[1]
-                x_adjoint: R.Tensor((3,), "float32") = R.add(lv51, lv61)
-                y_adjoint: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv4_adjoint, indices_or_sections=[3], axis=0)
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                lv1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = (x, x)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat(lv1, axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.concat(y, axis=0)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv2, lv3)
+                lv6: R.Tensor((6,), dtype="float32") = R.add(lv5, lv4)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -728,43 +757,41 @@ def test_tuple_op_const():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3,), "float32")) -> R.Tensor((), "float32"):
-            # block 0
+        def main_adjoint(x: R.Tensor((3,), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3,), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((6,), "float32") = R.concat((c1, c2), axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat((c3, x), axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.add(lv1, lv2)
-                lv5: R.Tensor((6,), "float32") = R.add(lv4, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
+                lv1: R.Tensor((6,), dtype="float32") = R.concat((c1, c2), axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat((c3, x), axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.add(lv1, lv2)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv4, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv5_adjoint: R.Tensor((6,), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([6]))
+                lv4_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                lv3_adjoint: R.Tensor((6,), dtype="float32") = lv5_adjoint
+                lv2_adjoint: R.Tensor((6,), dtype="float32") = lv4_adjoint
+                lv: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
+                x_adjoint: R.Tensor((3,), dtype="float32") = lv[0]
+                lv1_1: R.Tensor((3,), dtype="float32") = lv[1]
+                x_adjoint1: R.Tensor((3,), dtype="float32") = R.add(x_adjoint, lv1_1)
+                lv2_1: R.Tuple(R.Tensor((3,), dtype="float32"), R.Tensor((3,), dtype="float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
+                lv3_1: R.Tensor((3,), dtype="float32") = lv2_1[1]
+                x_adjoint2: R.Tensor((3,), dtype="float32") = R.add(x_adjoint1, lv3_1)
+                x_adjoint_out: R.Tensor((3,), dtype="float32") = x_adjoint2
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
 
         @R.function
-        def main_adjoint(x: R.Tensor((3,), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3,), "float32"))):
-            # block 0
+        def main(x: R.Tensor((3,), dtype="float32")) -> R.Tensor((), dtype="float32"):
             with R.dataflow():
-                lv1: R.Tensor((6,), "float32") = R.concat((c1, c2), axis=0)
-                lv2: R.Tensor((6,), "float32") = R.concat((c3, x), axis=0)
-                lv3: R.Tensor((6,), "float32") = R.concat((x, x), axis=0)
-                lv4: R.Tensor((6,), "float32") = R.add(lv1, lv2)
-                lv5: R.Tensor((6,), "float32") = R.add(lv4, lv3)
-                gv: R.Tensor((), "float32") = R.sum(lv5, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv5_adjoint: R.Tensor((6,), "float32") = R.broadcast_to(gv_adjoint, (6,))
-                lv4_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv3_adjoint: R.Tensor((6,), "float32") = lv5_adjoint
-                lv2_adjoint: R.Tensor((6,), "float32") = lv4_adjoint
-                lv1_adjoint: R.Tensor((6,), "float32") = lv4_adjoint
-                lv: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv3_adjoint, indices_or_sections=[3], axis=0)
-                lv11: R.Tensor((3,), "float32") = lv[0]
-                lv21: R.Tensor((3,), "float32") = lv[1]
-                lv31: R.Tensor((3,), "float32") = R.add(lv11, lv21)
-                lv41: R.Tuple(R.Tensor((3,), "float32"), R.Tensor((3,), "float32")) = R.split(lv2_adjoint, indices_or_sections=[3], axis=0)
-                lv51: R.Tensor((3,), "float32") = lv41[1]
-                x_adjoint: R.Tensor((3,), "float32") = R.add(lv31, lv51)
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
+                lv1: R.Tensor((6,), dtype="float32") = R.concat((c1, c2), axis=0)
+                lv2: R.Tensor((6,), dtype="float32") = R.concat((c3, x), axis=0)
+                lv3: R.Tensor((6,), dtype="float32") = R.concat((x, x), axis=0)
+                lv4: R.Tensor((6,), dtype="float32") = R.add(lv1, lv2)
+                lv5: R.Tensor((6,), dtype="float32") = R.add(lv4, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv5, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -794,42 +821,348 @@ def test_const():
     @I.ir_module
     class Expected:
         @R.function
-        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tensor((), "float32"):
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, cst)
-                lv2: R.Tensor((3, 3), "float32") = cst
-                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (cst, (cst, lv1))
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3[1]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.subtract(lv5, lv2)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, cst)
+                lv2: R.Tensor((3, 3), dtype="float32") = cst
+                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (cst, (cst, lv1))
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3[1]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.subtract(lv5, lv2)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = lv6_adjoint
+                lv: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv4_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = (lv, lv5_adjoint)
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                lv3_adjoint: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (lv1_1, lv4_adjoint)
+                lv2_1: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3_adjoint[1]
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = lv2_1[1]
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = lv1_adjoint
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.zeros(R.shape([3, 3]), dtype="float32")
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.add(x, cst)
+                lv2: R.Tensor((3, 3), dtype="float32") = cst
+                lv3: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))) = (cst, (cst, lv1))
+                lv4: R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32")) = lv3[1]
+                lv5: R.Tensor((3, 3), dtype="float32") = lv4[1]
+                lv6: R.Tensor((3, 3), dtype="float32") = R.subtract(lv5, lv2)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv6, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_shape_expr():
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 4), "float32")):
+            with R.dataflow():
+                s = R.shape([3, 2, 2])
+                lv = R.reshape(x, s)
+                gv = R.sum(lv)
                 R.output(gv)
             return gv
 
+    @I.ir_module
+    class Expected:
         @R.function
-        def main_adjoint(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32")) -> R.Tuple(R.Tensor((), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))):
+        def main_adjoint(x: R.Tensor((3, 4), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 4), dtype="float32"))):
             with R.dataflow():
-                lv1: R.Tensor((3, 3), "float32") = R.add(x, cst)
-                lv2: R.Tensor((3, 3), "float32") = cst
-                lv3: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (cst, (cst, lv1))
-                lv4: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3[1]
-                lv5: R.Tensor((3, 3), "float32") = lv4[1]
-                lv6: R.Tensor((3, 3), "float32") = R.subtract(lv5, lv2)
-                gv: R.Tensor((), "float32") = R.sum(lv6, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), "float32") = R.ones((), "float32")
-                lv6_adjoint: R.Tensor((3, 3), "float32") = R.broadcast_to(gv_adjoint, (3, 3))
-                lv5_adjoint: R.Tensor((3, 3), "float32") = lv6_adjoint
-                lv: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv4_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = (lv, lv5_adjoint)
-                lv11: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                lv3_adjoint: R.Tuple(R.Tensor((3, 3), "float32"), R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32"))) = (lv11, lv4_adjoint)
-                lv2_adjoint: R.Tensor((3, 3), "float32") = R.negative(lv6_adjoint)
-                lv21: R.Tuple(R.Tensor((3, 3), "float32"), R.Tensor((3, 3), "float32")) = lv3_adjoint[1]
-                lv1_adjoint: R.Tensor((3, 3), "float32") = lv21[1]
-                x_adjoint: R.Tensor((3, 3), "float32") = lv1_adjoint
-                y_adjoint: R.Tensor((3, 3), "float32") = R.zeros((3, 3), "float32")
-                R.output(gv, x_adjoint, y_adjoint)
-            return (gv, (x_adjoint, y_adjoint))
+                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
+                lv: R.Tensor((3, 2, 2), dtype="float32") = R.reshape(x, s)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv_adjoint: R.Tensor((3, 2, 2), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 2, 2]))
+                x_adjoint: R.Tensor((3, 4), dtype="float32") = R.reshape(lv_adjoint, R.shape([3, 4]))
+                x_adjoint_out: R.Tensor((3, 4), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 4), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            with R.dataflow():
+                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
+                lv: R.Tensor((3, 2, 2), dtype="float32") = R.reshape(x, s)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+# Checkpointing structural equality checks
+
+
+def test_cp_sequential():
+    """Comp. graph is a sequence"""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            R.func_attr({"checkpoint": ["lv2"]})
+            with R.dataflow():
+                lv1 = R.power(x, R.const(3, "float32"))
+                lv2 = R.power(lv1, R.const(3, "float32"))
+                lv3 = R.power(lv2, R.const(3, "float32"))
+                lv4 = R.power(lv3, R.const(3, "float32"))
+                gv = R.sum(lv4)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            R.func_attr({"checkpoint": ["lv2"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(3, "float32"))
+                lv1_1: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv2_1: R.Tensor((3, 3), dtype="float32") = R.power(lv3_cp, lv1_1)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv, lv2_1)
+                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, R.const(3, "float32"))
+                lv7: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv8: R.Tensor((3, 3), dtype="float32") = R.power(lv2, lv7)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
+                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv12: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(3, "float32"))
+                lv13: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv14: R.Tensor((3, 3), dtype="float32") = R.power(lv1_cp, lv13)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv12, lv14)
+                lv18: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(3, "float32"))
+                lv19: R.Tensor((), dtype="float32") = R.subtract(R.const(3, "float32"), R.const(1, "float32"))
+                lv20: R.Tensor((3, 3), dtype="float32") = R.power(x, lv19)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv18, lv20)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            R.func_attr({"checkpoint": ["lv2"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.power(x, R.const(3, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.power(lv1, R.const(3, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.power(lv2, R.const(3, "float32"))
+                lv4: R.Tensor((3, 3), dtype="float32") = R.power(lv3, R.const(3, "float32"))
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After, Expected)
+
+
+def test_cp_tree():
+    """Comp. graph is a output-directed tree"""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32"), y: R.Tensor((3, 3), "float32"), z: R.Tensor((3, 3), "float32"), u: R.Tensor((3, 3), "float32"), v: R.Tensor((3, 3), "float32")):
+            R.func_attr({"checkpoint": ["lv1", "lv4"]})
+            with R.dataflow():
+                lv1 = x * y
+                lv2 = lv1 * z
+                lv3 = u * v
+                lv4 = lv2 * lv3
+                gv = R.sum(lv4)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected1:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"), R.Tensor((3, 3), dtype="float32"))):
+            R.func_attr({"checkpoint": ["lv1", "lv4"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv2_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv3_cp)
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv2_cp)
+                u_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, v)
+                v_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint, u)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, z)
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1)
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, y)
+                y_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, x)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
+                y_adjoint_out: R.Tensor((3, 3), dtype="float32") = y_adjoint
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                u_adjoint_out: R.Tensor((3, 3), dtype="float32") = u_adjoint
+                v_adjoint_out: R.Tensor((3, 3), dtype="float32") = v_adjoint
+                R.output(gv, x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out, v_adjoint_out)
+            return (gv, (x_adjoint_out, y_adjoint_out, z_adjoint_out, u_adjoint_out, v_adjoint_out))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            R.func_attr({"checkpoint": ["lv1", "lv4"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After1 = relax.transform.Gradient("main")(Before)
+    assert_structural_equal(After1, Expected1)
+
+    # fmt: off
+    @I.ir_module
+    class Expected2:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            R.func_attr({"checkpoint": ["lv1", "lv4"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv3_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, lv3_cp)
+                z_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1)
+                z_adjoint_out: R.Tensor((3, 3), dtype="float32") = z_adjoint
+                R.output(gv, z_adjoint_out)
+            return (gv, (z_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32"), y: R.Tensor((3, 3), dtype="float32"), z: R.Tensor((3, 3), dtype="float32"), u: R.Tensor((3, 3), dtype="float32"), v: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            R.func_attr({"checkpoint": ["lv1", "lv4"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, y)
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, z)
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(u, v)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2, lv3)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv4, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+
+    After2 = relax.transform.Gradient("main", require_grads=Before["main"].params[2])(Before)
+    assert_structural_equal(After2, Expected2)
+
+
+def test_cp_dag():
+    """Comp. graph is a DAG with only one output. Here we only test the simple case: comp. graph
+    is a sequence of sub-graphs, and the checkpoints are the intersections of connected
+    subgraphs."""
+    # fmt: off
+    @I.ir_module
+    class Before:
+        @R.function
+        def main(x: R.Tensor((3, 3), "float32")):
+            R.func_attr({"checkpoint": ["lv3", "lv6", "lv9", "gv"]})
+            with R.dataflow():
+                lv1 = x * R.const(2, "float32")
+                lv2 = lv1 * R.const(2, "float32")
+                lv3 = x * lv2
+                lv4 = lv3 * R.const(2, "float32")
+                lv5 = lv4 * R.const(2, "float32")
+                lv6 = lv3 * lv5
+                lv7 = lv6 * R.const(2, "float32")
+                lv8 = lv7 * R.const(2, "float32")
+                lv9 = lv6 * lv8
+                gv = R.sum(lv9)
+                R.output(gv)
+            return gv
+
+    @I.ir_module
+    class Expected:
+        @R.function
+        def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
+            R.func_attr({"checkpoint": ["lv3", "lv6", "lv9", "gv"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, R.const(2, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(x, lv2)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4, R.const(2, "float32"))
+                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7, R.const(2, "float32"))
+                lv9: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv9_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
+                lv7_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7_cp, R.const(2, "float32"))
+                lv6_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv9_adjoint, lv8_cp)
+                lv8_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv9_adjoint, lv6)
+                lv7_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv8_adjoint, R.const(2, "float32"))
+                lv1_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7_adjoint, R.const(2, "float32"))
+                lv6_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(lv6_adjoint, lv1_1)
+                lv4_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_cp, R.const(2, "float32"))
+                lv3_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6_adjoint1, lv5_cp)
+                lv5_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6_adjoint1, lv3)
+                lv4_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv5_adjoint, R.const(2, "float32"))
+                lv4_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4_adjoint, R.const(2, "float32"))
+                lv3_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(lv3_adjoint, lv4_1)
+                lv1_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
+                lv2_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_cp, R.const(2, "float32"))
+                x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint1, lv2_cp)
+                lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3_adjoint1, x)
+                lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(2, "float32"))
+                lv7_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(2, "float32"))
+                x_adjoint1: R.Tensor((3, 3), dtype="float32") = R.add(x_adjoint, lv7_1)
+                x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint1
+                R.output(gv, x_adjoint_out)
+            return (gv, (x_adjoint_out,))
+
+        @R.function
+        def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            R.func_attr({"checkpoint": ["lv3", "lv6", "lv9", "gv"]})
+            with R.dataflow():
+                lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
+                lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, R.const(2, "float32"))
+                lv3: R.Tensor((3, 3), dtype="float32") = R.multiply(x, lv2)
+                lv4: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, R.const(2, "float32"))
+                lv5: R.Tensor((3, 3), dtype="float32") = R.multiply(lv4, R.const(2, "float32"))
+                lv6: R.Tensor((3, 3), dtype="float32") = R.multiply(lv3, lv5)
+                lv7: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, R.const(2, "float32"))
+                lv8: R.Tensor((3, 3), dtype="float32") = R.multiply(lv7, R.const(2, "float32"))
+                lv9: R.Tensor((3, 3), dtype="float32") = R.multiply(lv6, lv8)
+                gv: R.Tensor((), dtype="float32") = R.sum(lv9, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
     # fmt: on
 
     After = relax.transform.Gradient("main")(Before)
@@ -1055,47 +1388,6 @@ def test_report_error():
         relax.transform.Gradient("main")(IntDtypeTuple)
 
 
-def test_shape_expr():
-    # fmt: off
-    @I.ir_module
-    class Before:
-        @R.function
-        def main(x: R.Tensor((3, 4), "float32")):
-            with R.dataflow():
-                s = R.shape([3, 2, 2])
-                lv = R.reshape(x, s)
-                gv = R.sum(lv)
-                R.output(gv)
-            return gv
-
-    @I.ir_module
-    class Expected:
-        @R.function
-        def main_adjoint(x: R.Tensor((3, 4), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 4), dtype="float32"))):
-            with R.dataflow():
-                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
-                lv = R.reshape(x, s)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
-                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv_adjoint : R.Tensor([3, 2, 2], "float32") = R.broadcast_to(gv_adjoint, R.shape([3, 2, 2]))
-                x_adjoint: R.Tensor((3, 4), dtype="float32") = R.reshape(lv_adjoint, R.shape([3, 4]))
-                R.output(gv, x_adjoint)
-            return (gv, (x_adjoint,))
-
-        @R.function
-        def main(x: R.Tensor((3, 4), dtype="float32")) -> R.Tensor((), dtype="float32"):
-            with R.dataflow():
-                s: R.Shape([3, 2, 2]) = R.shape([3, 2, 2])
-                lv = R.reshape(x, s)
-                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
-                R.output(gv)
-            return gv
-    # fmt: on
-
-    After = relax.transform.Gradient("main")(Before)
-    assert_structural_equal(After, Expected)
-
-
 def test_mlp_script():
     """
     An example of single layer multi-layer perceptron. You can add extra layers if you want.
@@ -1133,17 +1425,19 @@ def test_mlp_script():
                 lv: R.Tensor((), dtype="float32") = R.divide(loss_adjoint, R.const(3, "float32"))
                 lv1: R.Tensor((), dtype="float32") = R.negative(lv)
                 logits_adjoint: R.Tensor((3, 5), dtype="float32") = R.multiply(lv1, label)
-                lv2: R.Tensor((3, 1), dtype="float32") = R.sum(logits_adjoint, axis=[-1], keepdims=True)
-                lv3: R.Tensor((3, 5), dtype="float32") = R.exp(logits)
-                lv4: R.Tensor((3, 5), dtype="float32") = R.multiply(lv2, lv3)
-                out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv4)
+                lv3: R.Tensor((3, 1), dtype="float32") = R.sum(logits_adjoint, axis=[-1], keepdims=True)
+                lv4: R.Tensor((3, 5), dtype="float32") = R.exp(logits)
+                lv5: R.Tensor((3, 5), dtype="float32") = R.multiply(lv3, lv4)
+                out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv5)
                 lv0_adjoint: R.Tensor((3, 5), dtype="float32") = out_adjoint
-                lv5: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                lv6: R.Tensor((10, 5), dtype="float32") = R.matmul(lv5, lv0_adjoint, out_dtype="void")
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv6, R.shape([10, 5]))
                 b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(out_adjoint, R.shape([5]))
-                R.output(loss, w0_adjoint, b0_adjoint)
-            return (loss, (w0_adjoint, b0_adjoint))
+                lv8: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
+                lv9: R.Tensor((10, 5), dtype="float32") = R.matmul(lv8, lv0_adjoint, out_dtype="void")
+                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv9, R.shape([10, 5]))
+                w0_adjoint_out: R.Tensor((10, 5), dtype="float32") = w0_adjoint
+                b0_adjoint_out: R.Tensor((5,), dtype="float32") = b0_adjoint
+                R.output(loss, w0_adjoint_out, b0_adjoint_out)
+            return (loss, (w0_adjoint_out, b0_adjoint_out))
 
         @R.function
         def main(x: R.Tensor((3, 10), dtype="float32"), w0: R.Tensor((10, 5), dtype="float32"), b0: R.Tensor((5,), dtype="float32"), label: R.Tensor((3, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):


### PR DESCRIPTION
This PR supports checkpointing for the Gradient pass. 

To be specific, in the backward process, we need to use vars computed in the forward process. Those vars contained in the given checkpoint array, and the inputs of the function, will be used as is; other vars will be computed again (this will generate bindings) using the checkpoint vars.

Example:

```
@I.ir_module
class Before:
    @R.function
    def main(x: R.Tensor((3, 3), "float32")):
        R.func_attr({"checkpoint": ["lv2", "gv"]})
        with R.dataflow():
            lv1 = x * R.const(2, "float32")
            lv2 = lv1 * R.const(2, "float32")
            gv = R.sum(lv2)
            R.output(gv)
        return gv

After = relax.transform.Gradient("main")(Before)
After.show(None, False)
```
-->
```
@I.ir_module
class Module:
    @R.function
    def main_adjoint(x: R.Tensor((3, 3), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((3, 3), dtype="float32"))):
        R.func_attr({"checkpoint": ["lv2", "gv"]})
        with R.dataflow():
            lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
            lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, R.const(2, "float32"))
            gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
            gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
            lv2_adjoint: R.Tensor((3, 3), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([3, 3]))
            lv1_cp: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
            lv1_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, R.const(2, "float32"))
            lv: R.Tensor((3, 3), dtype="float32") = R.multiply(lv2_adjoint, lv1_cp)
            x_adjoint: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, R.const(2, "float32"))
            lv1_1: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1_adjoint, x)
            x_adjoint_out: R.Tensor((3, 3), dtype="float32") = x_adjoint
            R.output(gv, x_adjoint_out)
        return (gv, (x_adjoint_out,))

    @R.function
    def main(x: R.Tensor((3, 3), dtype="float32")) -> R.Tensor((), dtype="float32"):
        R.func_attr({"checkpoint": ["lv2", "gv"]})
        with R.dataflow():
            lv1: R.Tensor((3, 3), dtype="float32") = R.multiply(x, R.const(2, "float32"))
            lv2: R.Tensor((3, 3), dtype="float32") = R.multiply(lv1, R.const(2, "float32"))
            gv: R.Tensor((), dtype="float32") = R.sum(lv2, axis=None, keepdims=False)
            R.output(gv)
        return gv
```
lv1_cp is checkpointed

This PR also fixes bugs in te gradients while intergrating with the te gradient infra.