### PR TITLE
[Unity][Dlight] GeMV rule skip cases of "outer dim being grouped"

### DIFF
--- a/python/tvm/dlight/gpu/gemv.py
+++ b/python/tvm/dlight/gpu/gemv.py
@@ -125,8 +125,9 @@ def normalize(
             if c_loops:
                 return None
             loop, c_loop = sch.split(loop, factors=[None, split_expr.lower_factor])
-            # we expect the inner most dim to be grouped atm
-            assert not (is_reduction ^ is_inner_reduction)
+            # we only support the inner most dim being grouped atm
+            if is_reduction ^ is_inner_reduction:
+                return None
             c_loops.append(c_loop)
         if is_reduction:
             r_loops.append(loop)


### PR DESCRIPTION
Prior to this PR, the GeMV contains an assumption that "the grouped dimension of the largest tensor in GeMV must has the same iter type as the innermost dimension", which is enforced by an assertion.

Since AutoGPTQ quantization only supports KN GeMV layout, the decode-GeMV generated under the AutoGPTQ quantization has the pattern where the reduction dimension is not the innermost and is grouped. This pattern does not follow the assersion above and thus an assertion error will be thrown.

This PR updates the logic to skip transforming such cases, instead of asserting the assumption. One real AutoGPTQ decode-GeMV workload is added as a test case for future awareness.