### PR TITLE
[Fix][Training] Fix Bind TE Grad and Handle ExternOp in Gradient Pass

### DIFF
--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -197,7 +197,8 @@ def bind_te_grad_func(mod: IRModule, func_name: str, te_grad_func: Callable):
     if previous_grad_dict is None:
         return mod.with_attr(attr_key, {func_name: handler})
 
-    assert isinstance(previous_grad_dict, dict)
+    # tvm.container.Map -> dict
+    previous_grad_dict = dict(previous_grad_dict)
     if func_name in previous_grad_dict:
         raise TVMError(f"Grad func has already been bound to the function {func_name}")
     previous_grad_dict[func_name] = handler

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -106,6 +106,11 @@ class BackwardBindingGenerator : private ExprVisitor {
   // Handle the adjoint expr of the inputs of binding
   // For call node, we would call the registered gradient functions
   void VisitBinding_(const VarBindingNode* binding, const CallNode* call) final {
+    // Skip if it is not an Op
+    if (!call->op->IsInstance<OpNode>()) {
+      return;
+    }
+
     static const OpAttrMap<FPrimalGradient>& gradient_op_map =
         Op::GetAttrMap<FPrimalGradient>("FPrimalGradient");
 


### PR DESCRIPTION
This PR contains two quick fixes for current gradient mechanism. First, it fixes the type of the attribute `te_grad_bind_handler` (use a cast from dict to tvm Map). Second, we ignore the ExternOp when `VisitingBinding` in the Gradient pass.