### PR TITLE
[CMake] Add CMAKE_CUDA_ARCHITECTURES to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,15 @@ else()
   set(CMAKE_CUDA_STANDARD 17)
 endif()
 
+if ((USE_CUDA AND USE_CUTLASS))
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES "75;80;86;89;90")
+    message(STATUS "Set CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
+  else ()
+    message(STATUS "Found CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
+  endif()
+endif()
+
 # Module rules
 include(cmake/modules/VTA.cmake)
 include(cmake/modules/StandaloneCrt.cmake)


### PR DESCRIPTION
1. Bump `3rdparty/cutlass_fpA_intB_gemm`
2. Set `CMAKE_CUDA_ARCHITECTURES=75;80;86;89;90` when it's not defined