### PR TITLE
[Relax][Training] Update on registering te gradient functions

### DIFF
--- a/include/tvm/relax/attrs/op.h
+++ b/include/tvm/relax/attrs/op.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tvm/relax/attrs/op.h
+ * \brief Attributes for relax specific operators.
+ */
+#ifndef TVM_RELAX_ATTRS_CREATE_H_
+#define TVM_RELAX_ATTRS_CREATE_H_
+
+#include <tvm/relax/expr.h>
+
+namespace tvm {
+namespace relax {
+
+/*! \brief Attributes used in call_tir */
+struct CallTIRAttrs : public tvm::AttrsNode<CallTIRAttrs> {
+  Optional<String> te_grad_name;
+  Map<String, ObjectRef> te_grad_kwargs;
+
+  TVM_DECLARE_ATTRS(CallTIRAttrs, "relax.attrs.CallTIRAttrs") {
+    TVM_ATTR_FIELD(te_grad_name)
+        .describe("The name of the te gradient function associated with this call_tir node.");
+    TVM_ATTR_FIELD(te_grad_kwargs)
+        .describe("The keyword arguments passed to the te gradient function.");
+  }
+};  // struct CallTIRAttrs
+
+}  // namespace relax
+}  // namespace tvm
+
+#endif  // TVM_RELAX_ATTRS_OP_H_

--- a/include/tvm/relax/attrs/op.h
+++ b/include/tvm/relax/attrs/op.h
@@ -21,8 +21,8 @@
  * \file tvm/relax/attrs/op.h
  * \brief Attributes for relax specific operators.
  */
-#ifndef TVM_RELAX_ATTRS_CREATE_H_
-#define TVM_RELAX_ATTRS_CREATE_H_
+#ifndef TVM_RELAX_ATTRS_OP_H_
+#define TVM_RELAX_ATTRS_OP_H_
 
 #include <tvm/relax/expr.h>
 

--- a/python/tvm/relax/block_builder.py
+++ b/python/tvm/relax/block_builder.py
@@ -302,7 +302,9 @@ class BlockBuilder(Object):
                   that gets generated.
                 - 'primfunc_attrs' is reserved for passing func attributes to
                   be added to the PrimFunc that gets created.
-
+                - 'te_grad_name' is the registered name of the te gradient function associated with
+                  the call_tir node.
+                - 'te_grad_kwargs' is the keyword arguments passed to the te gradient function.
 
         Returns
         -------
@@ -311,13 +313,15 @@ class BlockBuilder(Object):
         """
 
         primfunc_name = kwargs.pop("primfunc_name_hint", None)
+        te_grad_name = kwargs.pop("te_grad_name", None)
+        te_grad_kwargs = kwargs.pop("te_grad_kwargs", None)
         tir_func, call_args, output_sinfo, tir_vars = gen_call_tir_inputs(func, *args, **kwargs)
 
         if not primfunc_name:
             primfunc_name = func.__name__
         gvar = self.add_func(tir_func, primfunc_name)
 
-        return call_tir(gvar, call_args, output_sinfo, tir_vars)
+        return call_tir(gvar, call_args, output_sinfo, tir_vars, te_grad_name, te_grad_kwargs)
 
     def emit_te(self, func: Callable, *args: Any, **kwargs: Any) -> Var:
         """Emit a call node according to the te function.

--- a/python/tvm/relax/op/base.py
+++ b/python/tvm/relax/op/base.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # pylint: disable=redefined-builtin
 """The base Relax operators."""
-from typing import Union, List, Tuple, Optional, Callable
+from typing import Dict, Union, List, Tuple, Optional, Callable
 
 
 import tvm
@@ -72,6 +72,8 @@ def call_tir(
     args: Expr,
     out_sinfo: Union[TensorStructInfo, List[TensorStructInfo]],
     tir_vars: Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]] = None,
