### PR TITLE
[Cherry-Pick][Training] More Relax operators supported

### DIFF
--- a/python/tvm/relax/op/binary.py
+++ b/python/tvm/relax/op/binary.py
@@ -250,11 +250,9 @@ def not_equal(x1: Expr, x2: Expr) -> Expr:
     return _ffi_api.not_equal(x1, x2)  # type: ignore
 
 
-###################### Comparison operators ######################
-
-
 def maximum(x1: Expr, x2: Expr) -> Expr:
     """Element-wise maximum
+
     Parameters
     ----------
     x1 : relax.Expr
@@ -272,6 +270,7 @@ def maximum(x1: Expr, x2: Expr) -> Expr:
 
 def minimum(x1: Expr, x2: Expr) -> Expr:
     """Element-wise minimum
+
     Parameters
     ----------
     x1 : relax.Expr

--- a/tests/python/relax/test_op_gradient_numeric.py
+++ b/tests/python/relax/test_op_gradient_numeric.py
@@ -233,6 +233,7 @@ def test_unary(target, dev, unary_op_func, can_be_neg):
     (relax.op.multiply,),
     (relax.op.divide,),
     (relax.op.power,),
+    (relax.op.maximum,),
 )
 
 
@@ -297,6 +298,12 @@ def test_ones_zeros(target, dev, create_op_func):
     relax_check_gradients(
         create_op_func, [], target, dev, ignore_grads=[0], shape=(3, 3), dtype="float32"
     )
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_triu(target, dev):
+    data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
+    relax_check_gradients(relax.op.triu, [data_numpy], target, dev, k=0)
 
 
 ##################### Statistical #####################
@@ -483,6 +490,19 @@ def test_expand_dims_list(target, dev):
     relax_check_gradients(relax.op.expand_dims, [data_numpy], target, dev, axis=(0, 2, 3))
 
 
+@tvm.testing.parametrize_targets("llvm")
+def test_broadcast_to(target, dev):
+    data_numpy = np.random.randint(1, 16, (3, 4)).astype(np.float32)
+    relax_check_gradients(
+        relax.op.broadcast_to,
+        [data_numpy],
+        target,
+        dev,
+        shape=(2, 3, 4),
+        ignore_grads=[1],
+    )
+
+
 ##################### Index #####################
 
 
@@ -592,6 +612,12 @@ def test_relu(target, dev):
     sign = np.random.randint(0, 2, (3, 3)).astype(np.float32) * 2 - 1
     data1_numpy *= sign
     relax_check_gradients(relax.op.nn.relu, [data1_numpy], target, dev)
+
+
+@tvm.testing.parametrize_targets("llvm")
+def test_silu(target, dev):
+    data1_numpy = np.random.randint(0, 16, (3, 3)).astype(np.float32)
+    relax_check_gradients(relax.op.nn.silu, [data1_numpy], target, dev)
 
 
 @tvm.testing.parametrize_targets("llvm")


### PR DESCRIPTION
This PR introduces gradient functions for the following Relax operators:
- `R.maximum`
- `R.triu`
- `R.broadcast_to`
- `R.silu`

Cherry pick from https://github.com/apache/tvm/pull/14777 (Without the gradient of `R.minimum`).
**Drop this commit** when rebasing onto unity.