### PR TITLE
refactor(web): use singular requestFileHandle() instead of requestFileHandles()

### DIFF
--- a/web/src/artifact_cache.ts
+++ b/web/src/artifact_cache.ts
@@ -119,10 +119,10 @@ interface CrossOriginStorageWritable {
 }
 
 interface CrossOriginStorageAPI {
-  requestFileHandles(
-    descriptors: CrossOriginHashDescriptor[],
+  requestFileHandle(
+    descriptor: CrossOriginHashDescriptor,
     options?: CrossOriginStorageRequestFileHandleOptions,
-  ): Promise<CrossOriginStorageHandle[]>;
+  ): Promise<CrossOriginStorageHandle>;
 }
 
 declare global {
@@ -169,8 +169,7 @@ class CrossOriginStorage {
       if (!api) {
         return undefined;
       }
-      const handles = await api.requestFileHandles([hash]);
-      const handle = handles[0];
+      const handle = await api.requestFileHandle(hash);
       if (!handle) {
         return undefined;
       }
@@ -189,10 +188,9 @@ class CrossOriginStorage {
     if (!api) {
       throw new Error("Cross-origin storage API unavailable.");
     }
-    const handles = await api.requestFileHandles([hash], { create: true });
-    const handle = handles[0];
+    const handle = await api.requestFileHandle(hash, { create: true });
     if (!handle) {
-      throw new Error("Cross-origin storage API returned no handles.");
+      throw new Error("Cross-origin storage API returned no handle.");
     }
     const writableStream = await handle.createWritable();
     await writableStream.write(blob);


### PR DESCRIPTION
Switches from the deprecated plural `requestFileHandles([hash])` to the new singular `requestFileHandle(hash)` API, which returns a handle directly rather than a single-element array. Also updates the interface definition and removes the now-redundant `handles[0]` indexing.

The rename was adopted in the COS spec after a survey of all known real-world implementations found that every call site passed a single-element array and immediately indexed `[0]`.

See https://github.com/WICG/cross-origin-storage/issues/61 for details.