+    te_grad_name: Optional[str] = None,
+    te_grad_kwargs: Optional[Dict[str, Object]] = None,
 ) -> Call:
     """
     Call a tir.prim_func and return the output.
@@ -92,6 +94,13 @@ def call_tir(
     tir_vars : Optional[Union[ShapeExpr, Tuple[PrimExpr], List[PrimExpr]]]
         ShapeExpr representing a tuple of integers to unpack when calling func. Is null if not used
 
+    te_grad_name : Optional[str]
+        The registered name of the te gradient function associated with the call_tir node. See
+        tvm.relax.training.utils.register_te_gradient.
+
+    te_grad_kwargs : Optional[Dict[str, Object]]
+        The keyword arguments passed to the te gradient function.
+
     Returns
     -------
     ret: Call
@@ -106,7 +115,9 @@ def call_tir(
     if isinstance(tir_vars, (list, tuple)):
         tir_vars = ShapeExpr(tir_vars)
 
-    return _ffi_api.call_tir(gvar, args, out_sinfo, tir_vars)  # type: ignore
+    return _ffi_api.call_tir(  # type: ignore
+        gvar, args, out_sinfo, tir_vars, te_grad_name, te_grad_kwargs
+    )
 
 
 @args_converter.auto

--- a/python/tvm/relax/op/op_attrs.py
+++ b/python/tvm/relax/op/op_attrs.py
@@ -19,6 +19,11 @@ from tvm.ir import Attrs
 import tvm._ffi
 
 
+@tvm._ffi.register_object("relax.attrs.CallTIRAttrs")
+class CallTIRAttrs(Attrs):
+    """Attributes used in call_tir operator"""
+
+
 @tvm._ffi.register_object("relax.attrs.InitAttrs")
 class InitAttrs(Attrs):
     """Attributes used in full/full_like, ones/ones_like, and zeros/zeros_like operator"""

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -160,7 +160,8 @@ def AppendLoss(
 
 
 def register_te_gradient(te_grad_name: str, te_grad_func: Callable = None):
-    """Bind te grad function to an existing tir PrimFunc name.
+    """Register a te gradient function bind with name te_grad_name. te_grad_name can be referenced
+    later in call_tir nodes.
 
     Parameters
     ----------

--- a/python/tvm/relax/training/utils.py
+++ b/python/tvm/relax/training/utils.py
@@ -22,8 +22,6 @@ from typing import Optional, Callable
 import tvm
 from tvm import relax
 from tvm._ffi.registry import register_func
-from tvm.ir import IRModule
-from tvm.error import TVMError
 from tvm.relax.block_builder import BlockBuilder
 
 from ..expr import Function

--- a/src/relax/op/op.cc
+++ b/src/relax/op/op.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/relax/analysis.h>
+#include <tvm/relax/attrs/op.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/utils.h>
 #include <tvm/relay/op.h>
@@ -75,6 +76,8 @@ StructInfo InferStructInfoShapeOf(const Call& call, const BlockBuilder& ctx) {
 
 // call_tir
 
+TVM_REGISTER_NODE_TYPE(CallTIRAttrs);
+
 StructInfo InferStructInfoCallTIR(const Call& call, const BlockBuilder& ctx) {
   if (call->sinfo_args.size() != 1) {
     ctx->ReportFatal(Diagnostic::Error(call)
@@ -88,6 +91,7 @@ StructInfo InferStructInfoCallTIR(const Call& call, const BlockBuilder& ctx) {
 
 RELAY_REGISTER_OP("relax.call_tir")
     .set_num_inputs(3)
+    .set_attrs_type<CallTIRAttrs>()
     .add_argument("func", "Expr", "The destination-passing-style function.")
     .add_argument("args", "Tuple", "The input arguments.")
     .add_argument("packed_ints", "Expr",
@@ -96,7 +100,8 @@ RELAY_REGISTER_OP("relax.call_tir")
     .set_attr<FInferStructInfo>("FInferStructInfo", InferStructInfoCallTIR);
 
 Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
-                 Optional<Expr> packed_ints) {
+                 Optional<Expr> packed_ints, Optional<String> te_grad_name,
+                 Optional<Map<String, ObjectRef>> te_grad_kwargs) {
   for (const TensorStructInfo& sinfo : out_sinfo_list) {
     const auto* shape = sinfo->shape.as<ShapeExprNode>();
     CHECK(shape != nullptr) << "out_sinfo of call_tir should have defined ShapeExpr as shape. "
@@ -111,13 +116,17 @@ Expr MakeCallTIR(Expr func, Tuple args, Array<TensorStructInfo> out_sinfo_list,
     out_sinfo = TupleStructInfo({out_sinfo_list.begin(), out_sinfo_list.end()});
   }
 
+  ObjectPtr<CallTIRAttrs> attrs = make_object<CallTIRAttrs>();
+  attrs->te_grad_name = te_grad_name;
+  attrs->te_grad_kwargs = te_grad_kwargs.value_or(Map<String, ObjectRef>());
+
   static const Op& op = Op::Get("relax.call_tir");
   Call call;
   if (!packed_ints) {
     // don't use additional optional argument
-    call = Call(op, {func, args}, {}, {out_sinfo});
+    call = Call(op, {func, args}, Attrs(attrs), {out_sinfo});
   } else {
-    call = Call(op, {func, args, packed_ints.value()}, {}, {out_sinfo});
+    call = Call(op, {func, args, packed_ints.value()}, Attrs(attrs), {out_sinfo});
   }
   return call;
 }

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/relax/analysis.h>
+#include <tvm/relax/attrs/op.h>
 #include <tvm/relax/expr_functor.h>
 #include <tvm/relax/struct_info.h>
 #include <tvm/relax/transform.h>
@@ -873,7 +874,8 @@ class TIRFuseMutator : public ExprMutator {
         if (!tir_vars.empty()) {
           call_args.push_back(ShapeExpr(tir_vars));
         }
-        return Call(call_tir_op_, call_args, call->attrs, {GetStructInfo(call)});
+        return Call(call_tir_op_, call_args, Attrs(make_object<CallTIRAttrs>()),
+                    {GetStructInfo(call)});
       } else {
         // Case 1.2. The callee function is not primitive, nothing to do.
         return call;

--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -150,10 +150,13 @@ class BackwardBindingGenerator : private ExprVisitor {
     }
   }
 
-  // For Tuple nodes, we would iterate over the input tuple and update adjoint exprs for each
-  // input e.g. a = (b, c) b_adjoint += a_adjoint_var[0], c_adjoint += a_adjoint_var[1] a = ((b,
-  // c), d) b_adjoint += a_adjoint_var[0][0], c_adjoint += a_adjoint_var[0][1], d_adjoint +=
-  // a_adjoint_var[1]
+  // For Tuple nodes, we would iterate over the input tuple and update adjoint exprs for each input
+  // e.g.
+  // a = (b, c)
+  // b_adjoint += a_adjoint_var[0], c_adjoint += a_adjoint_var[1]
+  // a = ((b, c), d)
+  // b_adjoint += a_adjoint_var[0][0], c_adjoint += a_adjoint_var[0][1],
+  // d_adjoint += a_adjoint_var[1]
   //
   // Here we use adjoint_var to simplify calculation
   void VisitBinding_(const VarBindingNode* binding, const TupleNode* tuple) final {

--- a/src/script/printer/relax/call.cc
+++ b/src/script/printer/relax/call.cc
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <tvm/relax/attrs/op.h>
 #include <tvm/relax/distributed/struct_info.h>
 
 #include "./utils.h"
@@ -129,6 +130,17 @@ Optional<ExprDoc> PrintCallTIRDPSPacked(const relax::Call& n, const ObjectPath& 
       is_dtensor = true;
     }
     kwargs_values.push_back(d->AsDoc<ExprDoc>(o_sinfo, o_sinfo_p));
+  }
+  auto call_tir_attrs = n->attrs.as<relax::CallTIRAttrs>();
+  if (call_tir_attrs && call_tir_attrs->te_grad_name) {
+    kwargs_keys.push_back("te_grad_name");
+    kwargs_values.push_back(LiteralDoc::Str(call_tir_attrs->te_grad_name.value(),
+                                            n_p->Attr("attrs")->Attr("te_grad_name")));
+    if (!call_tir_attrs->te_grad_kwargs.empty()) {
+      kwargs_keys.push_back("te_grad_kwargs");
+      kwargs_values.push_back(d->AsDoc<ExprDoc>(call_tir_attrs->te_grad_kwargs,
+                                                n_p->Attr("attrs")->Attr("te_grad_kwargs")));
+    }
   }
   if (n->op.same_as(call_dps_packed_op)) {
     return Relax(d, "call_dps_packed")->Call(args, kwargs_keys, kwargs_values);

--- a/tests/python/relax/test_training_utils.py
+++ b/tests/python/relax/test_training_utils.py
@@ -15,25 +15,52 @@
 # specific language governing permissions and limitations
 # under the License.
 """Unit tests for relax training utils."""
+import pytest
+
 import tvm
 import tvm.testing
-from tvm import relax
+from tvm import relax, tir
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R, tir as T, ir as I
 
-from tvm.relax.training.utils import bind_te_grad_func
+from tvm.relax.training.utils import register_te_gradient
 from tvm.relax.transform import Gradient
 
 
-def test_bind_tir_grad_func():
+# Only run once in the whole test session
+@pytest.fixture(scope="module")
+def register_te_grads():
+    # register the gradient function
+    @register_te_gradient("f_mul_grad")
+    def f_mul_grad(output_grad, src1, src2):
+        def mul_grad_1(*idx):
+            return src2[idx] * output_grad[idx]
+
+        def mul_grad_2(*idx):
+            return src1[idx] * output_grad[idx]
+
+        return [
+            tvm.te.compute(src1.shape, mul_grad_1, name="f_mul_grad_1"),
+            tvm.te.compute(src2.shape, mul_grad_2, name="f_mul_grad_2"),
+        ]
+
+    # register the gradient function
+    @register_te_gradient("f_mulk_grad")
+    def f_mulk_grad(output_grad, src1, k):
+        def mulk_grad(*idx):
+            return output_grad[idx] * k
+
+        return [
+            tvm.te.compute(src1.shape, mulk_grad, name="f_mulk_grad"),
+        ]
+
+
+def get_expected_1():
+    # fmt: off
     @I.ir_module
     class Expected:
         @T.prim_func
-        def f_mul(
-            A: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-            B: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-            f_mul_1: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-        ):
+        def f_mul(A: T.Buffer((T.int64(5), T.int64(5)), "float32"), B: T.Buffer((T.int64(5), T.int64(5)), "float32"), f_mul_1: T.Buffer((T.int64(5), T.int64(5)), "float32")):
             T.func_attr({"tir.noalias": T.bool(True)})
             # with T.block("root"):
             for i0, i1 in T.grid(T.int64(5), T.int64(5)):
@@ -44,13 +71,7 @@ def test_bind_tir_grad_func():
                     f_mul_1[v_i0, v_i1] = A[v_i0, v_i1] * B[v_i0, v_i1]
 
         @T.prim_func
-        def f_mul_grad(
-            A: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-            B: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-            C: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-            f_mul_grad_1: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-            f_mul_grad_2: T.Buffer((T.int64(5), T.int64(5)), "float32"),
-        ):
+        def f_mul_grad(A: T.Buffer((T.int64(5), T.int64(5)), "float32"), B: T.Buffer((T.int64(5), T.int64(5)), "float32"), C: T.Buffer((T.int64(5), T.int64(5)), "float32"), f_mul_grad_1: T.Buffer((T.int64(5), T.int64(5)), "float32"), f_mul_grad_2: T.Buffer((T.int64(5), T.int64(5)), "float32")):
             T.func_attr({"tir.noalias": T.bool(True)})
             # with T.block("root"):
             for i0, i1 in T.grid(T.int64(5), T.int64(5)):
@@ -67,61 +88,38 @@ def test_bind_tir_grad_func():
                     f_mul_grad_2[v_i0, v_i1] = B[v_i0, v_i1] * A[v_i0, v_i1]
 
         @R.function
-        def main_adjoint(
-            a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")
-        ) -> R.Tuple(
-            R.Tensor((), dtype="float32"),
-            R.Tuple(R.Tensor((5, 5), dtype="float32"), R.Tensor((5, 5), dtype="float32")),
-        ):
+        def main_adjoint(a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((5, 5), dtype="float32"), R.Tensor((5, 5), dtype="float32"))):
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"))
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
-                lv_adjoint: R.Tensor((5, 5), dtype="float32") = R.broadcast_to(
-                    gv_adjoint, R.shape([5, 5])
-                )
-                lv_1 = R.call_tir(
-                    cls.f_mul_grad,
-                    (lv_adjoint, a, b),
-                    out_sinfo=[
-                        R.Tensor((5, 5), dtype="float32"),
-                        R.Tensor((5, 5), dtype="float32"),
-                    ],
-                )
+                lv_adjoint: R.Tensor((5, 5), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([5, 5]))
+                lv_1 = R.call_tir(cls.f_mul_grad, (lv_adjoint, a, b), out_sinfo=[R.Tensor((5, 5), dtype="float32"), R.Tensor((5, 5), dtype="float32")])
                 a_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[0]
                 b_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[1]
                 R.output(gv, a_adjoint, b_adjoint)
             return (gv, (a_adjoint, b_adjoint))
 
         @R.function
-        def main(
-            a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")
-        ) -> R.Tensor((), dtype="float32"):
+        def main(a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
             cls = Expected
             with R.dataflow():
-                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"))
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
                 gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
                 R.output(gv)
             return gv
+    # fmt: on
+    return Expected
 
+
+def test_emit_te(register_te_grads):
+    # Build the target module using emit_te
     def f_mul(src1, src2):
         def mul(*idx):
             return src1[idx] * src2[idx]
 
         return tvm.te.compute(src1.shape, mul, name="f_mul")
-
-    def f_mul_grad(output_grad, src1, src2):
-        def mul_grad_1(*idx):
-            return src2[idx] * output_grad[idx]
-
-        def mul_grad_2(*idx):
-            return src1[idx] * output_grad[idx]
-
-        return [
-            tvm.te.compute(output_grad.shape, mul_grad_1, name="f_mul_grad_1"),
-            tvm.te.compute(output_grad.shape, mul_grad_2, name="f_mul_grad_2"),
-        ]
 
     a = relax.Var("a", relax.TensorStructInfo([5, 5], "float32"))
     b = relax.Var("b", relax.TensorStructInfo([5, 5], "float32"))
@@ -129,18 +127,114 @@ def test_bind_tir_grad_func():
     bb = relax.BlockBuilder()
     with bb.function("main", [a, b]):
         with bb.dataflow():
-            d = bb.emit_te(f_mul, a, b, primfunc_name_hint="f_mul")
+            d = bb.emit_te(f_mul, a, b, primfunc_name_hint="f_mul", te_grad_name="f_mul_grad")
             out = bb.emit_output(R.sum(d))
         bb.emit_func_output(out)
 
-    mod = bb.get()
-    mod = bind_te_grad_func(mod, "f_mul", f_mul_grad)
-    with tvm.transform.PassContext():
-        After = Gradient("main")(mod)
+    Module = bb.get()
+    After = Gradient("main")(Module)
+    assert_structural_equal(After, get_expected_1())
 
-    # remove the module attr to pass the assert structrual equal
-    After = After.without_attr("te_grad_bind_handler")
 
+def test_call_tir(register_te_grads):
+    # fmt: off
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def f_mul(A: T.Buffer((T.int64(5), T.int64(5)), "float32"), B: T.Buffer((T.int64(5), T.int64(5)), "float32"), f_mul_1: T.Buffer((T.int64(5), T.int64(5)), "float32")):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i0, i1 in T.grid(T.int64(5), T.int64(5)):
+                with T.block("f_mul"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(A[v_i0, v_i1], B[v_i0, v_i1])
+                    T.writes(f_mul_1[v_i0, v_i1])
+                    f_mul_1[v_i0, v_i1] = A[v_i0, v_i1] * B[v_i0, v_i1]
+
+        @R.function
+        def main(a: R.Tensor((5, 5), dtype="float32"), b: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            cls = Module
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mul_grad")
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: off
+
+    After = Gradient("main")(Module)
+    assert_structural_equal(After, get_expected_1())
+
+
+def test_emit_te_kwargs(register_te_grads):
+    # Build the target module using emit_te
+    def f_mul2(src):
+        return tvm.te.compute(src.shape, lambda *idx: src[idx] * T.float32(2), name="f_mul2")
+
+    a = relax.Var("a", relax.TensorStructInfo([5, 5], "float32"))
+
+    bb = relax.BlockBuilder()
+    with bb.function("main", [a]):
+        with bb.dataflow():
+            d = bb.emit_te(
+                f_mul2,
+                a,
+                primfunc_name_hint="f_mul",
+                te_grad_name="f_mulk_grad",
+                te_grad_kwargs={"k": T.float32(2)},
+            )
+            out = bb.emit_output(R.sum(d))
+        bb.emit_func_output(out)
+
+    Module = bb.get()
+    After = Gradient("main")(Module)
+
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def f_mul(A: T.Buffer((T.int64(5), T.int64(5)), "float32"), f_mul2: T.Buffer((T.int64(5), T.int64(5)), "float32")):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i0, i1 in T.grid(T.int64(5), T.int64(5)):
+                with T.block("f_mul2"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(A[v_i0, v_i1])
+                    T.writes(f_mul2[v_i0, v_i1])
+                    f_mul2[v_i0, v_i1] = A[v_i0, v_i1] * T.float32(2)
+
+        @T.prim_func
+        def f_mulk_grad(A: T.Buffer((T.int64(5), T.int64(5)), "float32"), B: T.Buffer((T.int64(5), T.int64(5)), "float32"), f_mulk_grad_1: T.Buffer((T.int64(5), T.int64(5)), "float32")):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            # with T.block("root"):
+            for i0, i1 in T.grid(T.int64(5), T.int64(5)):
+                with T.block("f_mulk_grad"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(A[v_i0, v_i1])
+                    T.writes(f_mulk_grad_1[v_i0, v_i1])
+                    f_mulk_grad_1[v_i0, v_i1] = A[v_i0, v_i1] * T.float32(2)
+
+        @R.function
+        def main_adjoint(a: R.Tensor((5, 5), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor((5, 5), dtype="float32"))):
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv_adjoint: R.Tensor((5, 5), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([5, 5]))
+                lv_1 = R.call_tir(cls.f_mulk_grad, (lv_adjoint, a), out_sinfo=R.Tensor((5, 5), dtype="float32"))
+                a_adjoint: R.Tensor((5, 5), dtype="float32") = lv_1[0]
+                R.output(gv, a_adjoint)
+            return (gv, (a_adjoint,))
+
+        @R.function
+        def main(a: R.Tensor((5, 5), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a,), out_sinfo=R.Tensor((5, 5), dtype="float32"), te_grad_name="f_mulk_grad", te_grad_kwargs={"k": T.float32(2)})
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
     assert_structural_equal(After, Expected)
 
 


### PR DESCRIPTION
This PR registers te gradient functions as global functions. Previously we will register them as IRModule attributes, but that will lead to segment fault when program exits due to circular reference.

Current workflow is as follows:
```
# register te gradient function
@register_te_gradient("f_mul_grad")
def f_mul_grad(output_grad: te.Tensor, src1: te.Tensor, src2: te.Tensor, k: int):
    # returns a list of te tensors, representing gradients w.r.t. src1, src2
    # k is a constant parameter
    ...

# irmodule definition
@I.ir_module
class Module:
    @T.prim_func
    def f_mul(A, B, result):
        ...

    @R.function
    def main(a, b):
        cls = Module
        with R.dataflow():
            lv = R.call_tir(cls.f_mul, (a, b), te_grad_name="f_mul_grad", te_grad_kwargs={"k": 1})
            gv = R.output(lv)
        return gv
```

It's worth to note this PR defines an attribute to the call_tir node:
```
struct CallTIRAttrs : public tvm::AttrsNode<CallTIRAttrs> {
  Optional<String> te_grad_name;
  Map<String, ObjectRef> te_grad_kwargs;

  TVM_DECLARE_ATTRS(CallTIRAttrs, "relax.attrs.CallTIRAttrs") {
    TVM_ATTR_FIELD(te_grad_name)
        .describe("The name of the te gradient function associated with this call_tir node.");
    TVM_ATTR_FIELD(te_grad_kwargs)
        .describe("The keyword arguments passed to the te gradient function.");
  }
};  // struct CallTIRAttrs
```