### PR TITLE
[Fix] Package path to jvm/ and 3rdparty/

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,6 @@
 """Setup TVM package."""
 import os
 import pathlib
-import platform
 import shutil
 import sys
 import sysconfig
@@ -56,40 +55,16 @@ def get_lib_path():
                     libs.append(name)
                     break
 
-        # Add standalone_crt, if present
-        for name in lib_path:
-            candidate_path = os.path.join(os.path.dirname(name), "standalone_crt")
-            if os.path.isdir(candidate_path):
-                libs.append(candidate_path)
-                break
-
-        # Add microTVM template projects
-        for name in lib_path:
-            candidate_path = os.path.join(os.path.dirname(name), "microtvm_template_projects")
-            if os.path.isdir(candidate_path):
-                libs.append(candidate_path)
-                break
-
-        # Add tvmc configuration json files
-        for name in lib_path:
-            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "configs"))
-            if os.path.isdir(candidate_path):
-                libs.append(candidate_path)
-                break
-
-        # Add 3rdparty configuration json files
-        for name in lib_path:
-            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "3rdparty"))
-            if os.path.isdir(candidate_path):
-                libs.append(candidate_path)
-                break
-
-        # Add jvm configuration json files
-        for name in lib_path:
-            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "jvm"))
-            if os.path.isdir(candidate_path):
-                libs.append(candidate_path)
-                break
+        for dir in ["3rdparty", "jvm", "web", "rust", "golang", "include"]:
+            for name in lib_path:
+                candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", dir))
+                if os.path.isdir(candidate_path):
+                    libs.append(candidate_path)
+                    if dir == "3rdparty":
+                        # remove large files
+                        shutil.rmtree(os.path.join(candidate_path, "cutlass", "docs"))
+                        shutil.rmtree(os.path.join(candidate_path, "cutlass", "media"))
+                    break
     else:
         libs = None
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,6 +55,27 @@ def get_lib_path():
                     libs.append(name)
                     break
 
+        # Add standalone_crt, if present
+        for name in lib_path:
+            candidate_path = os.path.join(os.path.dirname(name), "standalone_crt")
+            if os.path.isdir(candidate_path):
+                libs.append(candidate_path)
+                break
+
+        # Add microTVM template projects
+        for name in lib_path:
+            candidate_path = os.path.join(os.path.dirname(name), "microtvm_template_projects")
+            if os.path.isdir(candidate_path):
+                libs.append(candidate_path)
+                break
+
+        # Add tvmc configuration json files
+        for name in lib_path:
+            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "configs"))
+            if os.path.isdir(candidate_path):
+                libs.append(candidate_path)
+                break
+
         for dir in ["3rdparty", "jvm", "web", "rust", "golang", "include"]:
             for name in lib_path:
                 candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", dir))

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,16 +79,14 @@ def get_lib_path():
 
         # Add 3rdparty configuration json files
         for name in lib_path:
-            candidate_path = os.path.abspath(
-                os.path.join(os.path.dirname(name), "..", "..", "3rdparty")
-            )
+            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "3rdparty"))
             if os.path.isdir(candidate_path):
                 libs.append(candidate_path)
                 break
 
         # Add jvm configuration json files
         for name in lib_path:
-            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "..", "jvm"))
+            candidate_path = os.path.abspath(os.path.join(os.path.dirname(name), "..", "jvm"))
             if os.path.isdir(candidate_path):
                 libs.append(candidate_path)
                 break


### PR DESCRIPTION
This PR fixed a bug introduced in https://github.com/mlc-ai/relax/pull/230, where the directory is mistakenly specified