### PR TITLE
[Transform] Enhance FuncCopier

### DIFF
--- a/tests/python/relax/test_training_register_te_gradient.py
+++ b/tests/python/relax/test_training_register_te_gradient.py
@@ -19,7 +19,7 @@ import pytest
 
 import tvm
 import tvm.testing
-from tvm import relax
+from tvm import relax, tir
 from tvm.ir.base import assert_structural_equal
 from tvm.script.parser import relax as R, tir as T, ir as I
 
@@ -273,6 +273,101 @@ def test_call_tir_kwargs(register_te_grads):
     After = Gradient("main")(Before)
     assert_structural_equal(After, get_expected_2())
 
+
+def get_expected_3():
+    # fmt: off
+    @I.ir_module
+    class Expected:
+        @T.prim_func
+        def f_mul(var_A: T.handle, var_B: T.handle, var_f_mul: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n = T.int64()
+            A = T.match_buffer(var_A, (n, n))
+            B = T.match_buffer(var_B, (n, n))
+            f_mul_1 = T.match_buffer(var_f_mul, (n, n))
+            # with T.block("root"):
+            for i0, i1 in T.grid(n, n):
+                with T.block("f_mul"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(A[v_i0, v_i1], B[v_i0, v_i1])
+                    T.writes(f_mul_1[v_i0, v_i1])
+                    f_mul_1[v_i0, v_i1] = A[v_i0, v_i1] * B[v_i0, v_i1]
+
+        @T.prim_func
+        def f_mul_grad(var_A: T.handle, var_B: T.handle, var_C: T.handle, var_f_mul_grad_1: T.handle, var_f_mul_grad_2: T.handle):
+            T.func_attr({"tir.noalias": T.bool(True)})
+            n = T.int64()
+            A = T.match_buffer(var_A, (n, n))
+            B = T.match_buffer(var_B, (n, n))
+            C = T.match_buffer(var_C, (n, n))
+            f_mul_grad_1 = T.match_buffer(var_f_mul_grad_1, (n, n))
+            f_mul_grad_2 = T.match_buffer(var_f_mul_grad_2, (n, n))
+            # with T.block("root"):
+            for i0, i1 in T.grid(n, n):
+                with T.block("f_mul_grad_1"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(C[v_i0, v_i1], A[v_i0, v_i1])
+                    T.writes(f_mul_grad_1[v_i0, v_i1])
+                    f_mul_grad_1[v_i0, v_i1] = C[v_i0, v_i1] * A[v_i0, v_i1]
+            for i0, i1 in T.grid(n, n):
+                with T.block("f_mul_grad_2"):
+                    v_i0, v_i1 = T.axis.remap("SS", [i0, i1])
+                    T.reads(B[v_i0, v_i1], A[v_i0, v_i1])
+                    T.writes(f_mul_grad_2[v_i0, v_i1])
+                    f_mul_grad_2[v_i0, v_i1] = B[v_i0, v_i1] * A[v_i0, v_i1]
+
+        @R.function
+        def main_adjoint(a: R.Tensor(("n", "n"), dtype="float32"), b: R.Tensor(("n", "n"), dtype="float32")) -> R.Tuple(R.Tensor((), dtype="float32"), R.Tuple(R.Tensor(("n", "n"), dtype="float32"), R.Tensor(("n", "n"), dtype="float32"))):
+            n = T.int64()
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((n, n), dtype="float32"), te_grad_name="f_mul_grad")
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                gv_adjoint: R.Tensor((), dtype="float32") = R.ones(R.shape([]), dtype="float32")
+                lv_adjoint: R.Tensor((n, n), dtype="float32") = R.broadcast_to(gv_adjoint, R.shape([n, n]))
+                lv_1 = R.call_tir(cls.f_mul_grad, (lv_adjoint, a, b), out_sinfo=[R.Tensor((n, n), dtype="float32"), R.Tensor((n, n), dtype="float32")])
+                a_adjoint: R.Tensor((n, n), dtype="float32") = lv_1[0]
+                b_adjoint: R.Tensor((n, n), dtype="float32") = lv_1[1]
+                a_adjoint_out: R.Tensor((n, n), dtype="float32") = a_adjoint
+                b_adjoint_out: R.Tensor((n, n), dtype="float32") = b_adjoint
+                R.output(gv, a_adjoint_out, b_adjoint_out)
+            return (gv, (a_adjoint_out, b_adjoint_out))
+
+        @R.function
+        def main(a: R.Tensor(("n", "n"), dtype="float32"), b: R.Tensor(("n", "n"), dtype="float32")) -> R.Tensor((), dtype="float32"):
+            n = T.int64()
+            cls = Expected
+            with R.dataflow():
+                lv = R.call_tir(cls.f_mul, (a, b), out_sinfo=R.Tensor((n, n), dtype="float32"), te_grad_name="f_mul_grad")
+                gv: R.Tensor((), dtype="float32") = R.sum(lv, axis=None, keepdims=False)
+                R.output(gv)
+            return gv
+    # fmt: on
+    return Expected
+
+
+def test_tir_var(register_te_grads):
+    def f_mul(src1, src2):
+        def mul(*idx):
+            return src1[idx] * src2[idx]
+
+        return tvm.te.compute(src1.shape, mul, name="f_mul")
+
+    n = tir.Var("n", "int64")
+    a = relax.Var("a", relax.TensorStructInfo([n, n], "float32"))
+    b = relax.Var("b", relax.TensorStructInfo([n, n], "float32"))
+
+    bb = relax.BlockBuilder()
+    with bb.function("main", [a, b]):
+        with bb.dataflow():
+            d = bb.emit_te(f_mul, a, b, primfunc_name_hint="f_mul", te_grad_name="f_mul_grad")
+            out = bb.emit_output(R.sum(d))
+        bb.emit_func_output(out)
+
+    Before = bb.get()
+    After = Gradient("main")(Before)
+    assert_structural_equal(After, get_expected_3())
+    assert relax.analysis.well_formed(After)
 
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_training_register_te_gradient.py
+++ b/tests/python/relax/test_training_register_te_gradient.py
@@ -369,5 +369,6 @@ def test_tir_var(register_te_grads):
     assert_structural_equal(After, get_expected_3())
     assert relax.analysis.well_formed(After)
 
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -1454,8 +1454,9 @@ def test_mlp_script():
                 out_adjoint: R.Tensor((3, 5), dtype="float32") = R.subtract(logits_adjoint, lv5)
                 lv0_adjoint: R.Tensor((3, 5), dtype="float32") = out_adjoint
                 b0_adjoint: R.Tensor((5,), dtype="float32") = R.collapse_sum_to(out_adjoint, R.shape([5]))
-                lv7: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
-                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.matmul(lv7, lv0_adjoint, out_dtype="void")
+                lv8: R.Tensor((10, 3), dtype="float32") = R.permute_dims(x, axes=[1, 0])
+                lv9: R.Tensor((10, 5), dtype="float32") = R.matmul(lv8, lv0_adjoint, out_dtype="void")
+                w0_adjoint: R.Tensor((10, 5), dtype="float32") = R.collapse_sum_to(lv9, R.shape([10, 5]))
                 w0_adjoint_out: R.Tensor((10, 5), dtype="float32") = w0_adjoint
                 b0_adjoint_out: R.Tensor((5,), dtype="float32") = b0_adjoint
                 R.output(loss, w0_adjoint_out, b0_adjoint_out)


### PR DESCRIPTION
Now FuncCopier will provide a var_map member as the relax var mapping from the old function and the new function. 

In FuncCopier we will call SymbolicVarRenewMutator, which also renews relax Vars. However, previously we did not consider this var mapping into account, leading that we will provide wrong var_map in FuncCopier.

That leads to bugs in the Gradient pass, whichs uses this member.

This PR will merge the var mappings in FuncCopier and in SymbolicVarRenewMutator.