### PR TITLE
[Relax][VM] Add additional flags for picojson

### DIFF
--- a/src/runtime/relax_vm/ndarray_cache_support.cc
+++ b/src/runtime/relax_vm/ndarray_cache_support.cc
@@ -35,6 +35,9 @@
  * runtime builtin provide as in this file.
  */
 #define PICOJSON_USE_INT64
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include "./ndarray_cache_support.h"
 
 #include <picojson.h>


### PR DESCRIPTION
This commits adds `__STDC_FORMAT_MACROS` when including picojson in C++. This should fix a recent build issue as below:

```
In file included from src/runtime/relax_vm/ndarray_cache_support.cc:40:
3rdparty/picojson/picojson.h: In member function 'std::string picojson::value::to_str() const':
3rdparty/picojson/picojson.h:494:37: error: expected ')' before 'PRId64'
  494 |       SNPRINTF(buf, sizeof(buf), "%" PRId64, u_.int64_);
      |               ~                     ^~~~~~~
      |                                     )
3rdparty/picojson/picojson.h:81:1: note: 'PRId64' is defined in header '<cinttypes>'; did you forget to '#include <cinttypes>'?
   80 | #include <errno.h>
  +++ |+#include <cinttypes>
   81 | #include <inttypes.h>
```