### PR TITLE
[Unity][Training] Fix bug in handling tuple in Gradient

### DIFF
--- a/src/relax/transform/gradient.cc
+++ b/src/relax/transform/gradient.cc
@@ -432,7 +432,6 @@ class BackwardBindingGenerator : private ExprVisitor {
         field = expr_tuple->fields[i];
       } else {
         field = TupleGetItem(tuple, i);
-        UpdateStructInfo(field, sinfo->fields[i]);
       }
       if (static_cast<int>(i) == index) {
         field = TupleAwareAdd(field, increment);

--- a/tests/python/relax/test_transform_gradient.py
+++ b/tests/python/relax/test_transform_gradient.py
@@ -371,7 +371,6 @@ def test_tuple():
     assert_structural_equal(After, Expected)
 
 
-@pytest.mark.skip("skip merge")
 def test_tuple_assignment():
     # fmt: off
     @I.ir_module
@@ -440,7 +439,6 @@ def test_tuple_assignment():
     assert_structural_equal(After, Expected)
 
 
-@pytest.mark.skip("skip merge")
 def test_tuple_nested():
     # fmt: off
     @I.ir_module
@@ -534,7 +532,6 @@ def test_tuple_nested():
     assert_structural_equal(After, Expected)
 
 
-@pytest.mark.skip("skip merge")
 def test_tuple_update():
     """One tensor `x` is used in and out of tuple many times."""
     # fmt: off

--- a/tests/python/relax/test_transform_gradient_numeric.py
+++ b/tests/python/relax/test_transform_gradient_numeric.py
@@ -133,7 +133,6 @@ def test_mlp_blockbuilder(target, dev):
     check_numerical_grads(func, [i.numpy() for i in args[1:-1]], [i.numpy() for i in grad])
 
 
-@pytest.mark.skip("merge skip")
 @tvm.testing.parametrize_targets("llvm")
 def test_complex(target, dev):
     cst = relax.const(np.ones((6,)), dtype="float32")


### PR DESCRIPTION
Now calling `TupleGetItem()` will automatically set structinfo for its result. So we do not need to manually set it any more.