### PR TITLE
[Relax] Enhance CopyWithNewVars utility

### DIFF
--- a/src/relax/transform/utils.h
+++ b/src/relax/transform/utils.h
@@ -285,6 +285,37 @@ class SymbolicVarRenewMutator : public ExprMutator, tir::ExprMutator {
 };
 
 /*!
+ * \brief Copy a function while renewing the relax Vars and the tir Vars.
+ * \details All variables that are bound inside the original function would be copied to satisfy
+ * the restriction in the well-formed check: Variables in Relax must be bound exactly once.
+ */
+class FunctionCopier : public ExprMutator {
+ public:
+  Function Copy(Function func) {
+    auto new_func = Downcast<Function>(VisitExpr(func));
+    return SymbolicVarRenewMutator::Renew(new_func);
+  }
+
+  Var VisitVarDef_(const DataflowVarNode* var) override {
+    Var new_var = ExprMutator::VisitVarDef_(var);
+    Var copied_var = DataflowVar(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
+    var_remap_[var->vid] = copied_var;
+    var_map.Set(GetRef<Var>(var), copied_var);
+    return copied_var;
+  }
+
+  Var VisitVarDef_(const VarNode* var) override {
+    Var new_var = ExprMutator::VisitVarDef_(var);
+    Var copied_var = Var(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
+    var_remap_[var->vid] = copied_var;
+    var_map.Set(GetRef<Var>(var), copied_var);
+    return copied_var;
+  }
+
+  Map<Var, Var> var_map;
+};
+
+/*!
  * \brief Create a Constant with a scalar
  *
  * \param dtype The data type.

--- a/src/relax/utils.cc
+++ b/src/relax/utils.cc
@@ -111,39 +111,13 @@ bool IsLeafOrTuple(const Expr& expr) {
          expr.as<OpNode>() || expr.as<TupleNode>();
 }
 
-/*! \brief Helper to implement CopyWithNewVars.*/
-class FunctionCopier : public ExprMutator {
- public:
-  static Function Transform(Function func) {
-    FunctionCopier copier;
-    // All variables that are bound inside the original function would be copied
-    // to satisfy the restriction in the well-formed check: Variables in Relax
-    // must be bound exactly once.
-    auto new_func = Downcast<Function>(copier.VisitExpr(func));
-    return SymbolicVarRenewMutator::Renew(new_func);
-  }
-
-  Var VisitVarDef_(const DataflowVarNode* var) override {
-    Var new_var = ExprMutator::VisitVarDef_(var);
-    Var copied_var = DataflowVar(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
-    var_remap_[var->vid] = copied_var;
-    return copied_var;
-  }
-
-  Var VisitVarDef_(const VarNode* var) override {
-    Var new_var = ExprMutator::VisitVarDef_(var);
-    Var copied_var = Var(new_var->name_hint(), GetStructInfo(new_var), new_var->span);
-    var_remap_[var->vid] = copied_var;
-    return copied_var;
-  }
-};
-
 /*!
  * \brief Copy a new Relax function with new remapped vars and symbolic vars.
+ * To get the var mapping from old vars to new vars, see FuncCopier in src/relax/transform/utils.h.
  * \param func The Relax function we want to copy.
  * \return The copied function.
  */
-Function CopyWithNewVars(Function func) { return FunctionCopier::Transform(func); }
+Function CopyWithNewVars(Function func) { return FunctionCopier().Copy(func); }
 
 TVM_REGISTER_GLOBAL("relax.CopyWithNewVars").set_body_typed(CopyWithNewVars);
 


### PR DESCRIPTION
This PR enhances the relax::CopyWithNewVars util by adding a `var_map_` member to the `FuncCopier` class. 

And the FuncCopier pass is moved to `src/relax/transform/utils.h` to include it in other C++ source files. 

Therefore, we can know the variable mapping from the old function to the new function. To use this you will need to:

```
// only copying a function
#include <tvm/relax/utils.h>
auto func = CopyWithNewVars(old_func);

// getting the var_map_ while copying the function
#include "src/relax/transform/utils.h"
auto copier = FuncCopier();
auto func = copier.Transform(old_func);
Map<Var, Var> var_map = copier.var_map_;
```