### PR TITLE
Require exactly same-dtype matching for WebGPU smem reuse

### DIFF
--- a/src/tir/transforms/storage_rewrite.cc
+++ b/src/tir/transforms/storage_rewrite.cc
@@ -1724,7 +1724,8 @@ Pass StorageRewrite() {
     }
 
     Optional<Target> target = f->GetAttr<Target>("target");
-    if (target.defined() && target.value()->kind->name == "vulkan") {
+    if (target.defined() &&
+        (target.value()->kind->name == "vulkan" || target.value()->kind->name == "webgpu")) {
       // Require exactly same-dtype matching in smem reuse for Vulkan
       reuse_require_exact_matched_dtype = true;
     }


### PR DESCRIPTION
Related to: https://github.com/apache/tvm/pull/16515

WebGPU has the problem of shared memory reuse with different dtype as well.